### PR TITLE
Bug/filter marine grid cells pressures

### DIFF
--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
@@ -25,7 +25,7 @@ const getPressureStatement = createSelector(getPressuresHierarchy, humanPressure
   const pressuresValues = pressures.map(p => p.value)
   const biggestPressure = orderBy(pressures, 'value', 'desc')[0].name;
   const totalPressure = pressuresValues.reduce((acc, current) => acc + current);
-  if (totalPressure === 0) return 'There is no human pressure on the selected area';
+  if (totalPressure === 0) return 'There is no land human pressure on the selected area';
   return `Of the current landscape, ${format(".2%")(totalPressure / 100)} is under human pressure, the majority of which is pressure from ${biggestPressure}.`
 })
 

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
@@ -2,9 +2,9 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import { orderBy } from 'lodash';
 import { format } from 'd3-format';
 import { humanPressuresLandscapeWidget } from 'constants/human-pressures';
-import { getHumanPressures } from 'selectors/grid-cell-selectors';
+import { getTerrestrialHumanPressures } from 'selectors/grid-cell-selectors';
 
-const getPressuresHierarchy = createSelector(getHumanPressures, humanPressures => {
+const getPressuresHierarchy = createSelector(getTerrestrialHumanPressures, humanPressures => {
   if (!humanPressures) return null;
   return {
     name: 'Human Pressures',
@@ -30,7 +30,7 @@ const getPressureStatement = createSelector(getPressuresHierarchy, humanPressure
 })
 
 export default createStructuredSelector({
-  humanPressures: getHumanPressures,
+  humanPressures: getTerrestrialHumanPressures,
   data: getPressuresHierarchy,
   pressureStatement: getPressureStatement
 });

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-component.jsx
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-component.jsx
@@ -5,7 +5,7 @@ import styles from './human-pressure-widget-styles.module.scss';
 const HumanPressureWidgetComponent = ({ handleOnClick, data, pressureStatement, activeRect }) => {
   return (
     <div className={styles.container}>
-      <h3 className={styles.title}>Human pressures in this area</h3>
+      <h3 className={styles.title}>Land human pressures in this area</h3>
       <p className={styles.text}>{pressureStatement}</p>
       {data && <Treemap data={data} handleOnClick={handleOnClick} activeRect={activeRect} className={styles.treemap}/>}
       <p  className={styles.hint}>CLICK TO SHOW ON MAP</p>

--- a/src/selectors/grid-cell-selectors.js
+++ b/src/selectors/grid-cell-selectors.js
@@ -9,11 +9,13 @@ export const getCellSpecies = createSelector(selectCellData, cellData => {
   return species;
 })
 
-export const getHumanPressures = createSelector(
+export const getTerrestrialHumanPressures = createSelector(
   [selectCellData],
   cellData=> {
     if (!cellData) return null;
-    const pressures = cellData.reduce((acc, current) => {
+    const terrestrialGridCells = cellData.filter(c => c.ISMARINE === 0);
+    if (terrestrialGridCells.length === 0) return { rainfed: 0, agriculture: 0, urban: 0, pressureFree: 100 };
+    const pressures = terrestrialGridCells.reduce((acc, current) => {
       return {
         ...acc,
         [current.CELL_ID]: {
@@ -40,5 +42,5 @@ export const getHumanPressures = createSelector(
 
 export default createStructuredSelector({
   cellSpecies: getCellSpecies,
-  humanPressures: getHumanPressures
+  humanPressures: getTerrestrialHumanPressures
 })


### PR DESCRIPTION
This PR avoids Marine Grid cells to be accountable while calculating terrestrial human pressures (that was causing the skew of the pressures percentages).

[PIVOTAL](https://www.pivotaltracker.com/story/show/167037050)

@fannycc, @faustoperez , @gretacv, @benlaken  would it make sense to change the wording on the human pressures widget to aware users that the pressures displayed there are only terrestrial? I think eventually we would need some place to display marine pressures.

