### PR TITLE
Fix/add loading loaded flags to sidebar components

### DIFF
--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PieChart from 'components/pie-chart';
 import CheckboxGroup from 'components/checkbox-group';
+import DummyBlurWorkaround from 'components/dummy-blur-workaround';
+
 import { 
   COMMUNITY_BASED,
   PROTECTED
@@ -31,7 +33,7 @@ const ConservationEffortsWidget = ({
   return (
     <>
       <div className={styles.container} style={{ minHeight: noData ? 'auto' : '430px' }}>
-        <div className={styles.fixBlur} />
+        <DummyBlurWorkaround />
         <div className={styles.padding}>
           <h3 className={styles.title}>Conservation Efforts</h3>
           {noData &&  <p className={styles.description}>No conservation efforts data for this area.</p>}

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
@@ -27,12 +27,14 @@ const ConservationEffortsWidget = ({
   toggleLayer,
   loading
 }) => {
+  const noData = !loading && !rawData;
   return (
     <>
-      <div className={styles.container}>
+      <div className={styles.container} style={{ minHeight: noData ? 'auto' : '430px' }}>
         <div className={styles.fixBlur} />
         <div className={styles.padding}>
           <h3 className={styles.title}>Conservation Efforts</h3>
+          {noData &&  <p className={styles.description}>No conservation efforts data for this area.</p>}
           {!loading && rawData && (
             <>
               <ConservationEffortsDescription allProp={allProp} rawData={rawData} />

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
@@ -24,7 +24,8 @@ const ConservationEffortsWidget = ({
   alreadyChecked,
   protectedLayers,
   activeSlices,
-  toggleLayer
+  toggleLayer,
+  loading
 }) => {
   return (
     <>
@@ -32,7 +33,7 @@ const ConservationEffortsWidget = ({
         <div className={styles.fixBlur} />
         <div className={styles.padding}>
           <h3 className={styles.title}>Conservation Efforts</h3>
-          {rawData && (
+          {!loading && rawData && (
             <>
               <ConservationEffortsDescription allProp={allProp} rawData={rawData} />
               <PieChart
@@ -44,7 +45,7 @@ const ConservationEffortsWidget = ({
             </>
           )}
         </div>
-        {rawData && (
+        {!loading && rawData && (
           <>
             <CheckboxGroup 
               handleClick={toggleLayer}

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -14,13 +14,15 @@ const COLORS = () => ({
 })
 
 const conservationEffortsData = ({ conservationEffortsData }) => conservationEffortsData && conservationEffortsData.data;
+const conservationEffortsLoading = ({ conservationEffortsData }) => conservationEffortsData && conservationEffortsData.loading;
 
 const getActiveLayersFromProps = (state, props) => props.activeLayers;
 
 const getConservationEfforts = createSelector(
   [conservationEffortsData],
   cellData => {
-    if (!cellData) return null;
+    if (!cellData || !cellData.length) return null;
+    console.log('cellData: ',cellData)
     const conservationEfforts = cellData.reduce((acc, current) => {
       return {
         ...acc,
@@ -48,7 +50,6 @@ const getConservationAreasLogic = createSelector(
   [getConservationEfforts],
   (conservationEfforts) => {
     if (!conservationEfforts) return null;
-
     const areas = {};
     const { WDPA_prop, RAISG_prop, all_prop } = conservationEfforts;
     areas[NOT_UNDER_CONSERVATION] = (1 - (WDPA_prop +RAISG_prop)) * 100; // set NOT_UNDER_CONSERVATION first to render the slice below all others
@@ -134,5 +135,6 @@ export default createStructuredSelector({
   allProp: getAllPropsForDynamicSentence,
   alreadyChecked: getAlreadyChecked,
   protectedLayers: getProtectedLayers,
-  activeSlices: getActiveSlices
+  activeSlices: getActiveSlices,
+  loading: conservationEffortsLoading
 });

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -22,7 +22,6 @@ const getConservationEfforts = createSelector(
   [conservationEffortsData],
   cellData => {
     if (!cellData || !cellData.length) return null;
-    console.log('cellData: ',cellData)
     const conservationEfforts = cellData.reduce((acc, current) => {
       return {
         ...acc,

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
@@ -30,10 +30,6 @@ $margin: 8px;
   color: white;
 }
 
-.fixBlur {
-  position: fixed;
-}
-
 .overrideCheckbox-protected-areas {
   input[type="checkbox"]:checked + label::before {
     background: $persimmon;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
@@ -9,7 +9,10 @@ $margin: 8px;
   border-radius: $border-radius-desktop;
   padding-bottom: 34px;
   margin-top: $widgetsTopMargin;
-  height: 430px;
+
+  @media #{$tablet-portrait} {
+    min-height: 430px;
+  }
 }
 
 .padding {

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-styles.module.scss
@@ -12,6 +12,7 @@ $margin: 8px;
 
   @media #{$tablet-portrait} {
     min-height: 430px;
+    padding-bottom: 0;
   }
 }
 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -76,7 +76,7 @@ const ConservationEffortsWidget = (props) => {
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
         setConservationEfforts({ data: features.map(c => c.attributes), loading: false });
-      });
+      }).catch(() => setConservationEfforts({ data: null, loading: false }));
     }
   }, [terrestrialCellData])
 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -71,10 +71,11 @@ const ConservationEffortsWidget = (props) => {
 
   useEffect(() => {
     if (terrestrialCellData && queryParams) {
+      setConservationEfforts({ data: null, loading: true });
       queryParams.where = `CELL_ID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
-        setConservationEfforts(features.map(c => c.attributes));
+        setConservationEfforts({ data: features.map(c => c.attributes), loading: false });
       });
     }
   }, [terrestrialCellData])

--- a/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
+++ b/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
@@ -77,12 +77,12 @@ const SpeciesCarrousel = ({ selectedSpecies, handleSelectPrevSpecies, handleSele
   )
 };
 
-const SpeciesWidgetComponent = ({ data, selectedSpecies, handleSelectSpecies, handleSelectNextSpecies, handleSelectPrevSpecies }) => {
-
+const SpeciesWidgetComponent = ({ data, selectedSpecies, handleSelectSpecies, handleSelectNextSpecies, handleSelectPrevSpecies, loading }) => {
   return (
       <div className={styles.container}>
         <h3 className={styles.title}>SPECIES TO WATCH HERE</h3>
-        {data && selectedSpecies && (
+        {!data && !loading && <p className={styles.text}>No species data for this area.</p>}
+        {data && selectedSpecies && !loading && (
           <>
             <p className={styles.text}>The radar plot below shows the proportion of species range protected from the available taxonomic groups.</p>
             <div className={styles.chart}>

--- a/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
+++ b/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
@@ -3,13 +3,15 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import { ReactComponent as ArrowIcon } from 'icons/arrow_right.svg';
 import speciesPlaceholder from 'images/speciesPlaceholder.svg';
+import DummyBlurWorkaround from 'components/dummy-blur-workaround';
+
 import cx from 'classnames';
 
 import styles from './species-widget-styles.module.scss';
 
 const SpeciesChartDot = ({ species, selectedSpecies, handleSelectSpecies }) => {
   const isSelected = species.name === selectedSpecies.name;
-  const { name, scientificName, pointCoordinates, color } = species;
+  const { name, pointCoordinates, color } = species;
   return (
     <>
       <div 
@@ -81,6 +83,7 @@ const SpeciesWidgetComponent = ({ data, selectedSpecies, handleSelectSpecies, ha
   const noData = !data && !loading;
   return (
       <div className={styles.container} style={{ minHeight: noData ? 'auto' : '700px' }}>
+        <DummyBlurWorkaround />
         <h3 className={styles.title}>SPECIES TO WATCH HERE</h3>
         {noData && <p className={styles.text}>No species data for this area.</p>}
         {data && selectedSpecies && !loading && (

--- a/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
+++ b/src/components/landscape-sidebar/species-widget/species-widget-component.jsx
@@ -78,10 +78,11 @@ const SpeciesCarrousel = ({ selectedSpecies, handleSelectPrevSpecies, handleSele
 };
 
 const SpeciesWidgetComponent = ({ data, selectedSpecies, handleSelectSpecies, handleSelectNextSpecies, handleSelectPrevSpecies, loading }) => {
+  const noData = !data && !loading;
   return (
-      <div className={styles.container}>
+      <div className={styles.container} style={{ minHeight: noData ? 'auto' : '700px' }}>
         <h3 className={styles.title}>SPECIES TO WATCH HERE</h3>
-        {!data && !loading && <p className={styles.text}>No species data for this area.</p>}
+        {noData && <p className={styles.text}>No species data for this area.</p>}
         {data && selectedSpecies && !loading && (
           <>
             <p className={styles.text}>The radar plot below shows the proportion of species range protected from the available taxonomic groups.</p>

--- a/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
@@ -32,6 +32,7 @@ const getDotColor = (value) => {
 }
 
 const getSpeciesData = ({ speciesData }) => (speciesData && speciesData.data) || null;
+const getSpeciesDataLoading = ({ speciesData }) => speciesData && speciesData.loading;
 
 const getSelectedSpeciesName = (state, props) =>
   props.selectedSpecies
@@ -82,8 +83,8 @@ const getData = createSelector(getUniqeSpeciesData, speciesData => {
   const reptilesData = getChartData(speciesData, 'reptiles', 90);
   const mammalsData = getChartData(speciesData, 'mammals', 180)
   const amphibiansData = getChartData(speciesData, 'amphibians', 270);
-
-  return [...birdsData, ...reptilesData, ...mammalsData, ...amphibiansData];
+  const speciesChartData = [...birdsData, ...reptilesData, ...mammalsData, ...amphibiansData];
+  return speciesChartData.length ? speciesChartData : null;
 });
 
 const getSelectedSpeciesData = createSelector([getData, getSelectedSpeciesName],
@@ -97,5 +98,6 @@ const getSelectedSpeciesData = createSelector([getData, getSelectedSpeciesName],
 export default createStructuredSelector({
   data: getData,
   terrestrialCellData: getTerrestrialCellData,
-  selectedSpeciesData: getSelectedSpeciesData
+  selectedSpeciesData: getSelectedSpeciesData,
+  loading: getSpeciesDataLoading
 }); 

--- a/src/components/landscape-sidebar/species-widget/species-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/species-widget/species-widget-styles.module.scss
@@ -7,11 +7,11 @@
   padding: $mobile-sidebar-side-paddings;
   width: 100%;
   margin-top: $widgetsTopMargin;
-  height: 700px;
 
   @media #{$tablet-portrait} {
     padding: $sidebar-paddings;
     border-radius: $border-radius-desktop;
+    min-height: 700px;
   }
 }
 

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -74,7 +74,7 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
       if(terrestrialCellData.length) {
         querySpeciesData();
       } else {
-        setSpeciesData([])
+        setSpeciesData({ data: null })
       }
     }
   }, [speciesLayer, terrestrialCellData])

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -9,7 +9,7 @@ import * as urlActions from 'actions/url-actions';
 
 const actions = { ...setSpeciesActions, ...urlActions };
 
-const SpeciesWidget = ({ setSpecies, terrestrialCellData, data, changeGlobe, selectedSpeciesData }) => {
+const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
   const [speciesLayer, setLayer] = useState(null);
   const [selectedIndex, setSelectedIndex] = useState(0)
 
@@ -45,12 +45,13 @@ const SpeciesWidget = ({ setSpecies, terrestrialCellData, data, changeGlobe, sel
   }
 
   const querySpeciesData = () => {
+    setSpeciesData({ data: null, loading: true });
     const query = speciesLayer.createQuery();
     query.where = `HBWID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
     query.outFields = [ "HBWID", "scntfcn", "taxa", "RANGE_A", "PROP_RA", "url_sp", "cmmn_nm", "iucn_ct"];
     speciesLayer.queryFeatures(query).then(function(results){
       const { features } = results;
-      setSpecies(features.map(c => c.attributes));
+      setSpeciesData({ data: features.map(c => c.attributes), loading: false });
     });
   };
 
@@ -73,7 +74,7 @@ const SpeciesWidget = ({ setSpecies, terrestrialCellData, data, changeGlobe, sel
       if(terrestrialCellData.length) {
         querySpeciesData();
       } else {
-        setSpecies([])
+        setSpeciesData([])
       }
     }
   }, [speciesLayer, terrestrialCellData])
@@ -92,6 +93,7 @@ const SpeciesWidget = ({ setSpecies, terrestrialCellData, data, changeGlobe, sel
       handleSelectSpecies={handleSelectSpecies}
       handleSelectNextSpecies={handleSelectNextSpecies}
       handleSelectPrevSpecies={handleSelectPrevSpecies}
+      loading={loading}
     />
   );
 }

--- a/src/redux-modules/conservation-efforts/conservation-efforts-reducers.js
+++ b/src/redux-modules/conservation-efforts/conservation-efforts-reducers.js
@@ -1,10 +1,13 @@
 import * as actions from './conservation-efforts-actions';
 import { isEqual } from 'lodash';
 
-export const initialState = { data: null };
+export const initialState = {
+  data: null,
+  loading: false
+};
 
 function setConservationEfforts(state, { payload }) {
-  return isEqual(state.data, payload) ? state : { ...state, data: payload };
+  return isEqual(state.data, payload) ? state : { ...state, ...payload };
 }
 
 export default {

--- a/src/redux-modules/species/species-actions.js
+++ b/src/redux-modules/species/species-actions.js
@@ -1,5 +1,3 @@
 import { createAction } from 'redux-tools';
 
-export const setSpecies = createAction(
-  'SET_SPECIES_DATA'
-); 
+export const setSpeciesData = createAction('SET_SPECIES_DATA');

--- a/src/redux-modules/species/species-reducers.js
+++ b/src/redux-modules/species/species-reducers.js
@@ -1,12 +1,15 @@
 import * as actions from './species-actions';
 import { isEqual } from 'lodash';
 
-export const initialState = { data: null };
+export const initialState = {
+  data: null,
+  loading: false
+};
 
-function setSpecies(state, { payload }) {
-  return isEqual(state.data, payload) ? state : { ...state, data: payload };
+function setSpeciesData(state, { payload }) {
+  return isEqual(state.data, payload) ? state : { ...state, ...payload };
 }
 
 export default {
-  [actions.setSpecies]: setSpecies
+  [actions.setSpeciesData]: setSpeciesData,
 };


### PR DESCRIPTION
This PR clears content inside Species widget and Conservation Efforts widget when new data is being fetched.
![5oxal-xsz3b](https://user-images.githubusercontent.com/15097138/66403660-dcec5c80-e9de-11e9-9481-db09bbe8317f.gif)
