### PR TITLE
Persist in the url opened half earth modal

### DIFF
--- a/src/components/mobile-only/menu-settings/menu-settings-component.jsx
+++ b/src/components/mobile-only/menu-settings/menu-settings-component.jsx
@@ -5,7 +5,7 @@ import { FOOTER_OPTIONS } from 'constants/mobile-only';
 
 import styles from './menu-settings-styles.module.scss';
 
-const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal, isLandscapeMode, isLandscapeSidebarCollapsed }) => {
+const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal }) => {
   const isSettingsOpen = activeOption === FOOTER_OPTIONS.SETTINGS;
   const Component = activeModal && options[activeModal].Component;
   return (

--- a/src/components/mobile-only/menu-settings/menu-settings.js
+++ b/src/components/mobile-only/menu-settings/menu-settings.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { SETTINGS_OPTIONS } from 'constants/mobile-only';
@@ -19,10 +19,20 @@ const mapStateToProps = ({ pageTexts }) => ({
 });
 
 const MenuSettingsContainer = props => {
-  const { setPageTexts, textData } = props;
+  const { setPageTexts, textData, isHEModalOpen, changeUI } = props;
   const [activeModal, setActiveModal] = useState(null);
 
-  const closeModal = () => setActiveModal(null);
+  // take opened half earth modal from the url state
+  useEffect(() => {
+    if (isHEModalOpen) setActiveModal(HALF_EARTH_MODAL);
+  }, []);
+
+  const closeHEModal = () => { changeUI({ isHEModalOpen: false }) }
+
+  const closeModal = () => { 
+    if(activeModal === HALF_EARTH_MODAL) { closeHEModal() }
+    setActiveModal(null) 
+  };
 
   const { HALF_EARTH_MODAL, ABOUT_PARTNERS, ABOUT_INSTRUCTIONS } = SETTINGS_OPTIONS;
 
@@ -32,6 +42,7 @@ const MenuSettingsContainer = props => {
       Component: HalfEarthModal,
       onClickHandler: () => {
         setActiveModal(HALF_EARTH_MODAL);
+        changeUI({ isHEModalOpen: true });
       }
     },
     [ABOUT_PARTNERS]: {
@@ -40,12 +51,16 @@ const MenuSettingsContainer = props => {
       onClickHandler: () => {
         setPageTexts(PARTNERS_TEXT_SLUG)
         setActiveModal(ABOUT_PARTNERS);
+        closeHEModal()
       }
     },
     [ABOUT_INSTRUCTIONS]: {
       name: 'How to navigate the map',
       Component: MapInstructions,
-      onClickHandler: () => setActiveModal(ABOUT_INSTRUCTIONS)
+      onClickHandler: () => { 
+        setActiveModal(ABOUT_INSTRUCTIONS);
+        closeHEModal()
+      }
     }
   }
 

--- a/src/components/mobile-only/menu-settings/menu-settings.js
+++ b/src/components/mobile-only/menu-settings/menu-settings.js
@@ -51,7 +51,6 @@ const MenuSettingsContainer = props => {
       onClickHandler: () => {
         setPageTexts(PARTNERS_TEXT_SLUG)
         setActiveModal(ABOUT_PARTNERS);
-        closeHEModal()
       }
     },
     [ABOUT_INSTRUCTIONS]: {
@@ -59,7 +58,6 @@ const MenuSettingsContainer = props => {
       Component: MapInstructions,
       onClickHandler: () => { 
         setActiveModal(ABOUT_INSTRUCTIONS);
-        closeHEModal()
       }
     }
   }

--- a/src/components/widgets/minimap-widget/minimap-widget.js
+++ b/src/components/widgets/minimap-widget/minimap-widget.js
@@ -6,13 +6,19 @@ import MinimapWidgetComponent from './minimap-widget-component';
 import { disableInteractions, minimapLayerStyles, synchronizeWebScenes } from 'utils/minimap-utils';
 import HalfEarthModal from 'components/half-earth-modal/half-earth-modal';
 import { openHalfEarthMeterAnalyticsEvent } from 'actions/google-analytics-actions';
+import * as urlActions from 'actions/url-actions';
 import { isMobile } from 'constants/responsive';
 
 const VIEW = 'half-earth-meter';
-const actions = { openHalfEarthMeterAnalyticsEvent };
+const actions = { openHalfEarthMeterAnalyticsEvent, ...urlActions };
 
 const MinimapWidget = (props) => {
-  const [isModalOpen, setModalOpen] = useState(false);
+  const { isHEModalOpen } = props;
+
+  const setModal = (opened) => {
+    const { changeUI } = props;
+    changeUI({ isHEModalOpen: opened });
+  }
 
   const isOnMobile = isMobile();
 
@@ -27,13 +33,13 @@ const MinimapWidget = (props) => {
   };
 
   const handleModalOpen = () => {
-    setModalOpen(true);
+    setModal(true);
     const { openHalfEarthMeterAnalyticsEvent } = props;
     openHalfEarthMeterAnalyticsEvent();
   };
 
   const handleModalClose = () => {
-    setModalOpen(false);
+    setModal(false);
   };
 
   const { textData, hidden } = props;
@@ -41,7 +47,7 @@ const MinimapWidget = (props) => {
   return (
     <div style={{ display: hidden ? 'none' : 'block' }}>
       {!isOnMobile && <MinimapWidgetComponent handleMapLoad={handleMapLoad} {...props} handleModalOpen={handleModalOpen}/>}
-      {isModalOpen && <HalfEarthModal handleModalClose={handleModalClose} textData={textData}/>}
+      {isHEModalOpen && <HalfEarthModal handleModalClose={handleModalClose} textData={textData}/>}
     </div>
   );
 }

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -8,14 +8,14 @@ import MinimapWidget from 'components/widgets/minimap-widget';
 
 import { isMobile } from 'constants/responsive';
 
-const WidgetsComponent = ({ map, view, isFullscreenActive, isNotMapsList = true, hidden = false}) => {
+const WidgetsComponent = ({ map, view, isFullscreenActive, isHEModalOpen = false, isNotMapsList = true, hidden = false}) => {
   const isOnMobile = isMobile();
   const hiddenWidget = hidden || isOnMobile;
   return (
     <>
       <ToggleUiWidget map={map} view={view} isFullscreenActive={isFullscreenActive} hidden={hiddenWidget}/>
       <ZoomWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
-      <MinimapWidget map={map} view={view} hidden={hiddenWidget} />
+      <MinimapWidget map={map} view={view} hidden={hiddenWidget} isHEModalOpen={isHEModalOpen} />
       {!isOnMobile && <SearchWidget map={map} view={view} hidden={hiddenWidget} />}
       <LocationWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
     </>

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -43,6 +43,7 @@ const DataGlobeComponent = ({
   handleGlobeUpdating,
   setRasters,
   activeOption,
+  isHEModalOpen,
 }) => {
 
   const isOnMobile = isMobile();
@@ -58,14 +59,14 @@ const DataGlobeComponent = ({
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>
           <MenuFooter activeOption={activeOption} isSidebarOpen={isSidebarOpen} isLandscapeMode={isLandscapeMode} />
-          <MenuSettings activeOption={activeOption} isLandscapeMode={isLandscapeMode} isLandscapeSidebarCollapsed={isLandscapeSidebarCollapsed} />
+          <MenuSettings activeOption={activeOption} isHEModalOpen={isHEModalOpen} />
           <Slider />
         </MobileOnly>
         {!isOnMobile && <Switcher />}
-        <ArcgisLayerManager activeLayers={activeLayers}/>
         <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />
         <LandscapeViewManager zoomLevelTrigger={ZOOM_LEVEL_TRIGGER} isLandscapeMode={isLandscapeMode} />
-        <Widgets isFullscreenActive={isFullscreenActive}/>
+        <ArcgisLayerManager activeLayers={activeLayers} />
+        <Widgets isFullscreenActive={isFullscreenActive} isHEModalOpen={isHEModalOpen} />
         <DataGlobalSidebar
           isSidebarOpen={isSidebarOpen}
           activeOption={activeOption}

--- a/src/pages/data-globe/data-globe-selectors.js
+++ b/src/pages/data-globe/data-globe-selectors.js
@@ -35,6 +35,7 @@ export const getRasters = createSelector(getGlobeSettings, globeSettings => glob
 const getSelectedSpecies = createSelector(getGlobeSettings, globeSettings => globeSettings.selectedSpecies)
 const getActiveOption = createSelector(getUiSettings, uiSettings => uiSettings.activeOption)
 const getLandscapeSidebarCollapsed = createSelector(getUiSettings, uiSettings => uiSettings.isLandscapeSidebarCollapsed);
+const getHalfEarthModalOpen = createSelector(getUiSettings, uiSettings => uiSettings.isHEModalOpen);
 
 export default createStructuredSelector({
   sceneSettings: getGlobeSettings,
@@ -50,6 +51,7 @@ export default createStructuredSelector({
   hasMetadata: selectMetadataData,
   listeners: getListenersSetting,
   selectedSpecies: getSelectedSpecies,
+  isHEModalOpen: getHalfEarthModalOpen,
   activeOption: getActiveOption, // mobile
   isLandscapeSidebarCollapsed: getLandscapeSidebarCollapsed // mobile
 })

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -63,6 +63,7 @@ const DataGlobeComponent = ({
   mouseMoveCallbacksArray,
   activeOption,
   isLandscapeSidebarCollapsed,
+  isHEModalOpen,
 }) => {
   const isFeaturedPlaceCard = selectedFeaturedPlace && !isLandscapeMode;
   const isOnMobile = isMobile();
@@ -81,14 +82,14 @@ const DataGlobeComponent = ({
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>
           <MenuFooter featured selectedSidebar={selectedSidebar} selectedFeaturedMap={selectedFeaturedMap} activeOption={activeOption} isLandscapeMode={isLandscapeMode} />
-          <MenuSettings activeOption={activeOption} isLandscapeMode={isLandscapeMode} isLandscapeSidebarCollapsed={isLandscapeSidebarCollapsed} />
+          <MenuSettings activeOption={activeOption} isHEModalOpen={isHEModalOpen} />
           <Slider />
         </MobileOnly>
         <ArcgisLayerManager activeLayers={activeLayers} customFunctions={customFunctions}/>
         <GlobeEventsManager clickCallbacksArray={clickCallbacksArray} mouseMoveCallbacksArray={mouseMoveCallbacksArray} />
         <LandscapeViewManager zoomLevelTrigger={ZOOM_LEVEL_TRIGGER} isLandscapeMode={isLandscapeMode} />
         <FeaturedPlaceViewManager selectedFeaturedPlace={selectedFeaturedPlace} isLandscapeMode={isLandscapeMode} />
-        <Widgets isFullscreenActive={isFullscreenActive} hidden={esriWidgetsHidden}/>
+        <Widgets isFullscreenActive={isFullscreenActive} hidden={esriWidgetsHidden} isHEModalOpen={isHEModalOpen} />
         {selectedFeaturedMap &&
           <SelectedFeaturedMapCard
             className={uiStyles.uiTopLeft}

--- a/src/pages/featured-globe/featured-globe-selectors.js
+++ b/src/pages/featured-globe/featured-globe-selectors.js
@@ -36,6 +36,7 @@ const getGlobeUpdating = createSelector(getGlobeSettings, globeSettings => globe
 const getSelectedSpecies = createSelector(getGlobeSettings, globeSettings => globeSettings.selectedSpecies)
 const getActiveOption = createSelector(getUiSettings, uiSettings => uiSettings.activeOption)
 const getLandscapeSidebarCollapsed = createSelector(getUiSettings, uiSettings => uiSettings.isLandscapeSidebarCollapsed);
+const getHalfEarthModalOpen = createSelector(getUiSettings, uiSettings => uiSettings.isHEModalOpen);
 
 export const getRasters = createSelector(getGlobeSettings, globeSettings => globeSettings.rasters)
 
@@ -55,6 +56,7 @@ export default createStructuredSelector({
   rasters: getRasters,
   isGlobeUpdating: getGlobeUpdating,
   selectedSpecies: getSelectedSpecies,
+  isHEModalOpen: getHalfEarthModalOpen,
   activeOption: getActiveOption, // mobile
   isLandscapeSidebarCollapsed: getLandscapeSidebarCollapsed // mobile
 })


### PR DESCRIPTION
In the mobile design, we've got a share button in the Half-Earth Modal. For that purpose, we need to persist its opened state in the url when sharing the link. 
Note: the share functionality will come in a different PR.