### PR TITLE
Add param which when true shows pledges on the map-iframe globe

### DIFF
--- a/src/pages/map-iframe/map-iframe-initial-state.js
+++ b/src/pages/map-iframe/map-iframe-initial-state.js
@@ -7,7 +7,7 @@ export default {
   globe: {
     activeLayers: [
       { title: LABELS_LAYER_GROUP }, // This is the layer used to paint aggregated grid cells
-      { title: FIREFLY_BASEMAP_LAYER } // half-earth firefly
+      { title: FIREFLY_BASEMAP_LAYER }, // half-earth firefly
     ],
     rasters: {},
     zoom: 3,
@@ -19,5 +19,6 @@ export default {
     isFullscreenActive: false, 
     activeCategory: ''
   },
-  listeners: true
+  listeners: true,
+  isPledgesActive: false
 }

--- a/src/pages/map-iframe/map-iframe-selectors.js
+++ b/src/pages/map-iframe/map-iframe-selectors.js
@@ -23,9 +23,12 @@ const getSceneSettings = createSelector(getGlobeSettings, globeSettings => {
   }
 })
 
+const getPledgesActiveQuery = ({ location }) => location.query && (location.query.isPledgesActive || initialState.isPledgesActive);
+
 export const getActiveLayers = createSelector(getGlobeSettings, globeSettings => globeSettings.activeLayers)
 const getLandscapeMode = createSelector(getGlobeSettings, globeSettings => globeSettings.landscapeView)
 const getGlobeUpdating = createSelector(getGlobeSettings, globeSettings => globeSettings.isGlobeUpdating)
+const getPledgesActive = createSelector(getPledgesActiveQuery, pledgesActiveQuery => pledgesActiveQuery)
 
 export default createStructuredSelector({
   sceneLayers: getDataGlobeLayers,
@@ -33,5 +36,6 @@ export default createStructuredSelector({
   isLandscapeMode: getLandscapeMode,
   sceneSettings: getSceneSettings,
   isGlobeUpdating: getGlobeUpdating,
+  isPledgesActive: getPledgesActive,
   listeners: getListenersSetting
 })

--- a/src/pages/map-iframe/map-iframe.js
+++ b/src/pages/map-iframe/map-iframe.js
@@ -4,7 +4,7 @@ import postRobot from 'post-robot';
 
 import { loadModules } from '@esri/react-arcgis';
 
-import { LAND_HUMAN_PRESSURES_IMAGE_LAYER } from 'constants/layers-slugs';
+import { LAND_HUMAN_PRESSURES_IMAGE_LAYER, PLEDGES_LAYER } from 'constants/layers-slugs';
 import { PLEDGES_LAYER_URL } from 'constants/layers-urls';
 import { 
   layerManagerToggle,
@@ -33,7 +33,7 @@ const pledgeLight = {
   ]
 };
 
-const handleMapLoad = (map, view, activeLayers) => {
+const handleMapLoad = (map, view, activeLayers, isPledgesActive) => {
   const { layers } = map;
 
   // This fix has been added as a workaround to a bug introduced on v4.12
@@ -56,7 +56,7 @@ const handleMapLoad = (map, view, activeLayers) => {
       featureReduction: { type: 'selection' }
     });
     
-    layer.visible = false; // not displayed by default
+    layer.visible = activeLayers.find(l => l.title === PLEDGES_LAYER) || isPledgesActive === 'true';
     map.add(layer);
   })
   
@@ -115,7 +115,7 @@ const dataGlobeContainer = props => {
   return <Component
     handleLayerToggle={toggleLayer}
     handleZoomChange={handleZoomChange}
-    onLoad={(map, view) => handleMapLoad(map, view, props.activeLayers)}
+    onLoad={(map, view) => handleMapLoad(map, view, props.activeLayers, props.isPledgesActive)}
     {...props}/>
 }
 


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/story/show/168779418
Show pledges layer on the map-iframe globe if
a) pledges slug is in `activeLayers`
b) `isPledgesActive` param is set to true
The new param has been added to facilitate user-friendly activation of the pledges layer.
Go to `/map?isPledgesActive=true` to test.
On default pledges layer is not visible so on `/map` we don't render pledges layer.