### PR TITLE
Feature/terrain exaggeration

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -28,7 +28,7 @@ module.exports = function override(config, env) {
       sceneConfigs: path.resolve(__dirname, 'src/sceneConfigs'),
       hooks: path.resolve(__dirname, 'src/hooks'),
       images: path.resolve(__dirname, 'src/assets/images'),
-      providers: path.resolve(__dirname, 'src/providers'),
+      providers: path.resolve(__dirname, 'src/providers')
     }
   }
   config = rewireReactHotLoader(config, env);

--- a/src/components/grid-layer/grid-layer-component.jsx
+++ b/src/components/grid-layer/grid-layer-component.jsx
@@ -94,7 +94,7 @@ const GridLayer = ({map, view, setGridCellData, setGridCellGeometry}) => {
         return function cleanUp() {
           cleanUpHandles();
       }
-  }, [gridViewLayer, viewExtent]);
+  }, [gridViewLayer, viewExtent, gridCellGraphic]);
 
   useEffect(() => {
     return function cleanUp() {

--- a/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
+++ b/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { loadModules } from '@esri/react-arcgis';
+
+const exaggeratedElevationLayerComponent = ({ map, exaggeration = 2}) => {
+
+  useEffect(() => {
+    loadModules(["esri/layers/ElevationLayer", "esri/layers/BaseElevationLayer"]).then(([ElevationLayer, BaseElevationLayer]) => {
+      const ExaggeratedElevationLayer = BaseElevationLayer.createSubclass({
+    
+        properties: {
+          exaggeration
+        },
+      
+        load: function () {
+          this._elevation = new ElevationLayer({
+            url: "//elevation3d.arcgis.com/arcgis/rest/services/WorldElevation3D/Terrain3D/ImageServer"
+          });
+      
+          this.addResolvingPromise(this._elevation.load());
+        },
+      
+        fetchTile: function (level, row, col) {
+          // calls fetchTile() on the elevationlayer for the tiles
+          // visible in the view
+          return this._elevation.fetchTile(level, row, col)
+            .then(function (data) {
+      
+              var exaggeration = this.exaggeration;
+              for (var i = 0; i < data.values.length; i++) {
+                data.values[i] = data.values[i] * exaggeration;
+              }
+      
+              return data;
+            }.bind(this));
+        }
+      });
+    
+      map.ground.layers = [new ExaggeratedElevationLayer()];
+    })
+  }, [])
+
+  return null
+};
+
+export default exaggeratedElevationLayerComponent;

--- a/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer.js
+++ b/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer.js
@@ -1,0 +1,3 @@
+import Component from './terrain-exaggeration-layer-component';
+
+export default Component;

--- a/src/hooks/landscape-view-hooks.js
+++ b/src/hooks/landscape-view-hooks.js
@@ -24,7 +24,7 @@ import {
 
   export function useLandscapeViewCameraChange(view, isLandscapeMode) {
     useEffect(() => {
-      const tilt = isLandscapeMode ? 45 : 0;
+      const tilt = isLandscapeMode ? 55 : 0;
       const heading = 0;
       const target = { tilt, heading };
       const options = {

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -5,6 +5,7 @@ import { biodiversityCategories } from 'constants/mol-layers-configs';
 import Globe from 'components/globe';
 import ArcgisLayerManager from 'components/arcgis-layer-manager';
 import LandscapeViewManager from 'components/landscape-view-manager';
+import TerrainExaggerationLayer from 'components/terrain-exaggeration-layer';
 
 import EntryBoxes from 'components/entry-boxes';
 import Sidebar from 'components/sidebar';
@@ -51,6 +52,7 @@ const DataGlobeComponent = ({
   
   return (
     <Globe sceneId={SCENE_ID} sceneSettings={sceneSettings} onLoad={onLoad}>
+      <TerrainExaggerationLayer exaggeration={3}/>
       <ArcgisLayerManager activeLayers={activeLayers}/>
       <LandscapeViewManager zoomLevelTrigger={ZOOM_LEVEL_TRIGGER} onZoomChange={handleZoomChange} isLandscapeMode={isLandscapeMode} />
       <LocationWidget />

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -1,5 +1,4 @@
-import { FIREFLY_LAYER } from 'constants/base-layers';
-import { BIODIVERSITY_FACETS_LAYER } from 'constants/biodiversity';
+import { LEGEND_FREE_LAYERS } from 'constants/layers-groups';
 import { loadModules } from '@esri/react-arcgis';
 
 const DEFAULT_OPACITY = 0.6;
@@ -42,7 +41,7 @@ export const layerManagerOpacity = (layerId, opacity, activeLayers, callback) =>
 };
 
 export const layerManagerOrder = (datasets, activeLayers, callback) => {
-  const updatedLayers = activeLayers.filter(({ id }) => id === FIREFLY_LAYER || id === BIODIVERSITY_FACETS_LAYER);
+  const updatedLayers = activeLayers.filter(({ id }) => LEGEND_FREE_LAYERS.some(layer =>layer === id));
   datasets.forEach((d) => { updatedLayers.push(activeLayers.find(({ id }) => d === id )) });
   callback({ activeLayers: updatedLayers });
 };


### PR DESCRIPTION
This PR adds a terrain elevation layer. That has been a design request since the beginning of the project (it was requested again while going through landscape features labels task review).

It increases the draping sensation of grid cells on the terrain.

![image](https://user-images.githubusercontent.com/6906348/60970493-65952700-a322-11e9-8efe-f02a1d4ec868.png)

It also eases the understanding of some values distributions related with altitude on some datasets
![image](https://user-images.githubusercontent.com/6906348/60970707-d4728000-a322-11e9-8022-c1e9c8ed6da9.png)

The factor of exaggeration could be modified through a prop on the component.
```js
<TerrainExaggerationLayer exaggeration={3}/>
```

