### PR TITLE
Add visibility control on places layer

### DIFF
--- a/src/components/featured-places-layer/featured-places-layer.js
+++ b/src/components/featured-places-layer/featured-places-layer.js
@@ -3,7 +3,7 @@ import { loadModules } from '@esri/react-arcgis';
 
 
 
-const FeaturedMapLayer = ({ map, view, selectedFeaturedMap, featuredPlacesLayer }) => {
+const FeaturedMapLayer = ({ map, view, selectedFeaturedMap, featuredPlacesLayer, isLandscapeMode }) => {
 
   const [featuredPlacesLayerView, setFeaturedPlacesLayerView] = useState(null);
 
@@ -19,13 +19,20 @@ const FeaturedMapLayer = ({ map, view, selectedFeaturedMap, featuredPlacesLayer 
   // display only the places belonging to the selected featured map
   useEffect(() => {
     if (featuredPlacesLayerView) {
+      featuredPlacesLayerView.visible = true;
       loadModules(["esri/views/layers/support/FeatureFilter"]).then(([FeatureFilter]) => {
         featuredPlacesLayerView.filter = new FeatureFilter({
           where: `ftr_slg = '${selectedFeaturedMap}'`
         });
       })
+    } 
+  }, [featuredPlacesLayerView, selectedFeaturedMap, isLandscapeMode])
+
+  useEffect(() => {
+    if (isLandscapeMode) {
+      featuredPlacesLayerView.visible = false;
     }
-  }, [featuredPlacesLayerView, selectedFeaturedMap])
+  }, [isLandscapeMode])
 
   return null;
 }

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -105,6 +105,7 @@ const FeaturedGlobeComponent = ({
           <SelectedFeaturedMapLayer
             selectedFeaturedMap={selectedFeaturedMap}
             featuredPlacesLayer={featuredPlacesLayer}
+            isLandscapeMode={isLandscapeMode}
           />
           <FeaturedPlaceViewManager
             selectedFeaturedPlace={selectedFeaturedPlace}


### PR DESCRIPTION
This PR avoids the display of the featured place Marker when we enter `landscape view`.
[PIVOTAL](https://www.pivotaltracker.com/story/show/168215453)

![Kapture 2019-09-20 at 11 02 22](https://user-images.githubusercontent.com/6906348/65314334-6ce47680-db96-11e9-9c65-f7ac2e429ada.gif)
