### PR TITLE
Pass width and height params when fetching an image from contentful

### DIFF
--- a/src/components/featured-place-card/featured-place-card-component.jsx
+++ b/src/components/featured-place-card/featured-place-card-component.jsx
@@ -68,9 +68,9 @@ const FeaturedPlaceCardComponent = ({
               {isOnMobile && <h2 className={styles.title}>{featuredPlace.title}</h2>}
               <div className={styles.pictureContainer}>
                 <ShareModalButton theme={{ shareButton: styles.shareButton}} />
-                {featuredPlace.image && 
+                {featuredPlace.imageUrl && 
                   <img
-                    src={featuredPlace.image}
+                    src={featuredPlace.imageUrl}
                     className={styles.picture}
                     alt={featuredPlace.title}
                     onClick={handleLandscapeTrigger}

--- a/src/components/featured-place-card/featured-place-card-selectors.js
+++ b/src/components/featured-place-card/featured-place-card-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 
 const selectFeaturedMapsList = ({ featuredMapsList }) => featuredMapsList.data || null;
+const selectFeaturedMapPlaces = ({ featuredMapPlaces }) => featuredMapPlaces.data || null;
 
 const getFeaturedMapsList = createSelector(
   selectFeaturedMapsList,
@@ -14,5 +15,6 @@ const getFeaturedMapsList = createSelector(
 )
 
 export default createStructuredSelector({
-  featuredMapsList: getFeaturedMapsList
+  featuredMapsList: getFeaturedMapsList,
+  featuredMapPlaces: selectFeaturedMapPlaces
 })

--- a/src/components/featured-place-card/featured-place-card.js
+++ b/src/components/featured-place-card/featured-place-card.js
@@ -8,6 +8,7 @@ import Component from './featured-place-card-component';
 import mapStateToProps from './featured-place-card-selectors';
 import * as actions from 'actions/url-actions';
 
+const CONFIG = { imageWidth: 300, imageHeight: 190 };
 
 const FeaturedPlaceCardContainer = props => {
   const { view, map, featuredMapsList, selectedFeaturedMap, selectedFeaturedPlace, selectedTaxa, changeUI, isLandscapeMode } = props;
@@ -27,8 +28,8 @@ const FeaturedPlaceCardContainer = props => {
 
   useEffect(() => {
     const fetchData = async () => {
-      setFeaturedPlace({ ...featuredPlace, image: null })
-      const result = await CONTENTFUL.getFeaturedPlaceData(selectedFeaturedPlace);
+      setFeaturedPlace({ ...featuredPlace, image: null });
+      const result = await CONTENTFUL.getFeaturedPlaceData(selectedFeaturedPlace, CONFIG);
       if (result) {
         setFeaturedPlace(result);
       }

--- a/src/components/featured-place-card/featured-place-card.js
+++ b/src/components/featured-place-card/featured-place-card.js
@@ -1,22 +1,19 @@
 import React, { useState, useEffect} from 'react';
 import { connect } from 'react-redux';
 import { orderBy } from 'lodash';
-import CONTENTFUL from 'services/contentful';
 import { findLayerInMap } from 'utils/layer-manager-utils';
 import { FEATURED_PLACES_LAYER } from 'constants/layers-slugs';
 import Component from './featured-place-card-component';
 import mapStateToProps from './featured-place-card-selectors';
 import * as actions from 'actions/url-actions';
 
-const CONFIG = { imageWidth: 300, imageHeight: 190 };
-
 const FeaturedPlaceCardContainer = props => {
-  const { view, map, featuredMapsList, selectedFeaturedMap, selectedFeaturedPlace, selectedTaxa, changeUI, isLandscapeMode } = props;
+  const { view, map, featuredMapsList, selectedFeaturedMap, selectedFeaturedPlace, selectedTaxa, changeUI, isLandscapeMode, featuredMapPlaces } = props;
   const [featuredPlacesList, setFeaturedPlacesList] = useState(null);
   const [featuredMap, setFeaturedMap] = useState(null);
   const [featuredPlacesLayer, setFeaturedPlacesLayer] = useState(null);
   const [featuredPlace, setFeaturedPlace] = useState({
-    image: '',
+    imageUrl: '',
     title: '',
     description: ''
   });
@@ -27,16 +24,8 @@ const FeaturedPlaceCardContainer = props => {
   }, [])
 
   useEffect(() => {
-    const fetchData = async () => {
-      setFeaturedPlace({ ...featuredPlace, image: null });
-      const result = await CONTENTFUL.getFeaturedPlaceData(selectedFeaturedPlace, CONFIG);
-      if (result) {
-        setFeaturedPlace(result);
-      }
-    };
-
-    selectedFeaturedPlace && fetchData();
-  },[selectedFeaturedPlace])
+    featuredMapPlaces && selectedFeaturedMap && selectedFeaturedPlace && setFeaturedPlace({...featuredMapPlaces[selectedFeaturedMap][selectedFeaturedPlace]});
+  },[selectedFeaturedPlace, selectedFeaturedMap])
 
   useEffect(() => {
     if (featuredMapsList) {

--- a/src/redux-modules/featured-map-places/featured-map-places-actions.js
+++ b/src/redux-modules/featured-map-places/featured-map-places-actions.js
@@ -1,11 +1,11 @@
 import { createAction, createThunkAction } from 'redux-tools';
   import CONTENTFUL from 'services/contentful';
-
+  const CONFIG = { imageWidth: 300, imageHeight: 190 };
 export const setFeaturedMapPlaces = createThunkAction('setFeaturedMapPlaces', (slug) => async (dispatch, state) => {
   const { featuredMapPlaces: { data }} = state();
   if (!data || !data[slug]) {
     try {
-      const places = await CONTENTFUL.getFeaturedPlacesData(slug);
+      const places = await CONTENTFUL.getFeaturedPlacesData(slug, CONFIG);
       const dataObject = places.reduce((acc, place) => {
         const description = [];
         place.description && place.description.content.forEach((paragraph) => {

--- a/src/services/contentful.js
+++ b/src/services/contentful.js
@@ -1,6 +1,5 @@
 import { createClient } from 'contentful';
 
-import placeHolder from 'images/speciesPlaceholder.svg'
 const { REACT_APP_CONTENTFUL_SPACE_ID } = process.env;
 const { REACT_APP_CONTENTFUL_TOKEN } = process.env;
 
@@ -59,33 +58,7 @@ function parseFeaturedMaps(featuredMaps) {
   )
 }
 
-async function parseFeaturedPlace(data, config) {
-  const featuredPlace = {
-    title: data.fields.title,
-  };
-  if (data.fields.description) {
-    const description = [];
-    data.fields.description.content.forEach((paragraph) => {
-      const p = paragraph.content.reduce((acc, sentence) => {
-        if (sentence.nodeType === 'text') return acc + sentence.value;
-        return acc;
-      }, '');
-      description.push(p);
-    });
-    featuredPlace.description = description.join('\n');
-  };
-  if (!data.fields.image) {
-    featuredPlace.image = placeHolder;
-    return featuredPlace;
-  }
-  await getContentfulImage(data.fields.image.sys.id, config)
-    .then(mapImageUrl => {
-      featuredPlace.image = mapImageUrl;
-    });
-  return featuredPlace;
-}
-
-async function parseFeaturedPlaces(data) {
+async function parseFeaturedPlaces(data, config) {
   return data.reduce(
     async (acc, place) => {
       const featuredPlace = {
@@ -93,7 +66,7 @@ async function parseFeaturedPlaces(data) {
         title: place.fields.title,
         description: place.fields.description,
       };
-      place.fields.image && await getContentfulImage(place.fields.image.sys.id).then(placeImageUrl => {
+      place.fields.image && await getContentfulImage(place.fields.image.sys.id, config).then(placeImageUrl => {
         featuredPlace.image = placeImageUrl;
       });
       const acummPromise = await acc;
@@ -171,20 +144,12 @@ async function getFeaturedMapData() {
   return null;
 }
 
-async function getFeaturedPlaceData(slug, config) {
-  const data = await fetchContentfulEntry({ contentType: 'featuredPoints', filterField:'nameSlug', filterValue: slug });
-  if (data && data.items && data.items.length > 0) {
-    return parseFeaturedPlace(data.items[0], config);
-  }
-  return null;
-}
-
-async function getFeaturedPlacesData(slug) {
+async function getFeaturedPlacesData(slug, config) {
   const data = await fetchContentfulEntry({ contentType: 'featuredPoints', filterField:'featureSlug', filterValue: slug });
   if (data && data.items && data.items.length > 0) {
-    return parseFeaturedPlaces(data.items);
+    return parseFeaturedPlaces(data.items, config);
   }
   return null;
 }
 
-export default { getEntries: fetchContentfulEntry, getMetadata, getStories, getTexts, getFeaturedMapData, getFeaturedPlaceData, getFeaturedPlacesData };
+export default { getEntries: fetchContentfulEntry, getMetadata, getStories, getTexts, getFeaturedMapData, getFeaturedPlacesData };

--- a/src/services/contentful.js
+++ b/src/services/contentful.js
@@ -59,7 +59,7 @@ function parseFeaturedMaps(featuredMaps) {
   )
 }
 
-async function parseFeaturedPlace(data) {
+async function parseFeaturedPlace(data, config) {
   const featuredPlace = {
     title: data.fields.title,
   };
@@ -78,7 +78,7 @@ async function parseFeaturedPlace(data) {
     featuredPlace.image = placeHolder;
     return featuredPlace;
   }
-  await getContentfulImage(data.fields.image.sys.id)
+  await getContentfulImage(data.fields.image.sys.id, config)
     .then(mapImageUrl => {
       featuredPlace.image = mapImageUrl;
     });
@@ -110,9 +110,12 @@ const parseTexts = items => {
   }, {});
 }
 
-async function getContentfulImage(assetId) {
+async function getContentfulImage(assetId, config) {
   try {
     const imageUrl = await contentfulClient.getAsset(assetId).then(asset => asset.fields.file.url);
+    if (config) {
+      return `${imageUrl}?w=${config.imageWidth || ''}&h=${config.imageHeight || ''}`;
+    }
     return imageUrl;
   } catch (e) {
     console.warn(e);
@@ -168,10 +171,10 @@ async function getFeaturedMapData() {
   return null;
 }
 
-async function getFeaturedPlaceData(slug) {
+async function getFeaturedPlaceData(slug, config) {
   const data = await fetchContentfulEntry({ contentType: 'featuredPoints', filterField:'nameSlug', filterValue: slug });
   if (data && data.items && data.items.length > 0) {
-    return parseFeaturedPlace(data.items[0]);
+    return parseFeaturedPlace(data.items[0], config);
   }
   return null;
 }


### PR DESCRIPTION
This PR introduces image fetching optimization for files from Contentful. 
[PIVOTAL](https://www.pivotaltracker.com/story/show/168868215) | [PREVIEW](https://half-earth-v3-4p5rqk995.now.sh/featuredGlobe?globe=eyJ6b29tIjo2LjAwMDAwMDAwMDAwMDAwMiwiY2VudGVyIjpbOTcuNDk5MzE3NjMxNzAzMzksMjcuNzgyNDg4Nzc2NDM1ODgzXX0%3D&ui=eyJzZWxlY3RlZEZlYXR1cmVkUGxhY2UiOiIxNDUifQ%3D%3D)

By passing the width and the height as URL params, we can specify in pixels the size of an image that we're fetching. Thanks for @simaob for spotting [this example in the contentful documentation](https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/specify-width-&-height/retrieve-an-image/console).
e.g: `?w=300&h=190`

After that, we fetch around 90kb instead of 2mb / 3mb.

Just pass a config object width `imageWidth` and `imageHeight` to the `CONTENTFUL.getFeaturedPlaceData()` function.

A small comparison of random requests (from Zeit stagings):
**Fetching native size:**
![Screenshot from 2020-03-02 12 40 51](https://user-images.githubusercontent.com/15097138/75677769-18384200-5c84-11ea-8a92-241a53d4e3f3.png)

**Fetching defined size:**
![Screenshot from 2020-03-02 12 40 14](https://user-images.githubusercontent.com/15097138/75677777-1a9a9c00-5c84-11ea-9ea2-ed886c998601.png)

