### PR TITLE
Feature/terrestrial and marine grid

### DIFF
--- a/src/components/grid-layer/grid-layer-component.jsx
+++ b/src/components/grid-layer/grid-layer-component.jsx
@@ -23,7 +23,8 @@ const GridLayer = ({ view, setGridCellData, setGridCellGeometry }) => {
   const [viewExtent, setViewExtent] = useState();
   const [terrestrialGridLayer, setTerrestrialGridLayer] = useState(null);
   const [marineGridLayer, setMarineGridLayer] = useState(null);
-  const [ aggregatedCells, setAggregatedCells ] = useState(null);
+  const [aggregatedCells, setAggregatedCells] = useState(null);
+  const [singleCell, setSingleCell] = useState(null)
   const [gridCellGraphic, setGridCellGraphic] = useState(null);
   // References for cleaning up graphics
   const gridCellRef = useRef();
@@ -101,19 +102,30 @@ const GridLayer = ({ view, setGridCellData, setGridCellGeometry }) => {
   }, [aggregatedCells, gridCellGraphic]);
 
   useEffect(() => {
-    if (aggregatedCells && !aggregatedCells.length) {
+    if (aggregatedCells && !aggregatedCells.length > 0) {
       const centerTerrestrialCellQueryObject = centerQuery(terrestrialGridLayer, view.center);
+      const centerMarineCellQueryObject = centerQuery(marineGridLayer, view.center);
       terrestrialGridLayer.queryFeatures(centerTerrestrialCellQueryObject)
-        .then(function(results) {
-          const { features } = results;
-          if (features.length > 0) {
-            createCell(features, 'singleCell');
+      .then(function(results) {
+        const { features: terrestrialCell } = results;
+          if (terrestrialCell.length > 0) {
+            setSingleCell(terrestrialCell);
           } else {
-            console.log('paint marine')
+            marineGridLayer.queryFeatures(centerMarineCellQueryObject)
+            .then(function(results) {
+              const { features: marineCell } = results;
+                setSingleCell(marineCell);
+              })
           }
         })
     }
-  }, [aggregatedCells, gridCellGraphic]);
+  }, [aggregatedCells, viewExtent, gridCellGraphic]);
+
+  useEffect(() => {
+    if (singleCell) {
+      createCell(singleCell, 'singleCell')
+    }
+  }, [singleCell, gridCellGraphic]);
 
 
 

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -50,7 +50,8 @@ import {
 const bucketUrl = "https://storage.googleapis.com/cdn.mol.org/half-earth/tiles/phase2";
 const templatePattern = "{level}/{col}/{row}";
 
-export const BIODIVERSITY_FACETS_SERVICE_URL = "https://utility.arcgis.com/usrsvcs/servers/e6c05ee3ee7b45af9577904bf9238529/rest/services/Biodiversity_Facets_Dissolved/FeatureServer/0";
+export const TERRESTRIAL_GRID_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Global_Terrestrial_Species_Richness_and_Rarity_Patterns_for_Select_Taxa/FeatureServer";
+export const MARINE_GRID_URL = "https://utility.arcgis.com/usrsvcs/servers/e6c05ee3ee7b45af9577904bf9238529/rest/services/Biodiversity_Facets_Dissolved/FeatureServer/0";
 export const PLEDGES_LAYER_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer";
 
 

--- a/src/utils/grid-layer-utils.js
+++ b/src/utils/grid-layer-utils.js
@@ -78,4 +78,4 @@ export const centerQuery = (layer, center) => {
 }
 
 export const getCellsAttributes = features => features.map(gc => gc.attributes);
-export const getCellsIDs = results => results.features.map(gc => gc.attributes.CELL_ID);
+export const getCellsIDs = features => features.map(gc => gc.attributes.CELL_ID);

--- a/src/utils/grid-layer-utils.js
+++ b/src/utils/grid-layer-utils.js
@@ -78,4 +78,4 @@ export const centerQuery = (layer, center) => {
 }
 
 export const getCellsAttributes = features => features.map(gc => gc.attributes);
-export const getCellsIDs = features => features.map(gc => gc.attributes.CELL_ID);
+export const getCellsIDs = features => features.map(gc => gc.attributes.CELL_ID || gc.attributes.ID);


### PR DESCRIPTION
This PR updates the aggregation of grid cells functionality to make use of the new 55km terrestrial grid.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171566485)

This is the first iteration of this updated functionality working with two grids instead of one. A next iteration will be needed when a dedicated Marine grid is provided and the Terrestrial grid is whitelisted to avoid the need of going through the authentication flow.

To test this feature please enter landscape mode and be sure that the aggregation and painting of the grid cells are working as expected.
Some `landscape sidebar` functionality is not gonna work (species, conservation and human encroachment on terrestrial areas) since the new grid has different `cell ids` and the widgets need to be updated with the new summary data.

I've created the `epic/update-data-layers` branch to gather all the epic related features needed to release this functionality, since many of this tasks are dependent on each other. 