### PR TITLE
Feature/add area size on top of geodescriber description

### DIFF
--- a/src/components/category-box/category-box-component.jsx
+++ b/src/components/category-box/category-box-component.jsx
@@ -13,7 +13,11 @@ const CategoryBox = ({ title, category, isSidebarOpen, counter }) => (
     )}>
       <p className={styles.title}>
         {title}
-        <span className={styles.counter}>{counter > 0 && counter}</span>
+        {counter > 0 &&
+          <div className={styles.counter}>
+            <span className={styles.counterText}>{counter}</span>
+          </div>
+        }
       </p>
       <div className={styles.categoryContainer}>
         <p className={styles.category}>{category}</p>

--- a/src/components/category-box/category-box-styles.module.scss
+++ b/src/components/category-box/category-box-styles.module.scss
@@ -48,11 +48,25 @@
   margin: 0;
   margin-bottom: 8px;
   user-select: none;
+  display: flex;
+  align-items: baseline;
+}
 
-  .counter {
-    color: $robins-egg-blue;
-    margin-left: 6px;
-  };
+.counter {
+  align-items: center;
+  background-color: $robins-egg-blue;
+  border-radius: 8px;
+  color: $firefly;
+  display: flex;
+  font-weight: $font-weight-bold;
+  height: 16px;
+  justify-content: center;
+  margin-left: 6px;
+  width: 16px;
+}
+
+.counterText {
+  height: 10px;
 }
 
 .categoryContainer {

--- a/src/components/category-box/category-box-styles.module.scss
+++ b/src/components/category-box/category-box-styles.module.scss
@@ -54,9 +54,9 @@
 
 .counter {
   align-items: center;
-  background-color: $robins-egg-blue;
+  background-color: $brand-color-main;
   border-radius: 8px;
-  color: $firefly;
+  color: $dark-text;
   display: flex;
   font-weight: $font-weight-bold;
   height: 16px;

--- a/src/components/fixed-header/fixed-header-styles.module.scss
+++ b/src/components/fixed-header/fixed-header-styles.module.scss
@@ -24,7 +24,7 @@ $icon-size: 25px;
 
 .autoHeightHeader {
   height: unset;
-  padding-bottom: 14px;
+  padding-bottom: 20px;
 }
 
 .shareButton {
@@ -42,7 +42,6 @@ $icon-size: 25px;
   letter-spacing: 2px;
   color: $robins-egg-blue;
   padding: 0;
-  margin-left: -8px; // svg icon has some padding
 }
 
 .buttonText {

--- a/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-component.jsx
+++ b/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-component.jsx
@@ -61,9 +61,10 @@ const GeoDescriptionWidget = (props) => {
         viewMode={VIEW_MODE.LANDSCAPE}
         autoHeight 
       />
-      <p className={styles.description}>
-        {data.description}
-      </p>
+      <div className={styles.descriptionWrapper}>
+        <span className={styles.areaText}>{data.area}</span>
+        <p>{data.description}</p>
+      </div>
     </div>
   );
 };

--- a/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-selectors.js
+++ b/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-selectors.js
@@ -1,11 +1,30 @@
-import { createStructuredSelector } from 'reselect';
+import { createSelector, createStructuredSelector } from 'reselect';
 
 const getGeodescriberData = ({ geoDescription }) => (geoDescription && geoDescription.data) || null;
 const getGeodescriberLoading = ({ geoDescription }) => (geoDescription && geoDescription.loading) || null;
 const getGeodescriberError = ({ geoDescription }) => (geoDescription && geoDescription.error) || null;
 
+const parseGeodescriberText = (text =  '', params) => {
+  const parsedText = Object.keys(params).reduce((acc, key) => {
+    return acc.replace(new RegExp(`{${key}}`, 'g'), params[key]);
+  }, text);
+  return parsedText;
+}
+
+const getData = createSelector(
+  [getGeodescriberData],
+  geodescriberData => {
+    if (!geodescriberData) return null;
+    const { description, description_params, title, title_params } = geodescriberData;
+    const parsedDescription = parseGeodescriberText(description, description_params);
+    const parsedTitle = parseGeodescriberText(title, title_params);
+    const area = `Area: ${description_params.area_0}`;
+    return { description: parsedDescription, title: parsedTitle, area };
+  }
+);
+
 export default createStructuredSelector({
-  data: getGeodescriberData,
+  data: getData,
   loading: getGeodescriberLoading,
   error: getGeodescriberError
 })

--- a/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-styles.module.scss
@@ -61,13 +61,23 @@ $error-gif-size: 120px;
   width: 100%;
 }
 
-.description {
+.descriptionWrapper {
   @extend %bodyText;
+  color: $white;
   padding: $mobile-sidebar-side-paddings;
-  margin: 0;
-  color: white;
 
   @media #{$tablet-portrait} {
     padding: $sidebar-paddings;
   }
+
+  p {
+    margin: 0;
+  }
 }
+
+.areaText {
+  font-weight: $font-weight-bold;
+}
+
+
+

--- a/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-styles.module.scss
+++ b/src/components/landscape-sidebar/geo-description-widget/geo-description-widget-styles.module.scss
@@ -36,7 +36,7 @@ $error-gif-size: 120px;
 }
 
 .errorText {
-  padding: 0 $mobile-sidebar-side-paddings;;
+  padding: 0 $mobile-sidebar-side-paddings;
   color: white;
   font-size: 14px;
   font-weight: 300;
@@ -68,6 +68,7 @@ $error-gif-size: 120px;
 
   @media #{$tablet-portrait} {
     padding: $sidebar-paddings;
+    padding-bottom: 24px;
   }
 
   p {

--- a/src/redux-modules/geo-description/geo-description-reducers.js
+++ b/src/redux-modules/geo-description/geo-description-reducers.js
@@ -8,8 +8,8 @@ function setGeoDescriptionLoading(state, { payload }) {
 
 function setGeoDescriptionReady(state, { payload }) {
   const { data } = payload;
-  const { title, description } = data;
-  return { ...state, error: false, loading: false, data: { title, description } };
+  const { title, title_params, description, description_params } = data;
+  return { ...state, error: false, loading: false, data: { title, title_params, description, description_params } };
 }
 
 function setGeoDescriptionError(state, { payload }) {

--- a/src/redux-modules/geo-description/geo-description-sagas.js
+++ b/src/redux-modules/geo-description/geo-description-sagas.js
@@ -30,7 +30,7 @@ function* fetchGeodescriberData() {
   try {
     yield put(SET_GEO_DESCRIPTION_LOADING());
 
-    const response = yield fetch(REACT_APP_GEO_DESCRIBER_API, {
+    const response = yield fetch(`${REACT_APP_GEO_DESCRIBER_API}&template=True`, {
       method: 'POST',
       headers:{
         'Content-Type': 'application/json'
@@ -39,7 +39,7 @@ function* fetchGeodescriberData() {
     });
     const data = yield response.json();
     // Trigger species ready action
-    yield put(SET_GEO_DESCRIPTION_READY(data))
+    yield put(SET_GEO_DESCRIPTION_READY(data));
   } catch (error) {
     yield put(SET_GEO_DESCRIPTION_ERROR(error));
   } finally {


### PR DESCRIPTION
This PR adds the `Area` line on top of the geodescriber text:
[PIVOTAL](https://www.pivotaltracker.com/story/show/171629244) | [PREVIEW](https://half-earth-v3-c657cxzv4.now.sh/featuredGlobe?globe=eyJ6b29tIjozLjE3MTAyMjg0MTU4MTE0OTQsImNlbnRlciI6WzE2Ljk1MTU1MzYwMDAwMDA2OCwwLjExNjk1OTAwMTQzMTM1NTAxXX0%3D)

![image](https://user-images.githubusercontent.com/15097138/75910222-6a749100-5e45-11ea-9698-37322ecd86a8.png)

Also, I updated the selected layers counter styles, requested by fanny:
[PIVOTAL](https://www.pivotaltracker.com/story/show/169534134)

![image](https://user-images.githubusercontent.com/15097138/75910129-34cfa800-5e45-11ea-87ca-b292117f4e65.png)
