### PR TITLE
Layer opacity bug

### DIFF
--- a/src/components/arcgis-layer-manager/arcgis-layer-manager-component.jsx
+++ b/src/components/arcgis-layer-manager/arcgis-layer-manager-component.jsx
@@ -2,13 +2,21 @@ const ArcgisLayerManager = ({ map, activeLayers }) => {
   // Map prop is inherited from Webscene component
   // reference: https://github.com/Esri/react-arcgis#advanced-usage
   const { layers } = map;
+
+  const setOpacity = (layer) => {
+    const l = activeLayers.find(o => o.id === layer.id);
+    if (l) { layer.opacity = l.opacity !== undefined ? l.opacity : 1 };
+  }
+
   layers.items.forEach(mapLayer => {
     const setActive = activeLayers && activeLayers.some(activeLayer => activeLayer.id === mapLayer.id);
     mapLayer.layers && mapLayer.layers.items && mapLayer.layers.items.forEach(layer => {
       const setActive = activeLayers && activeLayers.some(activeLayer => activeLayer.id === layer.id);
+      setOpacity(layer);
       layer.visible = !!setActive;
       mapLayer.visible = !!setActive;
     })
+    setOpacity(mapLayer);    
     mapLayer.visible = !!setActive;
   })
   return null

--- a/src/components/legend/legend-component.jsx
+++ b/src/components/legend/legend-component.jsx
@@ -23,12 +23,6 @@ const HELegend = ({ map, datasets, handlers, isFullscreenActive, visibleLayers, 
   const { layers } = map;
 
   const handleChangeOpacity = (layer, opacity) => {
-    layers.items.forEach(mapLayer => {
-      if (mapLayer.id === layer.id) { mapLayer.opacity = opacity; }
-      mapLayer.layers && mapLayer.layers.items && mapLayer.layers.items.forEach(nestedLayer => {
-        if (nestedLayer.id === layer.id) { nestedLayer.opacity = opacity; }
-      })
-    })
     setLayerOpacity(layer.id, opacity);
   }
 

--- a/src/components/legend/legend-selectors.js
+++ b/src/components/legend/legend-selectors.js
@@ -44,7 +44,7 @@ const parseLegend = (config) => {
     molLogo: config && config.molLogo,
     layers: [{
       active: true,
-      opacity: config.opacity || 1,
+      opacity: config.opacity !== undefined ? config.opacity : 1,
       id: config.layerId,
       type: 'layer',
       legendConfig: {


### PR DESCRIPTION
Before we were setting layer's `opacity` directly on the WebScene's layer along with setting opacity in the url (in `handleChangeOpacity` method in `legend-component`) and it was causing issues on removing layers (we were changing only the visibility of the layers but the opacity was not resetted and we had two sources of truth).
Now, `handleChangeOpacity` is only changing opacity in the URL and then in the `arcgis-layer-manager-component` we're driving that value to feed it to webscene's layer.