### PR TITLE
Feature/blend marine and terrestrial layers

### DIFF
--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -46,9 +46,9 @@ const getConservationEfforts = createSelector(
       } else if (current.CELL_ID) {
         conservationData = {
           [current.CELL_ID]: {
-            community: current.RAISG_prop,
-            not_community: current.WDPA_prop,
-            all: current.all_prop
+            community: current.RAISG_prop * 100,
+            not_community: current.WDPA_prop * 100,
+            all: current.all_prop * 100
           }
         }
       }

--- a/src/selectors/grid-cell-selectors.js
+++ b/src/selectors/grid-cell-selectors.js
@@ -9,6 +9,14 @@ export const getTerrestrialCellData = createSelector(
     if (!cellData) return null;
     return cellData.filter(c => c.ID);
   }
+);
+
+export const getMarineCellData = createSelector(
+  [selectCellData],
+  cellData => {
+    if (!cellData) return null;
+    return cellData.filter(c => c.CELL_ID);
+  }
 )
 
 export const getTerrestrialHumanPressures = createSelector(

--- a/src/selectors/grid-cell-selectors.js
+++ b/src/selectors/grid-cell-selectors.js
@@ -11,14 +11,6 @@ export const getTerrestrialCellData = createSelector(
   }
 );
 
-export const getMarineCellData = createSelector(
-  [selectCellData],
-  cellData => {
-    if (!cellData) return null;
-    return cellData.filter(c => c.CELL_ID);
-  }
-)
-
 export const getTerrestrialHumanPressures = createSelector(
   [selectCellData],
   cellData=> {


### PR DESCRIPTION
This PR implements fetching the marine layers from the old layer `ConsProp`. It follows this thread started on Slack. 
So what I did here:
1. Fetching old `ConsProp` layer,
2. Querying the features from this layer,
3. Turn `marine` and `terrestrial` query into promises, and use `Promise.all()` to resolve them,
4. Save all layers to one `conservationEffortsData` state,
5. Calculate conservation efforts data depending on the structure of the cell (old or new)

The problem is that even when we fetch the marine data,  `RAISG_prop` `WDPA_prop` and `all_prop` are equal to zero, not sure why.