### PR TITLE
Fix cut titles in category boxes and fixed header

### DIFF
--- a/src/components/category-box/category-box-styles.module.scss
+++ b/src/components/category-box/category-box-styles.module.scss
@@ -72,6 +72,7 @@
 
   @media #{$tablet-portrait} {
     font-size: 32px;
+    overflow: visible;
   }
 }
 

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -95,6 +95,7 @@ $icon-size: 25px;
     padding-bottom: 0;
     margin-right: 0;
     font-size: 32px;
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
This PR fixes a bug with cut titles on desktop in the data globe (category boxes + fixed header in the sidebar): [PT](https://www.pivotaltracker.com/story/show/168972541)

**Category boxes**
![image](https://user-images.githubusercontent.com/6136899/66304739-d209cd00-e8f5-11e9-8b28-ae8ff1cf5af8.png)

**Sidebar**
![image](https://user-images.githubusercontent.com/6136899/66304781-e5b53380-e8f5-11e9-83de-3be726f52b63.png)
