### PR TITLE
Change range values for protea-rarity legend item

### DIFF
--- a/src/constants/mol-layers-configs.js
+++ b/src/constants/mol-layers-configs.js
@@ -1184,7 +1184,7 @@ export const legendConfigs = {
     items: [
     {
     color: "#0664f6",
-    value: "-10.9"
+    value: "low"
     },
     {
     color: "#0572d6",
@@ -1216,7 +1216,7 @@ export const legendConfigs = {
     },
     {
     color: "#fde300",
-    value: "-6.2"
+    value: "high"
     }
     ],
     title: "Protea regional rarity"


### PR DESCRIPTION
This tiny PR changes the hardcoded min/max values of the protea-rarity legend item - from numeric values to `low` and `high` labels.
[PIVOTAL](https://www.pivotaltracker.com/story/show/169544548)

![image](https://user-images.githubusercontent.com/15097138/76306203-62da3f80-62be-11ea-8177-af9fc8328145.png)