### PR TITLE
Add pledges layer to map iframe globe & fix unclickable entry box

### DIFF
--- a/src/assets/icons/pledge.svg
+++ b/src/assets/icons/pledge.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <filter x="-95%" y="-95%" width="290%" height="290%" filterUnits="objectBoundingBox" id="a">
+      <feGaussianBlur stdDeviation="3" in="SourceGraphic"/>
+    </filter>
+    <filter x="-100%" y="-100%" width="300%" height="300%" filterUnits="objectBoundingBox" id="b">
+      <feGaussianBlur stdDeviation="2" in="SourceGraphic"/>
+    </filter>
+  </defs>
+  <g transform="translate(7 7)" fill="none" fill-rule="evenodd">
+    <circle filter="url(#a)" cx="5" cy="5" r="5" fill="#18BAB4"/>
+    <circle fill="#FFF" filter="url(#b)" cx="5" cy="5" r="3"/>
+  </g>
+</svg>

--- a/src/components/entry-boxes/entry-boxes-component.jsx
+++ b/src/components/entry-boxes/entry-boxes-component.jsx
@@ -25,7 +25,7 @@ const EntryBoxesComponent = ({ isSidebarOpen, openSidebar, setActiveCategory, is
     <div data-cy="entry-boxes" className={styles.uiTopLeft}>
       {interfaceLoaded && categories.length &&
         categories.map(category => (
-          <div className={cx(animationStyles.transform, { [animationStyles.leftHidden]: categoryBoxHidden })} onClick={() => handleCategoryEnter(category)}>
+          <div key={category.name} className={cx(animationStyles.transform, { [animationStyles.leftHidden]: categoryBoxHidden })} onClick={() => handleCategoryEnter(category)}>
             <CategoryBox
               title='mapping'
               isSidebarOpen={isSidebarOpen}

--- a/src/components/legend/legend-selectors.js
+++ b/src/components/legend/legend-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { getActiveLayers, getRasters } from 'pages/data-globe/data-globe-selectors';
 import { LEGEND_FREE_LAYERS } from 'constants/layers-groups';
+import { PLEDGES_LAYER } from 'constants/layers-slugs';
 import { legendConfigs } from 'constants/mol-layers-configs';
 import { legendConfigs as humanPressureLegendConfigs, legendSingleRasterTitles } from 'constants/human-pressures';
 import { legendConfigs as WDPALegendConfigs } from 'constants/protected-areas';
@@ -36,6 +37,7 @@ const getLegendConfigs = createSelector(
     if(legendConfigs[layer.title]) return { ...sharedConfig, ...legendConfigs[layer.title], molLogo: true }
     if(humanPressureLegendConfigs[layer.title]) return { ...sharedConfig, ...humanPressureLegendConfigs[layer.title], title: humanPressuresDynamicTitle }
     if(WDPALegendConfigs[layer.title]) return { ...sharedConfig, ...WDPALegendConfigs[layer.title] }
+    if(layer.title === PLEDGES_LAYER) return { ...sharedConfig, title: 'Signed Pledges' }
     return sharedConfig;
   })
 

--- a/src/components/sidebar/sidebar-component.jsx
+++ b/src/components/sidebar/sidebar-component.jsx
@@ -12,8 +12,8 @@ const Sidebar = ({ map, view, theme, children, activeCategory, handleSidebarTogg
   const isSidebarVisible = isSidebarOpen && !isLandscapeMode && !isFullscreenActive;
 
   return (
-    <div className={cx(uiStyles.uiTopLeft, styles.sidebar, theme.sidebar)}>
-      <div className={cx(styles.wrapper, { [animationStyles.leftHidden]: !isSidebarVisible })}>
+    <div className={cx(uiStyles.uiTopLeft, styles.sidebar, theme.sidebar, { [animationStyles.leftHidden]: !isSidebarVisible })}>
+      <div className={cx(styles.wrapper)}>
         <FixedHeader closeSidebar={handleSidebarToggle} title={activeCategory} view={view}/>
         <div className={styles.content}>
           {React.Children.map(children || null, (child, i) => {

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -3,6 +3,7 @@
 @import 'styles/common-animations.module';
 
 .sidebar {
+  @include animationFunction();
   display: inline-block;
   box-sizing: border-box;
   border-radius: 2px;
@@ -11,7 +12,6 @@
 
 .wrapper {
   @include backdropBlur();
-  @include animationFunction();
   display: flex;
   flex-direction: column;
   position: relative;

--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -23,3 +23,6 @@ export const FEATURED_PLACES_LAYER = 'featured_places';
 
 // Basemap (featured mode)
 export const VIBRANT_BASEMAP_LAYER = 'Vibrant';
+
+// Pledges layer
+export const PLEDGES_LAYER = 'PledgeLocationsURL';

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -1,1 +1,2 @@
 export const BIODIVERSITY_FACETS_SERVICE_URL = "https://utility.arcgis.com/usrsvcs/servers/e6c05ee3ee7b45af9577904bf9238529/rest/services/Biodiversity_Facets_Dissolved/FeatureServer/0";
+export const PLEDGES_LAYER_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer";

--- a/src/layouts/app-layout/app-layout-component.jsx
+++ b/src/layouts/app-layout/app-layout-component.jsx
@@ -2,13 +2,15 @@ import React, { PureComponent } from 'react';
 import Proptypes from 'prop-types';
 import FeaturedGlobe from 'pages/featured-globe';
 import DataGlobe from 'pages/data-globe';
-
+import MapIframe from 'pages/map-iframe';
 
 class App extends PureComponent {
   render() {
     const { route } = this.props;
     const { page } = route;
-    return page === 'featured-globe' ? <FeaturedGlobe /> : <DataGlobe />;
+    const embedded = page === 'map-iframe';
+    const whichGlobe = embedded ? <MapIframe /> : <DataGlobe />
+    return page === 'featured-globe' ? <FeaturedGlobe /> : whichGlobe;
   }
 }
 

--- a/src/pages/map-iframe/map-iframe-component.jsx
+++ b/src/pages/map-iframe/map-iframe-component.jsx
@@ -6,7 +6,7 @@ import LandscapeViewManager from 'components/landscape-view-manager';
 import GridLayer from 'components/grid-layer';
 import Legend from 'components/legend';
 
-const { REACT_APP_DATA_GLOBE_SCENE_ID: SCENE_ID } = process.env;
+const { REACT_APP_STAGING_DATA_GLOBE_SCENE_ID: SCENE_ID } = process.env;
 const DataGlobeComponent = ({
   activeLayers,
   isLandscapeMode,

--- a/src/pages/map-iframe/map-iframe-initial-state.js
+++ b/src/pages/map-iframe/map-iframe-initial-state.js
@@ -1,15 +1,11 @@
 import {
-  BIODIVERSITY_FACETS_LAYER,
   LABELS_LAYER_GROUP,
-  FIREFLY_BASEMAP_LAYER,
-  GRID_LAYER
+  FIREFLY_BASEMAP_LAYER
 } from 'constants/layers-slugs';
 
 export default {
   globe: {
     activeLayers: [
-      { title: BIODIVERSITY_FACETS_LAYER }, // Biodiversity Facets (new grid)
-      { title: GRID_LAYER }, // This is the layer used to paint aggregated grid cells
       { title: LABELS_LAYER_GROUP }, // This is the layer used to paint aggregated grid cells
       { title: FIREFLY_BASEMAP_LAYER } // half-earth firefly
     ],

--- a/src/pages/map-iframe/map-iframe.js
+++ b/src/pages/map-iframe/map-iframe.js
@@ -4,7 +4,8 @@ import postRobot from 'post-robot';
 
 import { loadModules } from '@esri/react-arcgis';
 
-import { BIODIVERSITY_FACETS_LAYER, LAND_HUMAN_PRESSURES_IMAGE_LAYER } from 'constants/layers-slugs';
+import { LAND_HUMAN_PRESSURES_IMAGE_LAYER } from 'constants/layers-slugs';
+import { PLEDGES_LAYER_URL } from 'constants/layers-urls';
 import { 
   layerManagerToggle,
   layerManagerOpacity
@@ -14,21 +15,51 @@ import { createLayer } from 'utils/layer-manager-utils';
 
 import Component from './map-iframe-component.jsx';
 import mapStateToProps from './map-iframe-selectors';
+import pledgeLightIcon from 'icons/pledge.svg'
 
 import ownActions from './map-iframe-actions.js';
 const actions = { ...ownActions };
 
+const pledgeLight = {
+  type: "point-3d", // autocasts as new PointSymbol3D()
+  symbolLayers: [
+    {
+      type: "icon", // autocasts as new IconSymbol3DLayer()
+      resource: {
+        href: pledgeLightIcon // move the pledge icon to contentful?
+      },
+      size: 15
+    }
+  ]
+};
+
 const handleMapLoad = (map, view, activeLayers) => {
   const { layers } = map;
-  const gridLayer = layers.items.find(l => l.id === BIODIVERSITY_FACETS_LAYER);
-  // set the outFields for the BIODIVERSITY_FACETS_LAYER
-  // to get all the attributes available
-  gridLayer.outFields = ["*"];
 
   // This fix has been added as a workaround to a bug introduced on v4.12
   // The bug was causing the where clause of the mosaic rule to not work
   // It will be probably fixed on v4.13
   const humanImpactLayer = layers.items.find(l => l.title === LAND_HUMAN_PRESSURES_IMAGE_LAYER);
+
+  // pledges layer
+  loadModules([
+    'esri/layers/FeatureLayer'
+  ]).then(([
+    FeatureLayer
+  ]) => {
+    const layer = new FeatureLayer({
+      url: PLEDGES_LAYER_URL,
+      renderer: {
+        type: 'simple',
+        symbol: pledgeLight
+      },
+      featureReduction: { type: 'selection' }
+    });
+    
+    layer.visible = false; // not displayed by default
+    map.add(layer);
+  })
+  
   loadModules(["esri/config"]).then(([esriConfig]) => {
     esriConfig.request.interceptors.push({
       urls: `${humanImpactLayer.url}/exportImage`,
@@ -53,19 +84,19 @@ const handleMapLoad = (map, view, activeLayers) => {
 const dataGlobeContainer = props => {
   const attachPostRobotListeners = () => {
     postRobot.on('mapFlyToCoordinates', event => {
-      const { center = [], zoom = 1 } = event.data;
+      const { center = [], zoom = 1 } = event.data; // { center: [4, 5], zoom: 8 }
       if (center.length || zoom) {
         flyToLocation(center, zoom);
         return { done: true };
       }
       return { done: false };
     });
-    postRobot.on('setMapLayers', event => {
+    postRobot.on('setMapLayers', event => { // [ 'Pledges', 'Biodiversity-facets', ... ]
       const { layers = [] } = event.data;
       layers.forEach(layerId => toggleLayer(layerId));
       return { done: true };
     });
-    postRobot.on('setLayersOpacity', event => {
+    postRobot.on('setLayersOpacity', event => { // [ { id: 'Pledges', opacity: 1 }, { id: 'Biodiversity', opacity: 0.6 } ] 
       const { layers = [] } = event.data;
       layers.forEach(layer => setLayerOpacity(layer.id, layer.opacity));
       return { done: true };

--- a/src/styles/ui.module.scss
+++ b/src/styles/ui.module.scss
@@ -26,10 +26,6 @@ $share-button-margin: 12px;
   }
 }
 
-// .sidebar {
-//   @include rtl(float, left, right);
-// }
-
 %spacer {
   height: 1px;
   background-image: linear-gradient(to right, rgba($alto, $spacer-edge-opacity), rgba($white, $spacer-middle-opacity), rgba($alto, $spacer-edge-opacity))


### PR DESCRIPTION
- Fix the first entry box (Biodiversity) being unclickable - the bug appeared as a side effect of css animations PR ;) 
- Fix rendering `map-iframe` the `/map` path - as I discovered it wasn't working since we introduced featured mode
- Add pledges layer to the `map-iframe` globe - add it as a `FeatureLayer` with `featureReduction` of `selection` type enabled. The layer is added on `handleMapLoad`, it's not living on the WebScene. FeatureReduction option allows for the pledges not overlapping each other. FeatureReduction redraws dynamically depending on the zoom level. The spinning effect wasn't added for now.
- To see pledges layer on the globe and test it locally change this line of code in `map-iframe.js`:
```
layer.visible = false; // change to true
```
and go to `/map` endpoint
When that layer will be activated by `postRobot` we're gonna have a legend as well. Not sure if that's desired, we can add the pledges layer to `LEGEND_FREE_LAYERS` array to avoid showing it there.

![image](https://user-images.githubusercontent.com/6136899/65237035-bdde6700-dad1-11e9-88f8-8fe6c4e56d69.png)

I'm also posting here the 3 methods we have for showing the pledges layer for reference. We went for the 2nd option without the spinning effect to avoid lights appearing/disappearing (blinking effect).
There are three ways of showing them:
1. show all the pledges at once. caveat is that there's a LOT in the US so they overlap each other and it looks weird. there's a border issue. the benefit of that is that while spinning the globe, the pledges are not being redrawn on the globe - they're fixed (meaning that they're not appearing/disappearing depending on the view port)
2. feature reduction. we don't allow pledges overlapping each other. depending on the zoom there are as many pledges of the same icon size as long as they don't overlap each other. no border issue. While spinning the globe though, the pledges are redrawn depending on the viewport; feature reduction depends on the viewport. the issue of appearing/disappearing emerges (maybe not the issue? see the videos in the dev channel)
3. clustering. different pledge sizes. sometimes border issue. spinning the globe makes the pledges being redrawn every 3 sec (I had to tweak the library) -  the issue of appearing/disappearing emerges
