### PR TITLE
Fix broken layers counter in protected areas entry box

### DIFF
--- a/src/components/entry-boxes/entry-boxes-selectors.js
+++ b/src/components/entry-boxes/entry-boxes-selectors.js
@@ -9,7 +9,10 @@ const getCountedActiveLayers = createSelector(
   (activeLayers, rasters) => {
  
     const biodiversityLayers = activeLayers ? activeLayers.filter(({ category }) => category === 'Biodiversity').length : 0;
-    const protectionLayers = activeLayers ? activeLayers.filter(({ category }) => category === 'Existing protection').length : 0;
+    const protectionLayers = activeLayers ? activeLayers.filter(({ category, title }) => {
+      // we have to filter 'RAISIG' layer because activating 'Community-based' checbox selects two layers on the globe: "protected_areas_vector_tile_layer" and "RAISIG_areas_vector_tile_layer"
+      return category === 'Existing protection' && title !== 'RAISIG_areas_vector_tile_layer'
+    }).length : 0; 
     const humanPressureLayer = activeLayers ? activeLayers.filter(({ title }) => title === LAND_HUMAN_PRESSURES_IMAGE_LAYER).length : 0;
     const humanPressureRasters = humanPressureLayer && Object.keys(rasters).filter(key => rasters[key]).length;
 

--- a/src/components/entry-boxes/entry-boxes-selectors.js
+++ b/src/components/entry-boxes/entry-boxes-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { LAND_HUMAN_PRESSURES_IMAGE_LAYER } from 'constants/layers-slugs';
+import { LAND_HUMAN_PRESSURES_IMAGE_LAYER, RAISIG_AREAS_VECTOR_TILE_LAYER } from 'constants/layers-slugs';
 
 const getActiveLayers = (state, props) => props.activeLayers;
 const getRasters = (state, props) => props.rasters || {};
@@ -11,7 +11,7 @@ const getCountedActiveLayers = createSelector(
     const biodiversityLayers = activeLayers ? activeLayers.filter(({ category }) => category === 'Biodiversity').length : 0;
     const protectionLayers = activeLayers ? activeLayers.filter(({ category, title }) => {
       // we have to filter 'RAISIG' layer because activating 'Community-based' checbox selects two layers on the globe: "protected_areas_vector_tile_layer" and "RAISIG_areas_vector_tile_layer"
-      return category === 'Existing protection' && title !== 'RAISIG_areas_vector_tile_layer'
+      return category === 'Existing protection' && title !== RAISIG_AREAS_VECTOR_TILE_LAYER
     }).length : 0; 
     const humanPressureLayer = activeLayers ? activeLayers.filter(({ title }) => title === LAND_HUMAN_PRESSURES_IMAGE_LAYER).length : 0;
     const humanPressureRasters = humanPressureLayer && Object.keys(rasters).filter(key => rasters[key]).length;


### PR DESCRIPTION
This PR fixes the incorrect number of selected layers in `Existing protection`: when the `Community-based` checkbox was selected, the number of currently active layers was greater by two, not by one. The reason is that selecting `Community-based` layer now selects two layers: `protected_areas_vector_tile_layer` and `RAISIG_areas_vector_tile_layer`