### PR TITLE
Add halo to labels

### DIFF
--- a/src/components/labels-layer/labels-layer-component.jsx
+++ b/src/components/labels-layer/labels-layer-component.jsx
@@ -20,7 +20,8 @@ const labelClassFactory = (LabelClassConstructor, styleGroup) => {
           size: config.fontSize,
           weight: config.fontWeight || "normal"
         },
-        material: { color: config.color }
+        material: { color: config.color },
+        halo: { size: 1 }
       }]
     }
   });


### PR DESCRIPTION
This tiny PR adds a `halo` to labels to improve readability.

![image](https://user-images.githubusercontent.com/6906348/61704922-1d73fc80-ad45-11e9-930f-20a80e2fdc25.png)
