### PR TITLE
Fix missing biodiversity layers after relad

### DIFF
--- a/src/components/biodiversity-layers/biodiversity-layers.js
+++ b/src/components/biodiversity-layers/biodiversity-layers.js
@@ -1,31 +1,11 @@
 import React from 'react';
 import { loadModules } from '@esri/react-arcgis';
 import { layersConfig } from 'constants/mol-layers-configs';
+import { createLayer } from 'utils/layer-manager-utils';
+
 import Component from './biodiversity-layers-component';
 
 const BiodiversityLayerContainer = props => {
-
-  const createLayer = layer => {
-    loadModules(["esri/layers/WebTileLayer"]).then(([WebTileLayer]) => {
-      const { map } = props;
-      const { url, title, slug } = layer;
-      const tileLayer = new WebTileLayer({
-        urlTemplate: url,
-        title: title,
-        id: slug,
-        opacity: 0.6
-      })
-      map.add(tileLayer);
-      const hummingBirdsLayersSlugs = ['hummingbirds-rare', 'hummingbirds-rich'];
-      const isHummingBirdLayer = hummingBirdsLayersSlugs.includes(title);
-      const isSALayer = title.startsWith('sa');
-      if (isHummingBirdLayer || isSALayer) {
-        map.reorder(tileLayer, 2);
-      } else {
-        map.reorder(tileLayer, 1);
-      }
-    });
-  }
 
   const flyToLayerExtent = bbox => {
     const { view } = props;
@@ -54,7 +34,7 @@ const BiodiversityLayerContainer = props => {
       exclusiveLayerToggle(addLayer.slug, removeSlug);
       addLayer.bbox && flyToLayerExtent(addLayer.bbox);
     } else {
-      createLayer(addLayer);
+      createLayer(addLayer, map);
       exclusiveLayerToggle(addLayer.slug, removeSlug);
       addLayer.bbox && flyToLayerExtent(addLayer.bbox);
     }

--- a/src/components/human-impact-layers/human-impact-layers-component.jsx
+++ b/src/components/human-impact-layers/human-impact-layers-component.jsx
@@ -14,8 +14,6 @@ const HumanImpactLayers = ({ map, rasters, setRasters, setLayerVisibility, activ
   // eslint-disable-next-line no-mixed-operators
   }), {})) || {};
 
-  console.log('human impact layers', alreadyChecked);
-
   const handleHumanPressureRasters = (rasters, option) => {
     const { layers } = map;
     const humanImpactLayer = layers.items.find(l => l.id === HUMAN_PRESSURE_LAYER_ID);

--- a/src/pages/data-globe/data-globe.js
+++ b/src/pages/data-globe/data-globe.js
@@ -5,16 +5,30 @@ import { BIODIVERSITY_FACETS_LAYER } from 'constants/biodiversity';
 import { layerManagerToggle, exclusiveLayersToggle, layerManagerVisibility, layerManagerOpacity, layerManagerOrder } from 'utils/layer-manager-utils';
 import Component from './data-globe-component.jsx';
 import mapStateToProps from './data-globe-selectors';
+import { layersConfig } from 'constants/mol-layers-configs';
 
 import ownActions from './data-globe-actions.js';
+import { createLayer } from 'utils/layer-manager-utils';
+
 const actions = { ...ownActions };
 
-const handleMapLoad = (map, view) => {
+const handleMapLoad = (map, view, activeLayers) => {
   const { layers } = map;
+
   const gridLayer = layers.items.find(l => l.id === BIODIVERSITY_FACETS_LAYER);
   // set the outFields for the BIODIVERSITY_FACETS_LAYER
   // to get all the attributes available
   gridLayer.outFields = ["*"];
+
+  //list of active biodiversity layers
+  const biodiversityLayerIDs = activeLayers
+    .filter(({ category }) => category === "Biodiversity")
+    .map(({ id }) => id);
+
+  const biodiversityLayers = layersConfig
+    .filter(({ slug }) => biodiversityLayerIDs.includes(slug));
+
+  biodiversityLayers.forEach(layer => createLayer(layer, map));
 }
 
 const dataGlobeContainer = props => {
@@ -33,7 +47,7 @@ const dataGlobeContainer = props => {
     setLayerOpacity={setLayerOpacity}
     setLayerOrder={setLayerOrder}
     setRasters={setRasters}
-    onLoad={(map, view) => handleMapLoad(map, view)}
+    onLoad={(map, view) => handleMapLoad(map, view, props.activeLayers)}
     handleZoomChange={handleZoomChange}
     {...props}/>
 }

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -1,5 +1,6 @@
 import { FIREFLY_LAYER } from 'constants/base-layers';
 import { BIODIVERSITY_FACETS_LAYER } from 'constants/biodiversity';
+import { loadModules } from '@esri/react-arcgis';
 
 const DEFAULT_OPACITY = 0.6;
 
@@ -45,3 +46,24 @@ export const layerManagerOrder = (datasets, activeLayers, callback) => {
   datasets.forEach((d) => { updatedLayers.push(activeLayers.find(({ id }) => d === id )) });
   callback({ activeLayers: updatedLayers });
 };
+
+export const createLayer = (layer, map) => {
+  loadModules(["esri/layers/WebTileLayer"]).then(([WebTileLayer]) => {
+    const { url, title, slug } = layer;
+    const tileLayer = new WebTileLayer({
+      urlTemplate: url,
+      title: title,
+      id: slug,
+      opacity: 0.6
+    })
+    map.add(tileLayer);
+    const hummingBirdsLayersSlugs = ['hummingbirds-rare', 'hummingbirds-rich'];
+    const isHummingBirdLayer = hummingBirdsLayersSlugs.includes(title);
+    const isSALayer = title.startsWith('sa');
+    if (isHummingBirdLayer || isSALayer) {
+      map.reorder(tileLayer, 2);
+    } else {
+      map.reorder(tileLayer, 1);
+    }
+  });
+}


### PR DESCRIPTION
This PR fixes the bug when selected biodiversity layers weren't appearing after reload.
[PIVOTAL](https://www.pivotaltracker.com/story/show/166903296)

![kqogo-s9tef](https://user-images.githubusercontent.com/15097138/60455056-57158400-9c2d-11e9-8649-f7b7ac3fbe9e.gif)
