### PR TITLE
Chore/api version upgrade 4.12

### DIFF
--- a/src/components/arcgis-layer-manager/arcgis-layer-manager-component.jsx
+++ b/src/components/arcgis-layer-manager/arcgis-layer-manager-component.jsx
@@ -36,8 +36,13 @@ const ArcgisLayerManager = ({ map, activeLayers }) => {
       layer.visible = !!setActive;
       mapLayer.visible = !!setActive;
     })
-    setOpacity(mapLayer);    
-    mapLayer.visible = !!setActive;
+    setOpacity(mapLayer);
+    // Set group layers as visible to allow sublayers to be visible
+    if (mapLayer.type === "group") {
+      mapLayer.visible = true
+    } else {
+      mapLayer.visible = !!setActive;
+    }
   })
   return null
 }

--- a/src/components/grid-layer/grid-layer-component.jsx
+++ b/src/components/grid-layer/grid-layer-component.jsx
@@ -66,7 +66,8 @@ const GridLayer = ({map, view, setGridCellData, setGridCellGeometry}) => {
             queryHandle && (!queryHandle.isFulfilled()) && queryHandle.cancel();
             queryHandle = gridViewLayer.queryFeatures({
               geometry: extent,
-              spatialRelationship: 'intersects'
+              spatialRelationship: 'intersects',
+              returnGeometry: true
             }).then(function(results) {
               const containedGridCells = results.features.filter(gridCell => scaledDownExtent.contains(gridCell.geometry.extent));
               const hasContainedGridCells = containedGridCells.length > 0;

--- a/src/pages/data-globe/data-globe.js
+++ b/src/pages/data-globe/data-globe.js
@@ -17,11 +17,12 @@ const actions = { ...ownActions, enterLandscapeModeAnalyticsEvent };
 
 const handleMapLoad = (map, view, activeLayers) => {
   const { layers } = map;
+
   // set the outFields for the BIODIVERSITY_FACETS_LAYER
   // to get all the attributes available
   const gridLayer = layers.items.find(l => l.id === BIODIVERSITY_FACETS_LAYER);
   gridLayer.outFields = ["*"];
-  
+
   // This fix has been added as a workaround to a bug introduced on v4.12
   // The bug was causing the where clause of the mosaic rule to not work
   // It will be probably fixed on v4.13
@@ -37,9 +38,9 @@ const handleMapLoad = (map, view, activeLayers) => {
     });
   })
 
-
-
-  //list of active biodiversity layers
+  // Here we are creating the biodiversity layers active in the URL
+  // this is needed to have the layers displayed on the map when sharing the URL
+  // we would be able to get rid of it when this layers are added to the scene via arcgis online
   const biodiversityLayerIDs = activeLayers
     .filter(({ category }) => category === "Biodiversity")
     .map(({ id }) => id);

--- a/src/pages/data-globe/data-globe.js
+++ b/src/pages/data-globe/data-globe.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { loadModules } from '@esri/react-arcgis';
 
 import { BIODIVERSITY_FACETS_LAYER } from 'constants/biodiversity';
+import { HUMAN_PRESSURE_LAYER_ID } from 'constants/human-pressures';
 import { layerManagerToggle, exclusiveLayersToggle, layerManagerVisibility, layerManagerOpacity, layerManagerOrder } from 'utils/layer-manager-utils';
 import Component from './data-globe-component.jsx';
 import mapStateToProps from './data-globe-selectors';
@@ -15,11 +17,27 @@ const actions = { ...ownActions, enterLandscapeModeAnalyticsEvent };
 
 const handleMapLoad = (map, view, activeLayers) => {
   const { layers } = map;
-
-  const gridLayer = layers.items.find(l => l.id === BIODIVERSITY_FACETS_LAYER);
   // set the outFields for the BIODIVERSITY_FACETS_LAYER
   // to get all the attributes available
+  const gridLayer = layers.items.find(l => l.id === BIODIVERSITY_FACETS_LAYER);
   gridLayer.outFields = ["*"];
+  
+  // This fix has been added as a workaround to a bug introduced on v4.12
+  // The bug was causing the where clause of the mosaic rule to not work
+  // It will be probably fixed on v4.13
+  const humanImpactLayer = layers.items.find(l => l.id === HUMAN_PRESSURE_LAYER_ID);
+  loadModules(["esri/config"]).then(([esriConfig]) => {
+    esriConfig.request.interceptors.push({
+      urls: `${humanImpactLayer.url}/exportImage`,
+      before: function (params) {
+        if(params.requestOptions.query.mosaicRule) {
+          params.requestOptions.query.mosaicRule = JSON.stringify(humanImpactLayer.mosaicRule.toJSON());
+        }
+      }
+    });
+  })
+
+
 
   //list of active biodiversity layers
   const biodiversityLayerIDs = activeLayers


### PR DESCRIPTION
This PR upgrades the version of the ArcGIS js API used in the project from 4.11 to 4.12

Some fixes to breaking changes have been made.
- Group layers need to be active in order for their sub layers to display on screen.
- A `returnGeometry`  attribute with value `true` has been added to the `query` object of the `queryFeature` method on the facets layer. That was needed in order to calculate the aggregated grid cell.
- A workaround to a bug related to `imageryLayer`s `mosaic rules` has been added to the `onLoad` function.
