### PR TITLE
Create location widget and add it to the scene

### DIFF
--- a/src/components/globe-featured-view/globe-featured-view-component.jsx
+++ b/src/components/globe-featured-view/globe-featured-view-component.jsx
@@ -5,6 +5,7 @@ import styles from 'styles/themes/scene-theme.module.scss'
 import ArcgisLayerManager from 'components/shared/arcgis-layer-manager';
 import { layerManagerToggle } from 'utils/layer-manager-utils';
 import Sidebar from 'components/shared/sidebar';
+import LocationWidget from 'components/shared/widgets/location-widget';
 
 const GlobeComponent = ({ sceneConfig, isSidebarOpen, sceneLayers, updateFeaturedGlobeQueryParam, activeLayers, query }) => {
   const toggleLayer = e => layerManagerToggle(e, "data-layer-id", activeLayers, query, updateFeaturedGlobeQueryParam);
@@ -16,6 +17,7 @@ const GlobeComponent = ({ sceneConfig, isSidebarOpen, sceneLayers, updateFeature
         viewProperties={sceneConfig}
       >
         <ArcgisLayerManager activeLayers={activeLayers}/>
+        <LocationWidget />
       </WebScene>
       <Sidebar>
         {

--- a/src/components/globe-featured-view/globe-featured-view-component.jsx
+++ b/src/components/globe-featured-view/globe-featured-view-component.jsx
@@ -6,6 +6,8 @@ import ArcgisLayerManager from 'components/shared/arcgis-layer-manager';
 import { layerManagerToggle } from 'utils/layer-manager-utils';
 import Sidebar from 'components/shared/sidebar';
 import LocationWidget from 'components/shared/widgets/location-widget';
+import NavigationToggleWidget from 'components/shared/widgets/navigation-toggle-widget';
+import ZoomWidget from 'components/shared/widgets/zoom-widget';
 
 const GlobeComponent = ({ sceneConfig, isSidebarOpen, sceneLayers, updateFeaturedGlobeQueryParam, activeLayers, query }) => {
   const toggleLayer = e => layerManagerToggle(e, "data-layer-id", activeLayers, query, updateFeaturedGlobeQueryParam);
@@ -18,6 +20,8 @@ const GlobeComponent = ({ sceneConfig, isSidebarOpen, sceneLayers, updateFeature
       >
         <ArcgisLayerManager activeLayers={activeLayers}/>
         <LocationWidget />
+        <ZoomWidget />
+        <NavigationToggleWidget />
       </WebScene>
       <Sidebar>
         {

--- a/src/components/shared/widgets/location-widget/location-widget-component.jsx
+++ b/src/components/shared/widgets/location-widget/location-widget-component.jsx
@@ -1,15 +1,25 @@
 // Docs for Locate ui widget
 // https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html
-
 import { loadModules } from '@esri/react-arcgis';
+import { useState, useEffect } from 'react';
 
 const LocationWidgetComponent = ({ view }) => {
-  loadModules(["esri/widgets/Locate"]).then(([Locate]) => {
-    var locateWidget = new Locate({
-      view: view
-    });
-    view.ui.add(locateWidget, "top-right");
-  }).catch((err) => console.error(err));
+  const [locationWidget, setLocationWidget] = useState(null);
+
+  useEffect(() => {
+    loadModules(["esri/widgets/Locate"]).then(([Locate]) => {
+      const locationWidget = new Locate({
+        view: view
+      });
+      setLocationWidget(locationWidget);
+      view.ui.add(locationWidget, "top-right");
+
+    }).catch((err) => console.error(err));
+    return function cleanup() {
+      view.ui.remove(locationWidget);
+    };
+  }, [])
+
   return null;
 }
 

--- a/src/components/shared/widgets/location-widget/location-widget-component.jsx
+++ b/src/components/shared/widgets/location-widget/location-widget-component.jsx
@@ -18,7 +18,7 @@ const LocationWidgetComponent = ({ view }) => {
     return function cleanup() {
       view.ui.remove(locationWidget);
     };
-  }, [])
+  }, [view])
 
   return null;
 }

--- a/src/components/shared/widgets/location-widget/location-widget-component.jsx
+++ b/src/components/shared/widgets/location-widget/location-widget-component.jsx
@@ -1,0 +1,16 @@
+// Docs for Locate ui widget
+// https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html
+
+import { loadModules } from '@esri/react-arcgis';
+
+const LocationWidgetComponent = ({ view }) => {
+  loadModules(["esri/widgets/Locate"]).then(([Locate]) => {
+    var locateWidget = new Locate({
+      view: view
+    });
+    view.ui.add(locateWidget, "top-right");
+  }).catch((err) => console.error(err));
+  return null;
+}
+
+export default LocationWidgetComponent;

--- a/src/components/shared/widgets/location-widget/location-widget.js
+++ b/src/components/shared/widgets/location-widget/location-widget.js
@@ -1,0 +1,3 @@
+import Component from './location-widget-component';
+
+export default Component;

--- a/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget-component.jsx
+++ b/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget-component.jsx
@@ -16,7 +16,7 @@ const NavigationToggleWidgetComponent = ({ view }) => {
     return function cleanup() {
       view.ui.remove(navigationToggleWidget);
     };
-  }, [])
+  }, [view])
 
   return null;
 }

