### PR TITLE
Release/human encroachment service url update

### DIFF
--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -68,7 +68,7 @@ export const LAYERS_URLS = {
   [RAISIG_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Territorios_Ind%C3%ADgenas_RAISG/VectorTileServer',
   [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ConsProp/FeatureServer',
   [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/TerrestrialVertebrateSpeciesSHP/FeatureServer',
-  [LAND_HUMAN_PRESSURES_IMAGE_LAYER]: 'https://geoxc-imagery.bd.esri.com/arcgis/rest/services/MOL/Human_Impact/ImageServer',
+  [LAND_HUMAN_PRESSURES_IMAGE_LAYER]: 'https://utility.arcgis.com/usrsvcs/servers/f52a6e023d1242e7ad97b2b67495af7b/rest/services/HumanImpact/Human_Impact/ImageServer',
   [SA_AMPHIB_RARITY]: `${bucketUrl}/rarity_1km/amphibians/${templatePattern}` ,
   [SA_AMPHIB_RICHNESS]: `${bucketUrl}/richness_1km/amphibians/${templatePattern}` ,
   [SA_DRAGONFLIES_RARITY]: `${bucketUrl}/rarity_1km/dragonflies/${templatePattern}` ,


### PR DESCRIPTION
This release updates the Human encroachment service URL (the old one is being deprecated)