### PR TITLE
Fix/block globe interaction in all maps view

### DIFF
--- a/src/components/featured-map-card/featured-map-card-component.jsx
+++ b/src/components/featured-map-card/featured-map-card-component.jsx
@@ -28,7 +28,9 @@ const FeaturesMapCardComponent = ({
 
   // if we first arrive to all maps screen
   useEffect(() => {
-    if(!handle && !isOpen) { spinGlobe(view) }
+    view.when(() => {
+      if(!handle && !isOpen) { spinGlobe(view) }
+    });
   }, []);
 
   const isFeatureMapCardVisible = isOnScreen;

--- a/src/components/scene/scene-component.jsx
+++ b/src/components/scene/scene-component.jsx
@@ -3,7 +3,7 @@ import { loadModules } from 'esri-loader';
 import Spinner from 'components/spinner';
 import styles from 'styles/themes/scene-theme.module.scss';
 
-const SceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMapLoad = null, onViewLoad = null, style, spinner = true }) => {
+const SceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMapLoad = null, onViewLoad = null, style, spinner = true, interactionsDisabled = false }) => {
 
   const [map, setMap] = useState(null);
   const [view, setView] = useState(null);
@@ -51,7 +51,6 @@ const SceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMap
     }
   }, [map, view]);
 
-
   if (loadState === 'loading') {
     return (
     <>
@@ -61,7 +60,7 @@ const SceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMap
     )
   } else if (loadState === 'loaded') {
     return (
-      <div style={{ height: '100%', position: 'relative', width: '100%' }}>
+      <div style={{ height: '100%', position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset' }}>
         <div id={`scene-container-${sceneId}`} className={styles.sceneContainer} style={{width:'100%', height:'100%', backgroundColor: '#0A212E', ...style}}>
           {React.Children.map(children || null, (child, i) => {
             return child && <child.type key={i} map={map} view={view} {...child.props}/>;

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -78,7 +78,7 @@ const DataGlobeComponent = ({
         sceneSettings={sceneSettings}
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
         onMapLoad={onMapLoad}
-        style={{ pointerEvents: (isMapsList || isFeaturedPlaceCard) && !isOnMobile ? 'none' : '' }}
+        interactionsDisabled={(isMapsList || isFeaturedPlaceCard) && !isOnMobile}
       >
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>

--- a/src/pages/featured-globe/featured-globe.js
+++ b/src/pages/featured-globe/featured-globe.js
@@ -61,7 +61,7 @@ const feturedGlobeContainer = props => {
         }
       });
       setHandle(spinningGlobe);
-    })
+    });
   }
 
   const handleGlobeUpdating = (updating) => props.changeGlobe({ isGlobeUpdating: updating });


### PR DESCRIPTION
This small PR disables interactions on a spinning globe when "All maps" view is active.
[PIVOTAL](https://www.pivotaltracker.com/story/show/169602663) | [PREVIEW](https://half-earth-v3-cs9z4xw8f.now.sh/featuredGlobe?globe=eyJ6b29tIjoyLjU1ODEyMTMxMDgwOTc1OCwiY2VudGVyIjpbMTAxLjQ5OTk5OTI4MTk0MTI3LC0wLjc5Mzk1MjIzODEwNDE3ODFdfQ%3D%3D&ui=eyJzZWxlY3RlZFNpZGViYXIiOiJmZWF0dXJlZE1hcENhcmQiLCJzZWxlY3RlZEZlYXR1cmVkTWFwIjoicHJpb3JQbGFjZXMiLCJzZWxlY3RlZEZlYXR1cmVkUGxhY2UiOm51bGx9)

It also fixes the bug I found: once we try to refresh or open the "All maps" view, the app throws an error:
![gja6w-ajlw9](https://user-images.githubusercontent.com/15097138/75792549-0a5aed80-5d66-11ea-9f51-47f09588bcd2.gif)
![Screenshot from 2020-03-03 15 36 23](https://user-images.githubusercontent.com/15097138/75792672-370f0500-5d66-11ea-95ca-1faf83153815.png)

It was trying to spin the globe while `view` object wasn't ready, so I used `view.when(() => {})` to wait for that.
