### PR TITLE
Fix infinite loading spinner on activating conservation areas

### DIFF
--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -82,6 +82,7 @@ const ConservationEffortsWidget = (props) => {
     const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
   
     const layerToggled = map.layers.items.reduce((wantedLayer, currentLayer) => {
+      if(wantedLayer) return wantedLayer;
       if(currentLayer.title === option.id) return currentLayer;
       if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
       return wantedLayer;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { loadModules } from '@esri/react-arcgis';
 import conservationEffortsActions from 'redux_modules/conservation-efforts';
-import { handleLayerRendered, getToggledLayer } from 'utils/layer-manager-utils';
-import { addLayerAnalyticsEvent, removeLayerAnalyticsEvent } from 'actions/google-analytics-actions';
+import { toggleWDPALayer } from 'utils/layer-manager-utils';
 import { 
   COMMUNITY_BASED,
   PROTECTED
@@ -11,7 +10,7 @@ import {
 import Component from './conservation-efforts-widget-component';
 import mapStateToProps from './conservation-efforts-widget-selectors';
 
-const actions = { ...conservationEffortsActions, addLayerAnalyticsEvent, removeLayerAnalyticsEvent };
+const actions = { ...conservationEffortsActions };
 
 const findInDOM = (id) => document.getElementById(id);
 
@@ -21,8 +20,6 @@ const ConservationEffortsWidget = (props) => {
     activeLayers,
     view,
     handleGlobeUpdating,
-    addLayerAnalyticsEvent,
-    removeLayerAnalyticsEvent,
     handleLayerToggle,
     alreadyChecked,
     colors,
@@ -79,20 +76,7 @@ const ConservationEffortsWidget = (props) => {
   }, [terrestrialCellData])
 
   const toggleLayer = (layersPassed, option) => {
-    const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
-  
-    const layerToggled = getToggledLayer(map.layers.items, option);
-    
-    if (layerNotRendered) {
-      handleGlobeUpdating(true);
-    }
-  
-    handleLayerToggle(option.id);
-    handleLayerRendered(view, layerToggled, handleGlobeUpdating);
-  
-    const isLayerActive = alreadyChecked[option.value];
-    if (isLayerActive) addLayerAnalyticsEvent({ slug: option.slug })
-    else removeLayerAnalyticsEvent({ slug: option.slug });
+    toggleWDPALayer(activeLayers, option, handleGlobeUpdating, view, map, handleLayerToggle);
   }
 
   return <Component {...props} toggleLayer={toggleLayer} />;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { loadModules } from '@esri/react-arcgis';
 import conservationEffortsActions from 'redux_modules/conservation-efforts';
-import { handleLayerRendered } from 'utils/layer-manager-utils';
+import { handleLayerRendered, getToggledLayer } from 'utils/layer-manager-utils';
 import { addLayerAnalyticsEvent, removeLayerAnalyticsEvent } from 'actions/google-analytics-actions';
 import { 
   COMMUNITY_BASED,
@@ -81,12 +81,7 @@ const ConservationEffortsWidget = (props) => {
   const toggleLayer = (layersPassed, option) => {
     const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
   
-    const layerToggled = map.layers.items.reduce((wantedLayer, currentLayer) => {
-      if(wantedLayer) return wantedLayer;
-      if(currentLayer.title === option.id) return currentLayer;
-      if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
-      return wantedLayer;
-    }, null)
+    const layerToggled = getToggledLayer(map.layers.items, option);
     
     if (layerNotRendered) {
       handleGlobeUpdating(true);

--- a/src/components/protected-areas-layers/protected-areas-layers-component.jsx
+++ b/src/components/protected-areas-layers/protected-areas-layers-component.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import MultipleActiveLayers from 'components/multiple-active-layers';
 
 import { usePaintLayer } from 'hooks/esri';
-import { handleLayerRendered } from 'utils/layer-manager-utils';
+import { handleLayerRendered, getToggledLayer } from 'utils/layer-manager-utils';
 import { WDPALayers, PROTECTED_AREAS_COLOR, COMMUNITY_AREAS_COLOR } from 'constants/protected-areas';
 import { PROTECTED_AREAS_VECTOR_TILE_LAYER, PROTECTED_AREAS_LAYER_GROUP, COMMUNITY_AREAS_LAYER_GROUP, COMMUNITY_AREAS_VECTOR_TILE_LAYER } from 'constants/layers-slugs';
 
@@ -25,12 +25,7 @@ const ProtectedAreasLayers = ({ handleGlobeUpdating, handleLayerToggle, activeLa
   const toggleLayer = (layersPassed, option) => {
     const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
 
-    const layerToggled = layers.items.reduce((wantedLayer, currentLayer) => {
-      if(wantedLayer) return wantedLayer;
-      if(currentLayer.title === option.id) return currentLayer;
-      if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
-      return wantedLayer;
-    }, null)
+    const layerToggled = getToggledLayer(layers.items, option);
     
     if (layerNotRendered) {
       handleGlobeUpdating(true);

--- a/src/components/protected-areas-layers/protected-areas-layers-component.jsx
+++ b/src/components/protected-areas-layers/protected-areas-layers-component.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import MultipleActiveLayers from 'components/multiple-active-layers';
 
 import { usePaintLayer } from 'hooks/esri';
-import { handleLayerRendered, getToggledLayer } from 'utils/layer-manager-utils';
+import { toggleWDPALayer } from 'utils/layer-manager-utils';
 import { WDPALayers, PROTECTED_AREAS_COLOR, COMMUNITY_AREAS_COLOR } from 'constants/protected-areas';
 import { PROTECTED_AREAS_VECTOR_TILE_LAYER, PROTECTED_AREAS_LAYER_GROUP, COMMUNITY_AREAS_LAYER_GROUP, COMMUNITY_AREAS_VECTOR_TILE_LAYER } from 'constants/layers-slugs';
 
@@ -23,20 +23,7 @@ const ProtectedAreasLayers = ({ handleGlobeUpdating, handleLayerToggle, activeLa
   usePaintLayer(CommunityVTLLayer, 'WDPA_poly_Latest/1', COMMUNITY_AREAS_COLOR);
 
   const toggleLayer = (layersPassed, option) => {
-    const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
-
-    const layerToggled = getToggledLayer(layers.items, option);
-    
-    if (layerNotRendered) {
-      handleGlobeUpdating(true);
-    }
-
-    handleLayerToggle(option.id);
-    handleLayerRendered(view, layerToggled, handleGlobeUpdating);
-
-    const isLayerActive = alreadyChecked[option.value];
-    if (isLayerActive) addLayerAnalyticsEvent({ slug: option.slug })
-    else removeLayerAnalyticsEvent({ slug: option.slug });
+    toggleWDPALayer(activeLayers, option, handleGlobeUpdating, view, map, handleLayerToggle);
   }
 
   const alreadyChecked = WDPALayers.reduce((acc, option) => ({ 

--- a/src/components/protected-areas-layers/protected-areas-layers-component.jsx
+++ b/src/components/protected-areas-layers/protected-areas-layers-component.jsx
@@ -26,6 +26,7 @@ const ProtectedAreasLayers = ({ handleGlobeUpdating, handleLayerToggle, activeLa
     const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
 
     const layerToggled = layers.items.reduce((wantedLayer, currentLayer) => {
+      if(wantedLayer) return wantedLayer;
       if(currentLayer.title === option.id) return currentLayer;
       if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
       return wantedLayer;

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -66,3 +66,12 @@ export const handleLayerRendered = (view, layer, handleGlobeUpdating) => {
     })
   })
 }
+
+export const getToggledLayer = (layers, option) => {
+  return layers.reduce((wantedLayer, currentLayer) => {
+    if(wantedLayer) return wantedLayer;
+    if(currentLayer.title === option.id) return currentLayer;
+    if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
+    return wantedLayer;
+  }, null)
+}

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -1,5 +1,7 @@
 import { LEGEND_FREE_LAYERS } from 'constants/layers-groups';
 import { loadModules } from '@esri/react-arcgis';
+import { WDPALayers } from 'constants/protected-areas';
+import { addLayerAnalyticsEvent, removeLayerAnalyticsEvent } from 'actions/google-analytics-actions';
 
 const DEFAULT_OPACITY = 0.6;
 
@@ -74,4 +76,25 @@ export const getToggledLayer = (layers, option) => {
     if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
     return wantedLayer;
   }, null)
+}
+
+export const toggleWDPALayer = (activeLayers, option, handleGlobeUpdating, view, map, handleLayerToggle) => {
+  const layerNotRendered = !activeLayers.some(layer => layer.title === option.id);
+
+  const alreadyChecked = WDPALayers.reduce((acc, option) => ({
+    ...acc, [option.value]: activeLayers.some(layer => layer.title === option.title)
+  }), {});
+  
+  const layerToggled = getToggledLayer(map.layers.items, option);
+  
+  if (layerNotRendered) {
+    handleGlobeUpdating(true);
+  }
+
+  handleLayerToggle(option.id);
+  handleLayerRendered(view, layerToggled, handleGlobeUpdating);
+
+  const isLayerActive = alreadyChecked[option.value];
+  if (isLayerActive) addLayerAnalyticsEvent({ slug: option.slug })
+  else removeLayerAnalyticsEvent({ slug: option.slug });
 }


### PR DESCRIPTION
Sometimes we had an infinite loading spinner issue when activating protected areas layers as there was a bug in `layerToggled` function:
```
const layerToggled = map.layers.items.reduce((wantedLayer, currentLayer) => {
      if(wantedLayer) return wantedLayer; // without that line, even if we found the layer, we were still going through other layers and returned `undefined` instead, it was dependent on the layers order
      if(currentLayer.title === option.id) return currentLayer;
      if(currentLayer.layers) return currentLayer.layers.items.find(layer => layer.title === option.id);
      return wantedLayer;
    }, null)
```