--- a/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget-component.jsx
+++ b/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget-component.jsx
@@ -1,0 +1,24 @@
+import { loadModules } from '@esri/react-arcgis';
+import { useState, useEffect } from 'react';
+
+const NavigationToggleWidgetComponent = ({ view }) => {
+  const [navigationToggleWidget, setNavigationToggleWidget] = useState(null);
+
+  useEffect(() => {
+    loadModules(["esri/widgets/NavigationToggle"]).then(([NavigationToggle]) => {
+      const navigationToggleWidget = new NavigationToggle({
+        view: view
+      });
+      setNavigationToggleWidget(navigationToggleWidget);
+      view.ui.add(navigationToggleWidget, "top-left");
+
+    }).catch((err) => console.error(err));
+    return function cleanup() {
+      view.ui.remove(navigationToggleWidget);
+    };
+  }, [])
+
+  return null;
+}
+
+export default NavigationToggleWidgetComponent;

--- a/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget.js
+++ b/src/components/shared/widgets/navigation-toggle-widget/navigation-toggle-widget.js
@@ -1,0 +1,3 @@
+import Component from './navigation-toggle-widget-component';
+
+export default Component;

--- a/src/components/shared/widgets/zoom-widget/zoom-widget-component.jsx
+++ b/src/components/shared/widgets/zoom-widget/zoom-widget-component.jsx
@@ -1,0 +1,24 @@
+import { loadModules } from '@esri/react-arcgis';
+import { useState, useEffect } from 'react';
+
+const ZoomWidgetComponent = ({ view }) => {
+  const [zoomWidget, setZoomWidget] = useState(null);
+
+  useEffect(() => {
+    loadModules(["esri/widgets/Zoom"]).then(([Zoom]) => {
+      const zoomWidget = new Zoom({
+        view: view
+      });
+      setZoomWidget(zoomWidget);
+      view.ui.add(zoomWidget, "top-left");
+
+    }).catch((err) => console.error(err));
+    return function cleanup() {
+      view.ui.remove(zoomWidget);
+    };
+  }, [])
+
+  return null;
+}
+
+export default ZoomWidgetComponent;

--- a/src/components/shared/widgets/zoom-widget/zoom-widget-component.jsx
+++ b/src/components/shared/widgets/zoom-widget/zoom-widget-component.jsx
@@ -16,7 +16,7 @@ const ZoomWidgetComponent = ({ view }) => {
     return function cleanup() {
       view.ui.remove(zoomWidget);
     };
-  }, [])
+  }, [view])
 
   return null;
 }

--- a/src/components/shared/widgets/zoom-widget/zoom-widget.js
+++ b/src/components/shared/widgets/zoom-widget/zoom-widget.js
@@ -1,0 +1,3 @@
+import Component from './zoom-widget-component';
+
+export default Component;

--- a/src/sceneConfigs/featuredGlobeViewConfig.js
+++ b/src/sceneConfigs/featuredGlobeViewConfig.js
@@ -7,7 +7,7 @@ export default {
     atmosphereEnabled: false
   },
   ui: {
-    components: ['zoom', 'navigation-toggle']
+    components: []
   },
   center: [-0, 0],
   zoom: 3


### PR DESCRIPTION
This Pr adds a location widget to the map
[Pivotal](https://www.pivotaltracker.com/story/show/164925275)

It exposes arcgis [Locate widget](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html) as a component.
It is then used as `child` of the `webscene` component having then access to `view` and `map` props.

I think this is a nice way of explicitly  using arcgis ui [widgets](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Widget.html). Maybe we should move all the widgets we use on the views to be consumed like this, instead of setting some of them on the `sceneConfig` (that way we will be more explicit on what things we are displaying on the map)

Currently we are doing something like this:

`#featuredGlobeViewConfig.js`
```js
export default {
  environment: {
    atmosphereEnabled: false
  },
  ui: {
    components: ['zoom', 'navigation-toggle']
  },
  center: [-0, 0],
  zoom: 3
}
```
@aabdaab what do you think?