### PR TITLE
Feature/sidebar style tweaks

### DIFF
--- a/src/components/biodiversity-layers/biodiversity-layers-component.jsx
+++ b/src/components/biodiversity-layers/biodiversity-layers-component.jsx
@@ -39,7 +39,7 @@ const BiodiversityLayers = ({
           {
             subcategories.map(subct => (
               <div key={subct.name}>
-                <h2 className={styles.widgetTitle}>{subct.name}</h2>
+                <h2 className={styles.widgetSubTitle}>{subct.name}</h2>
                 <div className={styles.subcategoryRadioContainer}>
                   <RadioGroup
                     activeLayers={activeLayers}

--- a/src/components/biodiversity-layers/biodiversity-layers-styles.module.scss
+++ b/src/components/biodiversity-layers/biodiversity-layers-styles.module.scss
@@ -11,7 +11,7 @@
 
 .titleSection {
   display: flex;
-  padding-left: $sidebar-paddings;
+  padding: 0 $sidebar-paddings;
 }
 
 .widgetTitle {
@@ -34,7 +34,7 @@
   font-size: $font-size-xs;
   margin-top: 0;
   margin-bottom: 14px;
-  padding-left: $sidebar-paddings;
+  padding: 0 $sidebar-paddings;
 }
 
 .fineScaleWrapper {

--- a/src/components/biodiversity-layers/biodiversity-layers-styles.module.scss
+++ b/src/components/biodiversity-layers/biodiversity-layers-styles.module.scss
@@ -2,12 +2,16 @@
 @import 'styles/settings';
 
 .wrapper {
-  padding-bottom: $sidebar-paddings;
-  padding-left: $sidebar-paddings;
+  @include backdropBlur();
+  padding-bottom: 30px;
+  &:first-child {
+    padding-top: $sidebar-paddings;
+  }
 }
 
 .titleSection {
   display: flex;
+  padding-left: $sidebar-paddings;
 }
 
 .widgetTitle {
@@ -15,8 +19,14 @@
   font-size: $font-size-xs;
   font-weight: bold;
   letter-spacing: 2px;
-  text-transform: uppercase;
   line-height: 20px;
+  margin-top: 0;
+  text-transform: uppercase;
+}
+
+.widgetSubTitle {
+  @extend .widgetTitle;
+  padding-left: calc(2 * #{$sidebar-paddings})
 }
 
 .description {
@@ -24,14 +34,14 @@
   font-size: $font-size-xs;
   margin-top: 0;
   margin-bottom: 14px;
+  padding-left: $sidebar-paddings;
 }
 
 .fineScaleWrapper {
   @include backdropBlur($colour: rgba(2,114,186,0.1), $fallback: #003252, $fallbackOpacity: 0.6);
-  padding-bottom: $sidebar-paddings;
-  padding-left: $sidebar-paddings;
-  padding-top: $sidebar-paddings;
+  padding: $sidebar-paddings 0;
 }
-.subcategoryRadioContainer {
-  padding-left: $sidebar-margin;
+
+.subcategoryRadioContainer label {
+  padding-left: calc(2 * #{$sidebar-paddings});
 }

--- a/src/components/category-box/category-box-styles.module.scss
+++ b/src/components/category-box/category-box-styles.module.scss
@@ -40,6 +40,7 @@
   letter-spacing: 2px;
   margin: 0;
   margin-bottom: 8px;
+  user-select: none;
 
   .counter {
     color: $robins-egg-blue;
@@ -61,6 +62,7 @@
   line-height: 30px;
   overflow: hidden;
   text-overflow: ellipsis;
+  user-select: none;
 }
 
 .icon {

--- a/src/components/checkbox-group/checkbox/checkbox-styles.module.scss
+++ b/src/components/checkbox-group/checkbox/checkbox-styles.module.scss
@@ -6,11 +6,12 @@ $checkbox-size: 15px;
   color: $white;
   font-size: $font-size-sm;
   font-family: 'PierSans-Light';
-  padding: 5px 0 5px 0;
   display: flex;
   align-items: center;
   margin-bottom: 4px;
   cursor: pointer;
+  padding-right: $sidebar-paddings;
+
 
   &:hover {
     @extend .checkboxWrapperSelected;
@@ -19,20 +20,21 @@ $checkbox-size: 15px;
 
 .checkboxWrapperSelected {
   background-color: rgba(255, 255, 255, 0.05);
-  margin-left: -($sidebar-margin);
-  padding-left: $sidebar-margin;
 }
 
 input[type="checkbox"] {
   opacity: 0;
   position: absolute;
+  cursor: pointer;
 }
 
 .checkbox {
   display: flex;
   align-items: center;
   cursor: pointer;
-  height: 20px;
+  height: 30px;
+  width: 100%;
+  padding-left: 20px;
 
   &:before {
     content: "";

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -6,7 +6,7 @@
   padding-left: $sidebar-paddings;
   display: flex;
   flex-direction: column;
-  height: 100px;
+  height: $sidebar-header-height;
   position: relative;
 }
 

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -3,7 +3,6 @@
 
 .header {
   padding-top: $sidebar-margin;
-  padding-bottom: $sidebar-paddings;
   padding-left: $sidebar-paddings;
   display: flex;
   flex-direction: column;

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -6,11 +6,13 @@
   padding-left: $sidebar-paddings;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .shareButton {
-  align-self: flex-end;
-  margin-right: 10px;
+  position: absolute;
+  right: 8px;
+  top: 8px;
 }
 
 .button {
@@ -41,8 +43,14 @@
   text-overflow: ellipsis;
   padding-right: 10px;
   letter-spacing: 1px;
+  font-weight: normal;
 }
 
 .spacer {
   @extend %spacer;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  position: absolute;
+  width: 100%;
 }

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -6,6 +6,7 @@
   padding-left: $sidebar-paddings;
   display: flex;
   flex-direction: column;
+  height: 100px;
   position: relative;
 }
 

--- a/src/components/multiple-active-layers/multiple-active-layers-styles.module.scss
+++ b/src/components/multiple-active-layers/multiple-active-layers-styles.module.scss
@@ -4,11 +4,11 @@
 .wrapper {
   @include backdropBlur();
   padding-bottom: $sidebar-paddings;
-  padding-left: $sidebar-paddings;
 }
 
 .titleSection {
   display: flex;
+  padding-left: $sidebar-paddings;
 }
 
 .widgetTitle {
@@ -26,4 +26,5 @@
   line-height: 16px;
   margin-top: 0;
   margin-bottom: 14px;
+  padding-left: $sidebar-paddings;
 }

--- a/src/components/multiple-active-layers/multiple-active-layers-styles.module.scss
+++ b/src/components/multiple-active-layers/multiple-active-layers-styles.module.scss
@@ -8,7 +8,7 @@
 
 .titleSection {
   display: flex;
-  padding-left: $sidebar-paddings;
+  padding: 0 $sidebar-paddings;
 }
 
 .widgetTitle {
@@ -26,5 +26,5 @@
   line-height: 16px;
   margin-top: 0;
   margin-bottom: 14px;
-  padding-left: $sidebar-paddings;
+  padding: 0 $sidebar-paddings;
 }

--- a/src/components/radio-group/radio-group-component.jsx
+++ b/src/components/radio-group/radio-group-component.jsx
@@ -28,7 +28,7 @@ const RadioGroup = ({ activeLayers, options, title, handleSimpleLayerToggle, han
   const variant = (selected && selected.variant) || RARITY;
   const isRarityActive = variant === RARITY;
 
-  const isSelected = (option) => !!(activeLayers.find(l => l.id === option.layers[variant]))
+  const isSelected = (option) => !!(activeLayers.find(l => l.id === option.layers[variant]));
 
   return (
     <>
@@ -44,7 +44,7 @@ const RadioGroup = ({ activeLayers, options, title, handleSimpleLayerToggle, han
               id={option.value}
               value={option.value}
               checked={isSelected(option)}
-              onChange={() => {
+              onClick={() => {
                 if (isSelected(option)) {
                   handleSimpleLayerToggle(option.layers[variant]);
                 } else {

--- a/src/components/radio-group/radio-group-styles.module.scss
+++ b/src/components/radio-group/radio-group-styles.module.scss
@@ -6,12 +6,12 @@ $circle-size: 15px;
   color: $white;
   font-size: $font-size-sm;
   font-family: 'PierSans-Light';
-  padding: 5px 0 5px 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 4px;
   cursor: pointer;
+  height: 30px;
 
   &:hover {
     @extend .radioOptionSelected;
@@ -20,13 +20,12 @@ $circle-size: 15px;
 
 .radioOptionSelected {
   background-color: rgba(255,255,255,0.05);
-  margin-left: -($sidebar-margin);
-  padding-left: $sidebar-margin;
 }
 
 input[type="radio"] {
   opacity: 0;
   position: absolute;
+  cursor: pointer;
   // prevent the default radio button from taking up the space
   // display: none would screw up the keyboard navigation, so let's go for opacity
 }
@@ -36,8 +35,9 @@ input[type="radio"] {
   align-items: center;
   text-transform: capitalize;
   width: 100%;
-  height: 20px;
+  height: 30px;
   cursor: pointer;
+  padding-left: $sidebar-paddings;
 
   &:before {
     content: "";
@@ -51,6 +51,7 @@ input[type="radio"] {
 
 .radioOption input[type="radio"]:checked + .radioInput::before {
   background: linear-gradient(270deg, $vida-loca 0%, $cobalt 100%);
+  border-width: 2px;
 }
 
 .reverseSwitchIcon {
@@ -59,7 +60,7 @@ input[type="radio"] {
 
 .toggle {
   display: flex;
-  align-items: center;
+  // align-items: center;
   margin-left: 5px;
   margin-right: 18px;
 }

--- a/src/components/radio-group/radio-group-styles.module.scss
+++ b/src/components/radio-group/radio-group-styles.module.scss
@@ -60,6 +60,7 @@ input[type="radio"] {
 
 .toggle {
   display: flex;
+  align-items: center;
   margin-left: 5px;
   margin-right: 18px;
 }
@@ -77,4 +78,5 @@ input[type="radio"] {
 .button {
   display: flex;
   align-items: center;
+  height: 12px;
 }

--- a/src/components/radio-group/radio-group-styles.module.scss
+++ b/src/components/radio-group/radio-group-styles.module.scss
@@ -60,7 +60,6 @@ input[type="radio"] {
 
 .toggle {
   display: flex;
-  // align-items: center;
   margin-left: 5px;
   margin-right: 18px;
 }

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -15,7 +15,7 @@
   bottom: 0;
   width: $sidebar-width;
   overflow: hidden;
-  height: calc(100vh - 92px); // 92px => 2 * $sidebar-margin + search widget height and margin
+  // height: calc(100vh - 92px); // 92px => 2 * $sidebar-margin + search widget height and margin
 }
 
 .button {
@@ -40,5 +40,7 @@
 
 .content {
   @extend %verticalScrollBar;
-  height: calc(100% - 120px);
+  max-height: calc(100% - 240px);
+  position: fixed;
+  width: 280px;
 }

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -15,7 +15,6 @@
   bottom: 0;
   width: $sidebar-width;
   overflow: hidden;
-  // height: calc(100vh - 92px); // 92px => 2 * $sidebar-margin + search widget height and margin
 }
 
 .button {
@@ -40,7 +39,7 @@
 
 .content {
   @extend %verticalScrollBar;
-  max-height: calc(100% - 240px);
+  max-height: calc(100% - 200px);
   position: fixed;
   width: 280px;
 }

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -10,6 +10,8 @@
 
 .wrapper {
   @include backdropBlur();
+  display: flex;
+  flex-direction: column;
   position: relative;
   top: 0;
   bottom: 0;
@@ -39,7 +41,6 @@
 
 .content {
   @extend %verticalScrollBar;
-  max-height: calc(100% - 160px);
-  position: fixed;
-  width: 280px;
+  max-height: calc(100vh - (#{$sidebar-top-margin} + #{$sidebar-header-height}));
+  width: $sidebar-width;
 }

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -39,7 +39,7 @@
 
 .content {
   @extend %verticalScrollBar;
-  max-height: calc(100% - 200px);
+  max-height: calc(100% - 160px);
   position: fixed;
   width: 280px;
 }

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -14,19 +14,8 @@
   top: 0;
   bottom: 0;
   width: $sidebar-width;
-  overflow: auto;
+  overflow: hidden;
   height: calc(100vh - 92px); // 92px => 2 * $sidebar-margin + search widget height and margin
-}
-
-.content {
-  overflow-y: scroll;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none;  /* IE 10+ */
-
-  &::-webkit-scrollbar {
-    width: 0;
-    height: 0;
-  }
 }
 
 .button {
@@ -47,4 +36,9 @@
 .icon {
   transform: rotate(180deg);
   height: 25px;
+}
+
+.content {
+  @extend %verticalScrollBar;
+  height: calc(100% - 120px);
 }

--- a/src/constants/base-layers.js
+++ b/src/constants/base-layers.js
@@ -1,1 +1,1 @@
-export const FIREFLY_LAYER = '16b23629a42-layer-0';
+export const FIREFLY_LAYER = '16b4fc6cb63-layer-1';

--- a/src/constants/base-layers.js
+++ b/src/constants/base-layers.js
@@ -1,1 +1,1 @@
-export const FIREFLY_LAYER = '16b4fc6cb63-layer-1';
+export const FIREFLY_LAYER = '16b23629a42-layer-0';

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -50,7 +50,6 @@ $font-family-1: 'PierSans';
 $font-family-1-bold: 'PierSans-Bold';
 
 // Layout 
-$sidebar-width: 280px;  // use this for entry boxes and sidebar width
 $site-gutter: 20px;
 $widget-button-size: 24px;
 
@@ -70,6 +69,12 @@ $breakpoint-mobile-only: 37.4375rem; // 599px / 16px
 $breakpoint-tablet-portrait: 37.5rem; // 600px / 16px
 $breakpoint-tablet-landscape: 56.25rem; // 900px / 16px
 $breakpoint-desktop: 75rem; // 1200px / 16px
+
+// Sidebar
+$sidebar-top-margin: 60px;
+$sidebar-header-height: 100px;
+$sidebar-width: 280px;  // use this for entry boxes and sidebar width
+
 
 // Media queries
 $mobile-only: 'screen and (max-width: #{$breakpoint-mobile-only})';

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -59,7 +59,8 @@ $blur-level: 16px;
 
 // Global
 $sidebar-margin: 20px;
-$sidebar-paddings: 30px;
+// $sidebar-paddings: 30px;
+$sidebar-paddings: 20px;
 
 // Letter styles
 $letter-spacing: 1.5px;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -59,7 +59,6 @@ $blur-level: 16px;
 
 // Global
 $sidebar-margin: 20px;
-// $sidebar-paddings: 30px;
 $sidebar-paddings: 20px;
 
 // Letter styles

--- a/src/styles/ui.module.scss
+++ b/src/styles/ui.module.scss
@@ -53,3 +53,14 @@ $spacer-middle-opacity: 0.6;
   }
   
 }
+
+%verticalScrollBar {
+  overflow-y: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;  /* IE 10+ */
+
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+}

--- a/src/styles/ui.module.scss
+++ b/src/styles/ui.module.scss
@@ -5,7 +5,7 @@ $spacer-middle-opacity: 0.6;
 
 .uiTopLeft {
   position: absolute;
-  top: 60px;
+  top: $sidebar-top-margin;
   left: $site-gutter;
 }
 


### PR DESCRIPTION
This PR introduces a lot of small styles tweaks for the sidebar, to be more consistent with the design. 
Also, fixes radio-button bug - when you wanted to unselect radio button, it didn't work. I fixed this by simply changing an input event from `onChange` to `onClick`. Browser console complains about that, maybe there is a better way to fix this. We should think about extracting styles for radio-buttons/checkboxes and sidebar active-layers sections because they are repeated in a few different places, but I don't want to do it in this PR.

[PIVOTAL](https://www.pivotaltracker.com/story/show/166479396) | [INVISION](https://projects.invisionapp.com/d/main#/console/17484384/362411410/inspect)
![Untitled](https://user-images.githubusercontent.com/15097138/59514908-ce20ed80-8eb5-11e9-9861-660acaf99964.png)
