### PR TITLE
Add share button to Half Earth modal on mobile

### DIFF
--- a/src/components/featured-map-card/featured-map-card-component.jsx
+++ b/src/components/featured-map-card/featured-map-card-component.jsx
@@ -41,7 +41,7 @@ const FeaturesMapCardComponent = ({
             className={styles.titleSection}
             style={ {backgroundImage: `linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.3)), url(${featuredMap.image})`}}
           >
-            <ShareModalButton theme={{ shareButton: styles.shareButton}} view={view} />
+            <ShareModalButton theme={{ shareButton: styles.shareButton}} />
             <h2 className={styles.title}>{featuredMap.title}</h2>
           </section>
           <section className={styles.descriptionSection}>

--- a/src/components/featured-place-card/featured-place-card-component.jsx
+++ b/src/components/featured-place-card/featured-place-card-component.jsx
@@ -67,7 +67,7 @@ const FeaturedPlaceCardComponent = ({
             <>
               {isOnMobile && <h2 className={styles.title}>{featuredPlace.title}</h2>}
               <div className={styles.pictureContainer}>
-                <ShareModalButton theme={{ shareButton: styles.shareButton}} view={view} />
+                <ShareModalButton theme={{ shareButton: styles.shareButton}} />
                 {featuredPlace.image && 
                   <img
                     src={featuredPlace.image}

--- a/src/components/fixed-header/fixed-header-component.jsx
+++ b/src/components/fixed-header/fixed-header-component.jsx
@@ -22,7 +22,7 @@ const FixedHeader = ({ closeSidebar, title, view, autoHeight, toggleCollapsedLan
       { [styles.higherHeader]: isHigherHeader},
       { [styles.autoHeightHeader]: autoHeight}
     )}>
-      {!isOnMobile && <ShareModal theme={{ shareButton: styles.shareButton}} view={view} />}
+      {!isOnMobile && <ShareModal theme={{ shareButton: styles.shareButton}} />}
       {!noBackClick && <button
         className={styles.button}
         onClick={closeSidebar}

--- a/src/components/half-earth-modal/half-earth-modal-component.jsx
+++ b/src/components/half-earth-modal/half-earth-modal-component.jsx
@@ -45,6 +45,9 @@ const HalfEarthModalComponent = ({ handleModalClose, textData }) => {
             <img src={isOnMobile ? GlobeSmallImage : GlobeImage} className={styles.globe} alt="Half-Earth globe" />
           </div>
         </div>
+        <div className={styles.share}>
+          <ShareModalButton shareText />
+        </div>
       </div>
       <button
         className={styles.closeButton}
@@ -52,9 +55,7 @@ const HalfEarthModalComponent = ({ handleModalClose, textData }) => {
       >
         <CloseIcon />
       </button>
-      <div className={styles.share}>
-        <ShareModalButton shareText />
-      </div>
+
     </div>
   );
 }

--- a/src/components/half-earth-modal/half-earth-modal-component.jsx
+++ b/src/components/half-earth-modal/half-earth-modal-component.jsx
@@ -5,6 +5,7 @@ import { ReactComponent as CloseIcon } from 'icons/close.svg';
 import GlobeImage from 'images/globe.png';
 import GlobeSmallImage from 'images/globeSmall.png';
 import { isMobile } from 'constants/responsive';
+import ShareModalButton from 'components/share-modal';
 
 import data from './half-earth-modal-data';
 
@@ -51,6 +52,9 @@ const HalfEarthModalComponent = ({ handleModalClose, textData }) => {
       >
         <CloseIcon />
       </button>
+      <div className={styles.share}>
+        <ShareModalButton shareText />
+      </div>
     </div>
   );
 }

--- a/src/components/half-earth-modal/half-earth-modal-styles.module.scss
+++ b/src/components/half-earth-modal/half-earth-modal-styles.module.scss
@@ -189,3 +189,14 @@ $icon-size: 40px;
     display: block;
   }
 }
+
+.share {
+  display: none;
+  
+  @media #{$tablet-portrait} {
+    display: block;
+    position: absolute;
+    bottom: 30px;
+    right: 30px;
+  }
+}

--- a/src/components/half-earth-modal/half-earth-modal-styles.module.scss
+++ b/src/components/half-earth-modal/half-earth-modal-styles.module.scss
@@ -192,11 +192,10 @@ $icon-size: 40px;
 
 .share {
   display: none;
-  
   @media #{$tablet-portrait} {
     display: block;
-    position: absolute;
-    bottom: 100px;
-    right: 125px;
+    grid-area: globe;
+    align-self: flex-end;
+    justify-self: flex-end;
   }
 }

--- a/src/components/half-earth-modal/half-earth-modal-styles.module.scss
+++ b/src/components/half-earth-modal/half-earth-modal-styles.module.scss
@@ -196,7 +196,7 @@ $icon-size: 40px;
   @media #{$tablet-portrait} {
     display: block;
     position: absolute;
-    bottom: 30px;
-    right: 30px;
+    bottom: 100px;
+    right: 125px;
   }
 }

--- a/src/components/mobile-only/menu-settings/menu-settings-component.jsx
+++ b/src/components/mobile-only/menu-settings/menu-settings-component.jsx
@@ -30,12 +30,7 @@ const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal
               <ArrowExpandIcon className={styles.icon} />
               <span className={styles.backButton}>BACK</span>
             </button>
-            {isHalfEarthModal && 
-              <div className={styles.share}>
-                <span className={styles.shareText}>Share</span>
-                <ShareModalButton />
-              </div>
-            }          
+            {isHalfEarthModal && <ShareModalButton shareText />}          
           </div>
           <Component textData={textData} />
         </div>}

