### PR TITLE
Improvements

### DIFF
--- a/src/components/entry-boxes/entry-boxes-styles.module.scss
+++ b/src/components/entry-boxes/entry-boxes-styles.module.scss
@@ -19,7 +19,7 @@
 
   // entry box border-radius
   & > *:first-child > div:first-child {
-    border-radius: 16px 16px 0 0;
+    border-radius: $border-radius-mobile;
   }
 
   @media #{$tablet-portrait} {

--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -44,7 +44,7 @@ $card-content-max-height: 220px;
   pointer-events: all;
   background-color: $white;
   padding: 22px $mobile-sidebar-side-paddings 10px $mobile-sidebar-side-paddings;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
 
   @media #{$tablet-portrait} {
     padding: 0;

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -9,11 +9,12 @@ $icon-size: 25px;
   padding-left: $mobile-sidebar-side-paddings;
   display: flex;
   flex-direction: column;
-  height: $sidebar-header-height;
+  height: $sidebar-header-height-mobile;
   position: relative;
 
   @media #{$tablet-portrait} {
     padding-left: $sidebar-paddings;
+    height: $sidebar-header-height;
   }
 }
 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
@@ -28,30 +28,36 @@ const ConservationEffortsWidget = ({
 }) => {
   return (
     <>
-      {rawData && (
-        <div className={styles.container}>
-          <div className={styles.fixBlur} />
-          <div className={styles.padding}>
-            <h3 className={styles.title}>Conservation Efforts</h3>
-            {rawData && <ConservationEffortsDescription allProp={allProp} rawData={rawData} />}
-            <PieChart
-              data={rawData}
-              activeSlices={activeSlices}
-              colors={colors}
-              alreadyChecked={alreadyChecked}
-            />
-          </div>
-          <CheckboxGroup 
-            handleClick={toggleLayer}
-            checkedOptions={alreadyChecked}
-            options={protectedLayers}
-            theme={styles}
-          />
-          <p className={styles.notUnderConservationLabel}>
-            Not under conservation {dataFormatted.notUnderConservation}%
-          </p>
+      <div className={styles.container}>
+        <div className={styles.fixBlur} />
+        <div className={styles.padding}>
+          <h3 className={styles.title}>Conservation Efforts</h3>
+          {rawData && (
+            <>
+              <ConservationEffortsDescription allProp={allProp} rawData={rawData} />
+              <PieChart
+                data={rawData}
+                activeSlices={activeSlices}
+                colors={colors}
+                alreadyChecked={alreadyChecked}
+              />
+            </>
+          )}
         </div>
-      )}
+        {rawData && (
+          <>
+            <CheckboxGroup 
+              handleClick={toggleLayer}
+              checkedOptions={alreadyChecked}
+              options={protectedLayers}
+              theme={styles}
+            />
+            <p className={styles.notUnderConservationLabel}>
+              Not under conservation {dataFormatted.notUnderConservation}%
+            </p>
+          </>
+        )}
+      </div>
     </>
   )
 }

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
@@ -6,9 +6,10 @@ $margin: 8px;
 
 .container {
   @include backdropBlur();
-  border-radius: 2px;
+  border-radius: $border-radius-desktop;
   padding-bottom: 34px;
   margin-top: $widgetsTopMargin;
+  height: 430px;
 }
 
 .padding {

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-component.jsx
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-component.jsx
@@ -31,10 +31,10 @@ const PressureStatementComponent = ({ totalPressure, biggestPressureName }) => (
 const HumanPressureWidgetComponent = ({ handleOnClick, options, checkedRasters, selectedPressures, totalPressure, biggestPressureName, pressureFree }) => {
   return (
     <div className={styles.container}>
+      <h3 className={styles.title}>Land human pressures in this area</h3>
       <DummyBlurWorkaround />
       {options && 
         <>
-          <h3 className={styles.title}>Land human pressures in this area</h3>
           <PressureStatementComponent totalPressure={totalPressure} biggestPressureName={biggestPressureName} />
           <BarComponent selectedPressures={selectedPressures} totalPressure={totalPressure}/>
           <CheckboxGroup

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-widget-styles.module.scss
@@ -4,8 +4,9 @@
 
 .container {
   @include backdropBlur();
-  border-radius: 2px;
+  border-radius: $border-radius-desktop;
   margin-top: $widgetsTopMargin;
+  height: 400px;
 }
 
 .title {

--- a/src/components/landscape-sidebar/landscape-sidebar-styles.module.scss
+++ b/src/components/landscape-sidebar/landscape-sidebar-styles.module.scss
@@ -8,7 +8,7 @@ $margin: 20px;
   @extend %verticalScrollBar;
   display: inline-block;
   box-sizing: border-box;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
   height: 450px;
   position: absolute;
   bottom: 15px;

--- a/src/components/landscape-sidebar/mol-uploader/mol-uploader-styles.module.scss
+++ b/src/components/landscape-sidebar/mol-uploader/mol-uploader-styles.module.scss
@@ -4,6 +4,7 @@
   background-color: #031D2E;
   padding: $mobile-sidebar-side-paddings;
   margin-bottom: 50px;
+  border-radius: $border-radius-desktop;
 
   @media #{$tablet-portrait} {
     margin-top: $widgetsTopMargin;
@@ -13,9 +14,12 @@
 
 .buttonContainer {
   display: flex;
-  justify-content: center;
   margin-bottom: 12px;
   cursor: pointer;
+
+  @media #{$tablet-portrait} {
+    justify-content: center;
+  }
 }
 
 .uploadButton {

--- a/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
+++ b/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
@@ -80,41 +80,41 @@ const SpeciesCarrousel = ({ selectedSpecies, handleSelectPrevSpecies, handleSele
 const SpeciesWidgetComponent = ({ data, selectedSpecies, handleSelectSpecies, handleSelectNextSpecies, handleSelectPrevSpecies }) => {
 
   return (
-    <>
-      {data && selectedSpecies &&
-        <div className={styles.container}>
-          <h3 className={styles.title}>SPECIES TO WATCH HERE</h3>
-          <p className={styles.text}>The radar plot below shows the proportion of species range protected from the available taxonomic groups.</p>
-          <div className={styles.chart}>
-            <div className={styles.chartSlice}></div>
-            <div className={styles.chartSlice}>
-              {data.map((species, index) => (
-                <SpeciesChartDot
-                  key={`dot-${index}`}
-                  species={species}
-                  selectedSpecies={selectedSpecies}
-                  handleSelectSpecies={handleSelectSpecies}
-                />
-              ))}
+      <div className={styles.container}>
+        <h3 className={styles.title}>SPECIES TO WATCH HERE</h3>
+        {data && selectedSpecies && (
+          <>
+            <p className={styles.text}>The radar plot below shows the proportion of species range protected from the available taxonomic groups.</p>
+            <div className={styles.chart}>
+              <div className={styles.chartSlice}></div>
+              <div className={styles.chartSlice}>
+                {data.map((species, index) => (
+                  <SpeciesChartDot
+                    key={`dot-${index}`}
+                    species={species}
+                    selectedSpecies={selectedSpecies}
+                    handleSelectSpecies={handleSelectSpecies}
+                  />
+                ))}
+              </div>
+              <div className={styles.chartSlice}></div>
+              <div className={styles.chartSlice}></div>
             </div>
-            <div className={styles.chartSlice}></div>
-            <div className={styles.chartSlice}></div>
-          </div>
-          <SpeciesCarrousel
-            selectedSpecies={selectedSpecies}
-            handleSelectPrevSpecies={handleSelectPrevSpecies}
-            handleSelectNextSpecies={handleSelectNextSpecies}
-          />
-          <a
-            href='https://mol.org/'
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.molLogo}
-          >
-          </a>
-        </div>
-      }
-    </>
+            <SpeciesCarrousel
+              selectedSpecies={selectedSpecies}
+              handleSelectPrevSpecies={handleSelectPrevSpecies}
+              handleSelectNextSpecies={handleSelectNextSpecies}
+            />
+            <a
+              href='https://mol.org/'
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.molLogo}
+            >
+            </a>
+          </>
+        )}
+    </div>
   );
 }
 

--- a/src/components/landscape-sidebar/species-widget/species-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/species-widget/species-widget-styles.module.scss
@@ -7,9 +7,11 @@
   padding: $mobile-sidebar-side-paddings;
   width: 100%;
   margin-top: $widgetsTopMargin;
+  height: 700px;
 
   @media #{$tablet-portrait} {
     padding: $sidebar-paddings;
+    border-radius: $border-radius-desktop;
   }
 }
 

--- a/src/components/legend/legend-styles.module.scss
+++ b/src/components/legend/legend-styles.module.scss
@@ -59,7 +59,7 @@ $map-attribution-height: 30px;
     border-radius: 0;
 
     &:first-child {
-      border-radius: 16px 16px 0 0;
+      border-radius: $border-radius-mobile;
     }
 
     @media #{$tablet-portrait} {

--- a/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
+++ b/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
@@ -6,7 +6,7 @@
   @include backdropBlur();
   @include bottom();
   padding: 30px 20px;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
   display: none;
 }
 

--- a/src/components/scene/scene-component.jsx
+++ b/src/components/scene/scene-component.jsx
@@ -54,18 +54,20 @@ const SceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMap
 
   if (loadState === 'loading') {
     return (
-    <>
+    <div style={{ height: '100%', position: 'relative', width: '100%' }}>
       <div id={`scene-container-${sceneId}`} className={styles.sceneContainer} style={{width:'0%', height:'0%'}} />
-      <Spinner spinnerWithOverlay floating display={spinner}/>
-    </>
+      <Spinner spinnerWithOverlay initialLoading display={spinner}/>
+    </div>
     )
   } else if (loadState === 'loaded') {
     return (
-      <div id={`scene-container-${sceneId}`} className={styles.sceneContainer} style={{width:'100%', height:'100%', backgroundColor: '#0A212E', ...style}}>
-        {React.Children.map(children || null, (child, i) => {
-          return child && <child.type key={i} map={map} view={view} {...child.props}/>;
-        })}
-    </div>
+      <div style={{ height: '100%', position: 'relative', width: '100%' }}>
+        <div id={`scene-container-${sceneId}`} className={styles.sceneContainer} style={{width:'100%', height:'100%', backgroundColor: '#0A212E', ...style}}>
+          {React.Children.map(children || null, (child, i) => {
+            return child && <child.type key={i} map={map} view={view} {...child.props}/>;
+          })}
+        </div>
+      </div>
     )
   }
 

--- a/src/components/sidebar/sidebar-styles.module.scss
+++ b/src/components/sidebar/sidebar-styles.module.scss
@@ -5,7 +5,7 @@
 .sidebar {
   display: inline-block;
   box-sizing: border-box;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
   left: 0;
   top: auto;
   overflow: hidden;
@@ -29,7 +29,7 @@
   width: 100%;
   height: 345px;
   overflow-y: scroll;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
 
   @media #{$tablet-portrait} {
     overflow-y: unset;

--- a/src/components/spinner/spinner-component.jsx
+++ b/src/components/spinner/spinner-component.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 import cx from 'classnames';
 import styles from './spinner-styles.module';
 
-const Spinner = ({ floating = false, spinnerWithOverlay = false, display = true }) => {
+const Spinner = ({ floating = false, spinnerWithOverlay = false, initialLoading = false, display = true }) => {
   return display ? (
     <>
       {spinnerWithOverlay ? (
         <div className={styles.spinnerWithOverlay}>
-          <div className={cx(styles.spinner, {[styles.spinnerAbsolute]: floating})} />
+          <div className={cx(styles.spinner, {[styles.spinnerAbsolute]: floating, [styles.initialLoading]: initialLoading })} />
         </div>
       ) : (
-        <div className={cx(styles.spinner, {[styles.spinnerAbsolute]: floating})} />
+        <div className={cx(styles.spinner, {[styles.spinnerAbsolute]: floating, [styles.initialLoading]: initialLoading })} />
       )}
     </>
   ) : <div></div>;

--- a/src/components/spinner/spinner-styles.module.scss
+++ b/src/components/spinner/spinner-styles.module.scss
@@ -51,7 +51,12 @@ $size: 100px;
 .spinnerAbsolute {
   position: absolute;
   top: 42%;
-  left: 47%;
+  left: 42%;
+
+  @media #{$tablet-portrait} {
+    top: 42%;
+    left: 47%;
+  }
 }
 
 .spinnerWithOverlay {

--- a/src/components/spinner/spinner-styles.module.scss
+++ b/src/components/spinner/spinner-styles.module.scss
@@ -66,3 +66,11 @@ $size: 100px;
   display: flex;
   align-items: center;
 }
+
+.initialLoading {
+  left: 50%;
+  margin-right: -50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%) perspective(200px) rotateX(66deg);;
+}

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -10,13 +10,14 @@ import { isMobile } from 'constants/responsive';
 
 const WidgetsComponent = ({ map, view, isFullscreenActive, isNotMapsList = true, hidden = false}) => {
   const isOnMobile = isMobile();
-  return !isOnMobile && (
+  const hiddenWidget = hidden || isOnMobile;
+  return (
     <>
-      <ToggleUiWidget map={map} view={view} isFullscreenActive={isFullscreenActive} hidden={hidden}/>
-      <ZoomWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hidden} />
-      <MinimapWidget map={map} view={view} hidden={hidden} />
-      <SearchWidget map={map} view={view} hidden={hidden} />
-      <LocationWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hidden} />
+      <ToggleUiWidget map={map} view={view} isFullscreenActive={isFullscreenActive} hidden={hiddenWidget}/>
+      <ZoomWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
+      <MinimapWidget map={map} view={view} hidden={hiddenWidget} />
+      <SearchWidget map={map} view={view} hidden={hiddenWidget} />
+      <LocationWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
     </>
   )
 }

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -16,7 +16,7 @@ const WidgetsComponent = ({ map, view, isFullscreenActive, isNotMapsList = true,
       <ToggleUiWidget map={map} view={view} isFullscreenActive={isFullscreenActive} hidden={hiddenWidget}/>
       <ZoomWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
       <MinimapWidget map={map} view={view} hidden={hiddenWidget} />
-      <SearchWidget map={map} view={view} hidden={hiddenWidget} />
+      {!isOnMobile && <SearchWidget map={map} view={view} hidden={hiddenWidget} />}
       <LocationWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
     </>
   )

--- a/src/pages/data-globe/data-globe-initial-state.js
+++ b/src/pages/data-globe/data-globe-initial-state.js
@@ -19,6 +19,9 @@ export default {
     ],
     zoom: 1,
     center: [16.9515536, 0.116959],
+    padding: {
+      bottom: 60
+    },
     isGlobeUpdating: false,
     environment: {
       atmosphereEnabled: false,

--- a/src/pages/featured-globe/featured-globe-initial-state.js
+++ b/src/pages/featured-globe/featured-globe-initial-state.js
@@ -19,6 +19,9 @@ export default {
     ],
     zoom: 1,
     center: [16.9515536, 0.116959],
+    padding: {
+      bottom: 60
+    },
     isGlobeUpdating: false,
     environment: {
       atmosphereEnabled: false,

--- a/src/pages/featured-globe/featured-globe.js
+++ b/src/pages/featured-globe/featured-globe.js
@@ -13,6 +13,7 @@ import {
 import { 
   FEATURED_GLOBE_LANDSCAPE_ONLY_LAYERS
 } from 'constants/layers-groups';
+import { isMobile } from 'constants/responsive';
 
 import Component from './featured-globe-component.jsx';
 
@@ -24,6 +25,7 @@ const actions = { ...featuredMapsActions, ...urlActions}
 
 const feturedGlobeContainer = props => {
   const [handle, setHandle] = useState(null);
+  const isOnMobile = isMobile();
   const { changeUI, changeGlobe, featuredMapPlaces, selectedFeaturedMap, isFeaturedPlaceCard, isFullscreenActive } = props;
 
   const handleMarkerClick = (viewPoint, view) => {
@@ -33,8 +35,10 @@ const feturedGlobeContainer = props => {
     }
   }
   const handleMarkerHover = (viewPoint, view) => {
-    setCursor(viewPoint, FEATURED_PLACES_LAYER);
-    if (!isFeaturedPlaceCard) setAvatarImage(view, viewPoint, FEATURED_PLACES_LAYER, selectedFeaturedMap, featuredMapPlaces);
+    if (!isOnMobile) {
+      setCursor(viewPoint, FEATURED_PLACES_LAYER);
+      if (!isFeaturedPlaceCard) setAvatarImage(view, viewPoint, FEATURED_PLACES_LAYER, selectedFeaturedMap, featuredMapPlaces);
+    }
   };
 
   useEffect(() => {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -61,3 +61,7 @@ button {
 button:focus {
   outline: 0;
 }
+
+:focus {
+  outline: 0;
+}

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -25,8 +25,8 @@ $site-gutter: 20px;
 
 html {
   box-sizing: border-box;
-  font-size: 62.5%;
-  overflow-y: hidden;
+  font-size: 100%; // 1rem = 16px
+  overflow: hidden; // overflow-y does not work on Safari
 }
 
 *,

--- a/src/styles/override/esri-search-widget.scss
+++ b/src/styles/override/esri-search-widget.scss
@@ -7,7 +7,7 @@
   height: 345px;
   bottom: 55px;
   top: auto;
-  border-radius: 16px 16px 0 0;
+  border-radius: $border-radius-mobile;
   position: fixed;
   left: 0;
   padding: 30px 20px;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -87,6 +87,8 @@ $sidebar-top-margin: 60px;
 $sidebar-header-height: 100px;
 $sidebar-width: 280px;  // use this for entry boxes and sidebar width
 $widgetsTopMargin: 8px;
+$border-radius-desktop: 2px;
+$border-radius-mobile: 16px 16px 0 0;
 // featured cards
 $card-max-width: 820px;
 

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -85,6 +85,7 @@ $line-height: 14px;
 // Sidebar
 $sidebar-top-margin: 60px;
 $sidebar-header-height: 100px;
+$sidebar-header-height-mobile: 150px;
 $sidebar-width: 280px;  // use this for entry boxes and sidebar width
 $widgetsTopMargin: 8px;
 $border-radius-desktop: 2px;


### PR DESCRIPTION
This PR introduces a couple of fixes and improvements:
* Don't show marker avatars on hover on mobile
* Hide location widget on mobile
* Fix spinner position on mobile
* Remove focus outline (odd flash when clicking on the elements on mobile)
* Add bottom padding to the globe to move it higher
* Change global rem unit to 16px - font-size: 100% on html element
    - We had 62.5% for easier calculations - resulting in rem being 10px
    - That was causing scaling issues (i.e. Safari mobiles were treated as desktop)
    - relevant [article](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/)
* Render landscape components with fixed heights and titles before data is loaded
* Fix sidebar header height on mobile