### PR TITLE
Feature/default opacity and finescaledata max scale

### DIFF
--- a/src/components/biodiversity-layers/biodiversity-layers.js
+++ b/src/components/biodiversity-layers/biodiversity-layers.js
@@ -13,7 +13,7 @@ const BiodiversityLayerContainer = props => {
         urlTemplate: url,
         title: title,
         id: slug,
-        opacity: 1,
+        opacity: 0.6,
         maxScale: bbox ? 1000 : 2800000
       })
       map.add(tileLayer);

--- a/src/components/biodiversity-layers/biodiversity-layers.js
+++ b/src/components/biodiversity-layers/biodiversity-layers.js
@@ -8,13 +8,13 @@ const BiodiversityLayerContainer = props => {
   const createLayer = layer => {
     loadModules(["esri/layers/WebTileLayer"]).then(([WebTileLayer]) => {
       const { map } = props;
-      const { url, title, slug } = layer;
+      const { url, title, slug, bbox } = layer;
       const tileLayer = new WebTileLayer({
         urlTemplate: url,
         title: title,
         id: slug,
         opacity: 1,
-        maxScale: 2800000
+        maxScale: bbox ? 1000 : 2800000
       })
       map.add(tileLayer);
     });

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -1,20 +1,20 @@
+const DEFAULT_OPACITY = 0.6;
 export const layerManagerToggle = (layerId, activeLayers, callback, category) => {
   const id = layerId;
   const isActive = activeLayers && activeLayers.some(l => l.id === id);
-
   if (isActive) {
     const updatedLayers = activeLayers.filter(l => l.id !== id);
     callback({activeLayers: updatedLayers });
   } else {
     activeLayers
-      ? callback({ activeLayers: [ ...activeLayers, { id, category }] })
-      : callback({ activeLayers: [ { id, category }] });
+      ? callback({ activeLayers: [ ...activeLayers, { id, category, opacity: DEFAULT_OPACITY }] })
+      : callback({ activeLayers: [ { id, category, opacity: DEFAULT_OPACITY }] });
   }
 };
 
 export const exclusiveLayersToggle = (layerToActivate, layerToRemove, activeLayers, callback, category) => {
   const layerAfterRemove = layerToRemove ? activeLayers.filter(l => l.id !== layerToRemove) : activeLayers;
-  callback({activeLayers: [...layerAfterRemove, {id: layerToActivate, category}]});
+  callback({activeLayers: [...layerAfterRemove, {id: layerToActivate, category, opacity: DEFAULT_OPACITY }]});
 };
 
 export const layerManagerVisibility = (layerId, visible, activeLayers, callback) => {
@@ -26,8 +26,8 @@ export const layerManagerVisibility = (layerId, visible, activeLayers, callback)
     callback({activeLayers: updatedLayers });
   } else {
     activeLayers
-      ? callback({ activeLayers: [ ...activeLayers, { id }] })
-      : callback({ activeLayers: [ { id }] });
+      ? callback({ activeLayers: [ ...activeLayers, { id, opacity: DEFAULT_OPACITY }] })
+      : callback({ activeLayers: [ { id, opacity: DEFAULT_OPACITY }] });
   }
 };
 


### PR DESCRIPTION
This PR fixes the *maxScale* attribute for biodiversity fine scale layers (Hummingbirds and South Africa Layers). This feature was requested from MoL team on our last core meeting (only global biodiversity data must disappear when in landscape view).
It also sets default opacity for newly added layers to `0.6`, that has been a request from Esri agreed with the design team.
[PIVOTAL](https://www.pivotaltracker.com/story/show/166767898)

![Kapture 2019-06-19 at 9 59 50](https://user-images.githubusercontent.com/6906348/59747394-199e1780-9279-11e9-80f3-efa8773e1847.gif)