--- a/src/components/mobile-only/menu-settings/menu-settings-component.jsx
+++ b/src/components/mobile-only/menu-settings/menu-settings-component.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import cx from 'classnames';
 import { ReactComponent as ArrowExpandIcon } from 'icons/arrow_expand.svg';
-import { FOOTER_OPTIONS } from 'constants/mobile-only';
+import { FOOTER_OPTIONS, SETTINGS_OPTIONS } from 'constants/mobile-only';
+import ShareModalButton from 'components/share-modal';
 
 import styles from './menu-settings-styles.module.scss';
 
 const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal }) => {
   const isSettingsOpen = activeOption === FOOTER_OPTIONS.SETTINGS;
+  const isHalfEarthModal = activeModal && activeModal === SETTINGS_OPTIONS.HALF_EARTH_MODAL;
   const Component = activeModal && options[activeModal].Component;
   return (
     <>
@@ -20,13 +22,21 @@ const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal
       </div>
       {isSettingsOpen && activeModal && 
         <div className={styles.modalWrapper}>
-          <button
-            className={styles.button}
-            onClick={closeModal}
-          >
-            <ArrowExpandIcon className={styles.icon} />
-            <span className={styles.backButton}>BACK</span>
-          </button>
+          <div className={styles.buttonsContainer}>
+            <button
+              className={styles.button}
+              onClick={closeModal}
+            >
+              <ArrowExpandIcon className={styles.icon} />
+              <span className={styles.backButton}>BACK</span>
+            </button>
+            {isHalfEarthModal && 
+              <div className={styles.share}>
+                <span className={styles.shareText}>Share</span>
+                <ShareModalButton />
+              </div>
+            }          
+          </div>
           <Component textData={textData} />
         </div>}
     </>

--- a/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
+++ b/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
@@ -2,6 +2,8 @@
 @import 'styles/ui.module';
 @import 'styles/typography-extends';
 
+$buttonSideMargin: 24px;
+
 .container {
   @include backdropBlur();
   @include bottom();
@@ -52,8 +54,6 @@
 }
 
 .button {
-  margin-top: 38px;
-  margin-left: 24px;
   display: flex;
   align-items: center;
   font-size: $font-size-xxs;
@@ -64,6 +64,16 @@
   padding: 0;
 }
 
+.buttonsContainer {
+  margin-top: 38px;
+  margin: {
+    left: $buttonSideMargin;
+    right: $buttonSideMargin;
+  }
+  display: flex;
+  justify-content: space-between;
+}
+
 .icon {
   transform: rotate(180deg);
   height: 25px;
@@ -71,4 +81,14 @@
 
 .backButton {
   margin-top: 4px;
+}
+
+.shareText {
+  color: $white;
+  @extend %subtitle;
+}
+
+.share {
+  display: flex;
+  align-items: center;
 }

--- a/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
+++ b/src/components/mobile-only/menu-settings/menu-settings-styles.module.scss
@@ -82,13 +82,3 @@ $buttonSideMargin: 24px;
 .backButton {
   margin-top: 4px;
 }
-
-.shareText {
-  color: $white;
-  @extend %subtitle;
-}
-
-.share {
-  display: flex;
-  align-items: center;
-}

--- a/src/components/share-modal/share-modal-component.jsx
+++ b/src/components/share-modal/share-modal-component.jsx
@@ -83,21 +83,42 @@ const ShareModalComponent = (props) => {
     openShareModalAnalyticsEvent(viewMode);
   }
   const handleCloseShareModal = () => setShareModalOpen(false);
-  const { theme } = props;
+  const { theme, shareText = false } = props;
 
-  return (
-    <>
+  const tooltipId = {
+    'data-tip': 'data-tip',
+    'data-for': 'shareButtonId',
+    'data-place': 'right',
+    'data-effect':'solid',
+    'data-delay-show': 0
+  };
+
+  const shareButton = (withClickAndTooltip) => {
+    const tooltip = withClickAndTooltip ? {...tooltipId} : {};
+    return (
       <button
         className={cx(theme.shareButton)}
-        onClick={handleOpenShareModal}
-        data-tip
-        data-for='shareButtonId'
-        data-place='right'
-        data-effect='solid'
-        data-delay-show={0}
+        onClick={withClickAndTooltip ? handleOpenShareModal : (() => {})}
+        {...tooltip}
       >
         <ShareIcon className={styles.icon} />
       </button>
+    )
+  }
+
+  return (
+    <>
+      {shareText && (
+        <div 
+          className={styles.share}
+          onClick={handleOpenShareModal}
+          {...tooltipId}
+        >
+          <span className={styles.shareText}>Share</span>
+          {shareButton(false)}
+        </div>
+      )}
+      {!shareText && shareButton(true)}
       <ReactTooltip
         id='shareButtonId'
         className='infoTooltipStyle'

--- a/src/components/share-modal/share-modal-styles.module.scss
+++ b/src/components/share-modal/share-modal-styles.module.scss
@@ -172,3 +172,14 @@ $tabsMarginBottom: 8px;
 .icon {
   @extend %icon;
 }
+
+.shareText {
+  color: $white;
+  @extend %subtitle;
+}
+
+.share {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}


### PR DESCRIPTION
This PR adds share functionality to half earth modal when on mobile. 
[PT](https://www.pivotaltracker.com/story/show/169038866)

![image](https://user-images.githubusercontent.com/6136899/66500707-ec8ca380-eab9-11e9-84b3-8f4e1b36f6e1.png)
