### PR TITLE
Fix card navigation on safari

### DIFF
--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -99,6 +99,7 @@ $card-content-max-height: 220px;
   position: relative;
   flex-grow: 1;
   width: 100%;
+  height: 350px;
   max-width: $card-max-width;
   background-color: white;
   padding: 60px 40px 0px;


### PR DESCRIPTION
`height: 100%` doesn't work on chrome as it hides the bar above the card, so you can't go back:
![image](https://user-images.githubusercontent.com/6136899/65973795-d2244b80-e463-11e9-81e0-37e0eef49bf3.png)

Please check if that fixes the issue on `Safari` as browserstack doesn't render the globe :/ 
