### PR TITLE
cleanup: remove setgeojson action

### DIFF
--- a/src/components/landscape-view-manager/landscape-view-manager-component.jsx
+++ b/src/components/landscape-view-manager/landscape-view-manager-component.jsx
@@ -11,7 +11,7 @@ import {
   isLandscapeViewOffEvent
 } from 'utils/landscape-view-manager-utils';
 
-const LandscapeViewManager = ({ view, map, zoomLevelTrigger, onZoomChange, query, isLandscapeMode, setGridCellData, setGridCellGeojson, fetchGeoDescription }) => {
+const LandscapeViewManager = ({ view, map, zoomLevelTrigger, onZoomChange, query, isLandscapeMode, setGridCellData, fetchGeoDescription }) => {
   const [watchUtils, setWatchUtils] = useState(null);
   const [viewExtent, setViewExtent] = useState();
   // References for cleaning up graphics

--- a/src/redux-modules/grid-cell-data/grid-cell-data-actions.js
+++ b/src/redux-modules/grid-cell-data/grid-cell-data-actions.js
@@ -3,7 +3,3 @@ import { createAction } from 'redux-tools';
 export const setGridCellData = createAction(
   'SET_GRID_CELL_DATA'
 );
-
-export const setGridCellGeojson = createAction(
-  'SET_GRID_CELL_GEOJSON'
-);

--- a/src/redux-modules/grid-cell-data/grid-cell-data-reducers.js
+++ b/src/redux-modules/grid-cell-data/grid-cell-data-reducers.js
@@ -1,19 +1,13 @@
 import * as actions from './grid-cell-data-actions';
 import { isEqual } from 'lodash';
 
-export const initialState = { data: null, geojson: null };
+export const initialState = { data: null };
 
 function setGridCellData(state, { payload }) {
-  const gridCellsData = payload.map(cell => cell.attributes)
-  return isEqual(state.data, gridCellsData) ? state : { ...state, data: gridCellsData }
-}
-
-const setGridCellGeojson = (state, { payload }) => {
-  return { ...state, geojson: payload }
+  const gridCellsData = payload.map(cell => cell.attributes);
+  return isEqual(state.data, gridCellsData) ? state : { ...state, data: gridCellsData };
 }
 
 export default {
-  [actions.setGridCellData]: setGridCellData,
-  [actions.setGridCellGeojson]: setGridCellGeojson
+  [actions.setGridCellData]: setGridCellData
 };
-


### PR DESCRIPTION
I forgot to remove that not used anymore action to set GeoJSON for selected grid cell.

The GeoJSON is still set in other redux-module (geo-description module), but only to prevent subsequent requests for fetching the same area information.