### PR TITLE
Fix mosaic rule

### DIFF
--- a/src/pages/data-globe/data-globe.js
+++ b/src/pages/data-globe/data-globe.js
@@ -26,7 +26,7 @@ const handleMapLoad = (map, activeLayers) => {
   // It will be probably fixed on v4.13
   const humanImpactLayer = layers.items.find(l => l.title === LAND_HUMAN_PRESSURES_IMAGE_LAYER);
   loadModules(["esri/config"]).then(([esriConfig]) => {
-    mosaicRuleFix(esriConfig, humanImpactLayer)
+    mosaicRuleFix(esriConfig, humanImpactLayer, 'DATA')
   })
 
   // Update default human impact layer color ramp

--- a/src/pages/featured-globe/featured-globe.js
+++ b/src/pages/featured-globe/featured-globe.js
@@ -46,7 +46,7 @@ const handleMarkerHover = (viewPoint, view) => setAvatarImage(view, viewPoint, F
     // It will be probably fixed on v4.13
     const humanImpactLayer = layers.items.find(l => l.title === LAND_HUMAN_PRESSURES_IMAGE_LAYER);
     loadModules(["esri/config"]).then(([esriConfig]) => {
-      mosaicRuleFix(esriConfig, humanImpactLayer)
+      mosaicRuleFix(esriConfig, humanImpactLayer, 'FEATURED')
     })
 
     // Update default human impact layer color ramp

--- a/src/utils/raster-layers-utils.js
+++ b/src/utils/raster-layers-utils.js
@@ -55,13 +55,14 @@ export const setRasterFuntion = (RasterFunction, Color, colorRamp) => (
   })
 )
 
-export const mosaicRuleFix = (esriConfig, layer) => (
-  esriConfig.request.interceptors.push({
+export const mosaicRuleFix = (esriConfig, layer, globe) => {
+  esriConfig.request.interceptors = [{
+    globe,
     urls: `${layer.url}/exportImage`,
     before: function (params) {
       if(params.requestOptions.query.mosaicRule) {
         params.requestOptions.query.mosaicRule = JSON.stringify(layer.mosaicRule.toJSON());
       }
     }
-  })
-)
+  }]
+}


### PR DESCRIPTION
This PR fixes the human land pressures layer `mosaicRule` bug. The last selected set of land pressures rasters was persisted when changing experience (so if the last pressure selected on the `featured`globe was `urban` when changing to `expert` and selecting `rainfed` only `urban` raster will be displayed).

[PIVOTAL](https://www.pivotaltracker.com/story/show/168134824)