### PR TITLE
Fix/add share button to card component

### DIFF
--- a/src/components/featured-place-card/featured-place-card-component.jsx
+++ b/src/components/featured-place-card/featured-place-card-component.jsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import animationStyles from 'styles/common-animations.module.scss';
 import { isMobile } from 'constants/responsive';
 import { FOOTER_OPTIONS } from 'constants/mobile-only';
+import ShareModalButton from 'components/share-modal';
 import styles from './featured-place-card-styles.module';
 
 const FeaturedPlaceCardComponent = ({
@@ -17,7 +18,8 @@ const FeaturedPlaceCardComponent = ({
   handleNextPlaceClick,
   handlePrevPlaceClick,
   handleLandscapeTrigger,
-  activeOption
+  activeOption,
+  view
 }) => {
 
   const isOnMobile = isMobile();
@@ -60,16 +62,22 @@ const FeaturedPlaceCardComponent = ({
         {isOnMobile && <div className={styles.spacerContainer}>
           <div className={styles.spacer} />
         </div>}
-        <section className={styles.card}>
+        <section className={styles.cardGrid}>
           {featuredPlace &&
             <>
-              {!isOnMobile && <div className={styles.landscapeTriggerContainer}>
-                <img
-                  src={featuredPlace.image}
-                  className={styles.picture}
-                  alt={featuredPlace.title}
-                  onClick={handleLandscapeTrigger}
-                />
+              {isOnMobile && <h2 className={styles.title}>{featuredPlace.title}</h2>}
+              <div className={styles.pictureContainer}>
+                <ShareModalButton theme={{ shareButton: styles.shareButton}} view={view} />
+                {featuredPlace.image && 
+                  <img
+                    src={featuredPlace.image}
+                    className={styles.picture}
+                    alt={featuredPlace.title}
+                    onClick={handleLandscapeTrigger}
+                  />
+                }
+              </div>
+              {!isOnMobile && 
                 <button
                   className={styles.landscapeTriggerButton}
                   onClick={handleLandscapeTrigger}
@@ -77,27 +85,14 @@ const FeaturedPlaceCardComponent = ({
                   <GoToIcon className={styles.icon} />
                   <span className={styles.landscapeTriggerText}>explore this area</span>
                 </button>
-              </div>}
-              <div className={styles.contentContainer}>
-                {isOnMobile && (
-                  <>
-                    <h2 className={styles.title}>{featuredPlace.title}</h2>
-                    <img
-                      src={featuredPlace.image}
-                      className={styles.picture}
-                      alt={featuredPlace.title}
-                      onClick={handleLandscapeTrigger}
-                    />
-                  </>
-                )}
-                <div className={styles.contentWrapper} ref={contentWrapper}>
-                  {!isOnMobile && <h2 className={styles.title}>{featuredPlace.title}</h2>}
-                  <div>
-                    <p className={styles.text}>
-                      {featuredPlace.description}
-                    </p>
-                    {featuredMap && featuredMap.sourceText && <span className={styles.sourceText}>(Source: <i>{featuredMap.sourceText}</i>)</span>}
-                  </div>
+              }
+              <div className={styles.contentContainer} ref={contentWrapper}>
+                {!isOnMobile && <h2 className={styles.title}>{featuredPlace.title}</h2>}
+                <div>
+                  <p className={styles.text}>
+                    {featuredPlace.description}
+                  </p>
+                  {featuredMap && featuredMap.sourceText && <span className={styles.sourceText}>(Source: <i>{featuredMap.sourceText}</i>)</span>}
                 </div>
               </div>
             </>

--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -189,6 +189,8 @@ $card-content-max-height: 220px;
   .landscapeTriggerText {
     @extend %subtitle;
     color: $dark-text;
+    margin-left: 12px;
+    margin-top: 4px;
   }
 
   .contentContainer {

--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -158,7 +158,6 @@ $card-content-max-height: 220px;
     grid-area: picture;
 
     .picture {
-      float: left;
       height: 100%;
       object-fit: cover;
       margin-right: 0;

--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -151,31 +151,6 @@ $card-content-max-height: 220px;
     padding: 60px 40px 40px;
   }
 
-  .pictureContainer {
-    background-color: $alto;
-    height: 170px;
-    position: relative;
-    grid-area: picture;
-
-    .picture {
-      height: 100%;
-      object-fit: cover;
-      margin-right: 0;
-      margin-bottom: 22px;
-      cursor: pointer;
-      width: 100%;
-    }
-
-    @media #{$tablet-portrait} {
-      height: unset;
-
-      .picture {
-        margin-right: 40px;
-        margin-bottom: 0;
-      }
-    }
-  }
-
   .landscapeTriggerButton {
     align-self: end;
     display: flex;
@@ -243,6 +218,31 @@ $card-content-max-height: 220px;
     @extend %bodyText;
     color: $dark-text;
     padding-bottom: 24px;
+  }
+}
+
+.pictureContainer {
+  background-color: $alto;
+  height: 170px;
+  position: relative;
+  grid-area: picture;
+
+  .picture {
+    height: 100%;
+    object-fit: cover;
+    margin-right: 0;
+    margin-bottom: 22px;
+    cursor: pointer;
+    width: 100%;
+  }
+
+  @media #{$tablet-portrait} {
+    height: unset;
+
+    .picture {
+      margin-right: 40px;
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/src/components/featured-place-card/featured-place-card-styles.module.scss
+++ b/src/components/featured-place-card/featured-place-card-styles.module.scss
@@ -121,54 +121,59 @@ $card-content-max-height: 220px;
   }
 }
 
-.card {
+.cardGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto 170px 1fr;
+  grid-template-areas: 
+    "title"
+    "picture"
+    "text";
+
+  background-color: $white;
   pointer-events: all;
   position: relative;
-  flex-grow: 1;
-  width: 100%;
-  height: 350px;
   max-width: $card-max-width;
-  background-color: white;
   padding: 12px $mobile-sidebar-side-paddings 0;
   overflow-y: scroll;
+  width: 100%;
 
   @media #{$tablet-portrait} {
-    overflow-y: unset;
-    padding: 60px 40px 0px;
-    display: grid;
+    grid-column-gap: 40px;
     grid-template-columns: 1fr 1fr;
+    grid-template-rows: 190px 1fr;
+    grid-template-areas: 
+      "picture text"
+      "exploreButton text";
+
+    overflow-y: unset;
+    height: 350px;
+    padding: 60px 40px 40px;
   }
 
-  .landscapeTriggerContainer {
-    display: grid;
-    max-height: $card-content-max-height;
-    width: 100%;    
+  .pictureContainer {
+    background-color: $alto;
+    height: 170px;
+    position: relative;
+    grid-area: picture;
 
-    @media #{$tablet-portrait} {
-      grid-template-rows: 185px 1fr;
-      width: 300px;
+    .picture {
+      float: left;
+      height: 100%;
+      object-fit: cover;
+      margin-right: 0;
+      margin-bottom: 22px;
+      cursor: pointer;
+      width: 100%;
     }
 
-    .icon {
-      fill: $dark-text;
-      position: relative;
-      top: -2px;
-      margin-right: 12px;
-    }
-
-  }
-  
-  .picture {
-    float: left;
-    width: 100%;
-    margin-right: 0;
-    margin-bottom: 22px;
-    cursor: pointer;
-
     @media #{$tablet-portrait} {
-      max-height: 100%;
-      margin-right: 40px;
-      margin-bottom: 0;
+      height: unset;
+
+      .picture {
+        margin-right: 40px;
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -178,6 +183,7 @@ $card-content-max-height: 220px;
     justify-self: start;
     align-items: center;
     margin-top: 20px;
+    grid-area: exploreButton;
   }
 
   .landscapeTriggerText {
@@ -186,21 +192,11 @@ $card-content-max-height: 220px;
   }
 
   .contentContainer {
+    grid-area: text;
+    padding-bottom: 20px;
+
     @media #{$tablet-portrait} {
       max-height: $card-content-max-height;
-      overflow: hidden;
-      mask-image: linear-gradient(to bottom,
-      rgba(0,0,0,1) 85%,
-      rgba(0,0,0,0) 100%
-      );
-    }
-  }
-
-  .contentWrapper {    
-    @media #{$tablet-portrait} {
-      max-height: $card-content-max-height;
-
-      // %verticalScrollBar - cannot extend inside @media
       overflow-y: scroll; 
       scrollbar-width: none; /* Firefox */
       -ms-overflow-style: none;  /* IE 10+ */
@@ -209,6 +205,10 @@ $card-content-max-height: 220px;
         width: 0;
         height: 0;
       }
+      mask-image: linear-gradient(to bottom,
+      rgba(0,0,0,1) 85%,
+      rgba(0,0,0,0) 100%
+      );
     }
   }
 
@@ -219,6 +219,7 @@ $card-content-max-height: 220px;
     color: $dark-text;
     margin: 0;
     margin-bottom: 12px;
+    grid-area: title;
 
     @media #{$tablet-portrait} {
       margin-bottom: 0;
@@ -280,4 +281,13 @@ $card-content-max-height: 220px;
   padding: 10px 40px;
   color: $firefly;
   background-color: $robins-egg-blue;
+}
+
+.shareButton {
+  background-color: $elephant;
+  height: 32px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 32px;
 }

--- a/src/components/featured-place-card/featured-place-card.js
+++ b/src/components/featured-place-card/featured-place-card.js
@@ -27,6 +27,7 @@ const FeaturedPlaceCardContainer = props => {
 
   useEffect(() => {
     const fetchData = async () => {
+      setFeaturedPlace({ ...featuredPlace, image: null })
       const result = await CONTENTFUL.getFeaturedPlaceData(selectedFeaturedPlace);
       if (result) {
         setFeaturedPlace(result);

--- a/src/components/share-modal/share-modal-styles.module.scss
+++ b/src/components/share-modal/share-modal-styles.module.scss
@@ -1,26 +1,51 @@
 @import 'styles/settings';
 @import 'styles/ui.module';
+@import 'styles/typography-extends';
 
 $tabsMarginBottom: 8px;
 
 .modal {
-  padding: 50px 60px !important;
-  width: 600px !important;
+  width: 90% !important;
+  max-width: 90% !important;
+  padding: 60px 32px !important;
+  height: auto !important;
 
   @media #{$tablet-landscape} {
+    padding: 50px 60px !important;
     max-width: 620px !important;
-    width: 80% !important;
-    height: auto !important;
+    width: 600px !important;
+    
   }
 }
 
 .modalContent {
-  padding: 50px 60px !important;
+  padding: 0 !important;
+  @media #{$tablet-landscape} {
+    padding: 50px 60px !important;
+  }
+}
+
+.closeBtn {
+  background-color: transparent !important;
+  height: 33px;
+  right: 24px !important;
+  top: 24px !important;
+  border: none !important;
+
+  @media #{$tablet-landscape} {
+    right: 35px !important;
+    top: 35px !important;
+  }
 }
 
 .copyContainer {
   display: flex;
   margin-bottom: 20px;
+  flex-direction: column;
+
+  @media #{$tablet-landscape} {
+    flex-direction: row;
+  }
 }
 
 .coordinates {
@@ -37,12 +62,17 @@ $tabsMarginBottom: 8px;
   width: stretch;
   height: 40px;
   border-radius: 2px;
-  border-right-style: none;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
+  margin-bottom: 8px;
 
   &:focus {
     outline: none;
+  }
+
+  @media #{$tablet-landscape} {
+    border-right-style: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 0;
   }
 }
 
@@ -55,11 +85,15 @@ $tabsMarginBottom: 8px;
 }
 
 .copyButton {
-  margin-left: -10px !important;
-  width: 100px !important;
   letter-spacing: 2px !important;
   font-size: $font-size-xs !important;
   padding: 0 !important;
+  width: 100% !important;
+
+  @media #{$tablet-landscape} {
+    margin-left: -10px !important;
+    width: 100px !important;
+  }
 }
 
 .copied {
@@ -73,10 +107,15 @@ $tabsMarginBottom: 8px;
 }
 
 .title {
+  @extend %headline;
   text-align: center;
   font-size: $font-size-xl;
   text-shadow: 0 0 10px 0 rgba(255, 255, 255, 0.5);
-  margin-bottom: 50px;
+  margin-bottom: 32px;
+
+  @media #{$tablet-landscape} {
+    margin-bottom: 50px;
+  }
 }
 
 .tabs {
@@ -114,12 +153,14 @@ $tabsMarginBottom: 8px;
 }
 
 .facebookIcon {
-  margin-right: 60px;
+  // margin-right: 60px;
 }
 
 .iconBackground {
-  height: 60px;
-  width: 60px;
+  height: 45px !important;
+  width: 45px !important;
+  padding: 0 !important;
+  margin: 15px !important;
 }
 
 .socialMediaContainer {

--- a/src/styles/tooltip.scss
+++ b/src/styles/tooltip.scss
@@ -12,7 +12,8 @@
 :global {
 	.infoTooltipStyle {
 		@extend %tooltip-apperance;
-	
+		box-shadow: 0 2px 10px 0 rgba(23, 27, 48, 0.15);
+
 		&.place-left:after {
 			border-left-color: $white !important;
 		}


### PR DESCRIPTION
This PR:
- adds share button to the card image - [PIVOTAL](https://www.pivotaltracker.com/story/show/169038866)
- adds light-grey background of the empty card image:
![3ui94-3rkyf (1)](https://user-images.githubusercontent.com/15097138/66489757-0624ef80-eaa8-11e9-97cb-f78cc521e971.gif)
- implements share button mobile styles:
![Screenshot from 2019-10-09 14 58 31](https://user-images.githubusercontent.com/15097138/66489674-e8f02100-eaa7-11e9-91e9-00ea52a6d67c.png)
- refactors the card grid styles in `FeaturedPlaceCardComponent` 