### PR TITLE
Feature/update conservation widget with 55km data

### DIFF
--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-component.jsx
@@ -12,7 +12,7 @@ import styles from './conservation-efforts-widget-styles.module.scss';
 const ConservationEffortsDescription = ({ allProp, rawData }) => {
   return (
     <p className={styles.description}>
-      Of the current landscape, <span className={styles.boldFont}>{allProp.toFixed(2)}% is under protection.</span>
+      Of the current landscape, <span className={styles.boldFont}>{allProp}% is under protection.</span>
       {rawData[COMMUNITY_BASED] > rawData[PROTECTED] ? 'The majority of the protected areas are community managed.' : ''}
     </p>
   )

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -53,7 +53,7 @@ const getConservationAreasLogic = createSelector(
 
     const areas = {};
     areas[NOT_UNDER_CONSERVATION] = 100 - (not_community_prop + community_prop); // set NOT_UNDER_CONSERVATION first to render the slice below all others
-
+    console.log('conservationEfforts: ',conservationEfforts)
     if (not_community_prop + community_prop > all_prop) {
       areas[COMMUNITY_BASED] = all_prop - not_community_prop;
       areas[PROTECTED] = not_community_prop;
@@ -62,12 +62,7 @@ const getConservationAreasLogic = createSelector(
       areas[COMMUNITY_BASED] = community_prop;
       areas[PROTECTED] = not_community_prop;
     }
-    
-    // const areas = {
-    //   [NOT_UNDER_CONSERVATION]: 100 - (all_prop),
-    //   [COMMUNITY_BASED]: community_prop,
-    //   [PROTECTED]: not_community_prop
-    // };
+
     return areas;
   }
 )

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -25,21 +25,21 @@ const getConservationEfforts = createSelector(
     const conservationEfforts = cellData.reduce((acc, current) => {
       return {
         ...acc,
-        [current.CELL_ID]: {
-          WDPA_prop: current.WDPA_prop,
-          RAISG_prop: current.RAISG_prop,
-          all_prop: current.all_prop
+        [current.ID]: {
+          community: current.comm_prot_prop,
+          not_community: current.not_comm_prot_prop,
+          all: current.all_prot_prop
         }
         }
     }, {});
     const values = Object.values(conservationEfforts)
     const gridCellsLength = Object.keys(conservationEfforts).length;
-    const WDPA_prop = sumBy(values, 'WDPA_prop') / gridCellsLength;
-    const RAISG_prop = sumBy(values, 'RAISG_prop') / gridCellsLength;
-    const all_prop = sumBy(values, 'all_prop') / gridCellsLength;
+    const community_prop = sumBy(values, 'community') / gridCellsLength;
+    const not_community_prop = sumBy(values, 'not_community') / gridCellsLength;
+    const all_prop = sumBy(values, 'all') / gridCellsLength;
     return {
-      WDPA_prop,
-      RAISG_prop,
+      community_prop,
+      not_community_prop,
       all_prop
     }
   }
@@ -49,18 +49,12 @@ const getConservationAreasLogic = createSelector(
   [getConservationEfforts],
   (conservationEfforts) => {
     if (!conservationEfforts) return null;
-    const areas = {};
-    const { WDPA_prop, RAISG_prop, all_prop } = conservationEfforts;
-    areas[NOT_UNDER_CONSERVATION] = (1 - (WDPA_prop +RAISG_prop)) * 100; // set NOT_UNDER_CONSERVATION first to render the slice below all others
-    if (WDPA_prop + RAISG_prop > all_prop) {
-      areas[COMMUNITY_BASED] = (all_prop - WDPA_prop) * 100;
-      areas[PROTECTED] = WDPA_prop * 100;
-      areas[NOT_UNDER_CONSERVATION] = 100 - (areas[PROTECTED] + areas[COMMUNITY_BASED]);
-    } else {
-      areas[COMMUNITY_BASED] = RAISG_prop * 100;
-      areas[PROTECTED] = WDPA_prop * 100;
-    }
-
+    const { community_prop, not_community_prop, all_prop } = conservationEfforts;
+    const areas = {
+      [NOT_UNDER_CONSERVATION]: 100 - (all_prop),
+      [COMMUNITY_BASED]: community_prop,
+      [PROTECTED]: not_community_prop
+    };
     return areas;
   }
 )
@@ -69,7 +63,7 @@ const getAllPropsForDynamicSentence = createSelector(
   [getConservationEfforts],
   (conservationEfforts) => {
     if (!conservationEfforts) return null;
-    return conservationEfforts.all_prop * 100;
+    return conservationEfforts.all_prop.toFixed(2);
   }
 )
 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -53,7 +53,6 @@ const getConservationAreasLogic = createSelector(
 
     const areas = {};
     areas[NOT_UNDER_CONSERVATION] = 100 - (not_community_prop + community_prop); // set NOT_UNDER_CONSERVATION first to render the slice below all others
-    console.log('conservationEfforts: ',conservationEfforts)
     if (not_community_prop + community_prop > all_prop) {
       areas[COMMUNITY_BASED] = all_prop - not_community_prop;
       areas[PROTECTED] = not_community_prop;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -50,11 +50,24 @@ const getConservationAreasLogic = createSelector(
   (conservationEfforts) => {
     if (!conservationEfforts) return null;
     const { community_prop, not_community_prop, all_prop } = conservationEfforts;
-    const areas = {
-      [NOT_UNDER_CONSERVATION]: 100 - (all_prop),
-      [COMMUNITY_BASED]: community_prop,
-      [PROTECTED]: not_community_prop
-    };
+
+    const areas = {};
+    areas[NOT_UNDER_CONSERVATION] = 100 - (not_community_prop + community_prop); // set NOT_UNDER_CONSERVATION first to render the slice below all others
+
+    if (not_community_prop + community_prop > all_prop) {
+      areas[COMMUNITY_BASED] = all_prop - not_community_prop;
+      areas[PROTECTED] = not_community_prop;
+      areas[NOT_UNDER_CONSERVATION] = 100 - (areas[PROTECTED] + areas[COMMUNITY_BASED]);
+    } else {
+      areas[COMMUNITY_BASED] = community_prop;
+      areas[PROTECTED] = not_community_prop;
+    }
+    
+    // const areas = {
+    //   [NOT_UNDER_CONSERVATION]: 100 - (all_prop),
+    //   [COMMUNITY_BASED]: community_prop,
+    //   [PROTECTED]: not_community_prop
+    // };
     return areas;
   }
 )

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -72,7 +72,7 @@ const ConservationEffortsWidget = (props) => {
   useEffect(() => {
     if (terrestrialCellData && queryParams) {
       setConservationEfforts({ data: null, loading: true });
-      queryParams.where = `ID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
+      queryParams.where = `ID IN (${terrestrialCellData.map(i => i.ID).join(', ')})`;
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
         setConservationEfforts({ data: features.map(c => c.attributes), loading: false });

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -39,7 +39,7 @@ const ConservationEffortsWidget = (props) => {
         const consPropLayer = new FeatureLayer({
           url: layersConfig[GRID_CELLS_PROTECTED_AREAS_PERCENTAGE].url
         });
-        setConservationPropsLayer(consPropLayer)
+        setConservationPropsLayer(consPropLayer);
       });
     }
   }, []);
@@ -72,7 +72,7 @@ const ConservationEffortsWidget = (props) => {
   useEffect(() => {
     if (terrestrialCellData && queryParams) {
       setConservationEfforts({ data: null, loading: true });
-      queryParams.where = `CELL_ID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
+      queryParams.where = `ID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
         setConservationEfforts({ data: features.map(c => c.attributes), loading: false });

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -71,7 +71,7 @@ export const LAYERS_URLS = {
   [COMMUNITY_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/community_based/VectorTileServer',
   [RAISIG_AREAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/RAISG_Tls/FeatureServer',
   [RAISIG_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Territorios_Ind%C3%ADgenas_RAISG/VectorTileServer',
-  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ConsProp/FeatureServer',
+  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/grid_55km_prot_prop/FeatureServer',
   [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/TerrestrialVertebrateSpeciesSHP/FeatureServer',
   [GRID_CELLS_LAND_HUMAN_PRESSURES_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/human_pressure_55km/FeatureServer',
   [URBAN_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/gHM_Urban_levels_1_to_6/MapServer',

--- a/src/selectors/grid-cell-selectors.js
+++ b/src/selectors/grid-cell-selectors.js
@@ -6,7 +6,7 @@ export const getTerrestrialCellData = createSelector(
   [selectCellData],
   cellData => {
     if (!cellData) return null;
-    return cellData;
+    return cellData.filter(c => c.ID);
   }
 )
 

--- a/src/selectors/grid-cell-selectors.js
+++ b/src/selectors/grid-cell-selectors.js
@@ -6,7 +6,7 @@ export const getTerrestrialCellData = createSelector(
   [selectCellData],
   cellData => {
     if (!cellData) return null;
-    return cellData.filter(c => c.ID);
+    return cellData;
   }
 )
 


### PR DESCRIPTION
This PR updates the conservation efforts widget with new 55km data. The conservation efforts data requires double-checking, but this feature can be merged independently.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171566937)