### PR TITLE
Feature/update species widget

### DIFF
--- a/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
@@ -1,5 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
-import { getTerrestrialCellData } from 'selectors/grid-cell-selectors';
+import { getTerrestrialCellData, getMarineCellData } from 'selectors/grid-cell-selectors';
 import { format, precisionPrefix, formatPrefix } from 'd3-format';
 import { uniqBy } from "lodash";
 import IUCNList from 'constants/iucn-list';
@@ -98,6 +98,7 @@ const getSelectedSpeciesData = createSelector([getData, getSelectedSpeciesName],
 export default createStructuredSelector({
   data: getData,
   terrestrialCellData: getTerrestrialCellData,
+  marineCellData: getMarineCellData,
   selectedSpeciesData: getSelectedSpeciesData,
   loading: getSpeciesDataLoading
 }); 

--- a/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
@@ -39,7 +39,7 @@ const getSelectedSpeciesName = (state, props) =>
 
 const getUniqeSpeciesData= createSelector(getSpeciesData, speciesData => {
   if (!speciesData) return [];
-  return uniqBy(speciesData, 'scntfcn');
+  return uniqBy(speciesData, 'species_name');
 })
 
 const calculateChartPosition = (angle, propRange) => {
@@ -63,15 +63,15 @@ const getChartData = (speciesData, taxa, startAngle)  => {
     const angle = startAngle + angleOffset + angleOffset * i;
     return {
       id: s.HBWID,
-      name: s.cmmn_nm !== " " ? s.cmmn_nm : s.scntfcn,
-      scientificName: s.scntfcn,
-      rangeArea: formatRangeArea(s.RANGE_A),
-      proportion: format(".2%")(s.PROP_RA),
+      name: s.common_name !== " " ? s.common_name : s.species_name,
+      scientificName: s.species_name,
+      rangeArea: formatRangeArea(s.RANGE_AREA_KM2),
+      proportion: format(".2%")(s.PROP_RANGE_PROT),
       taxa: s.taxa,
       imageURL: s.url_sp.startsWith('http') ? s.url_sp : null,
-      pointCoordinates: calculateChartPosition(angle, s.PROP_RA),
-      color: getDotColor(s.PROP_RA),
-      iucnCategory: IUCNList[s.iucn_ct] || '-'
+      pointCoordinates: calculateChartPosition(angle, s.PROP_RANGE_PROT),
+      color: getDotColor(s.PROP_RANGE_PROT),
+      iucnCategory: IUCNList[s.iucn_cat] || '-'
     }
   });
   return chartData;
@@ -79,10 +79,10 @@ const getChartData = (speciesData, taxa, startAngle)  => {
 
 const getData = createSelector(getUniqeSpeciesData, speciesData => {
   if (!speciesData) return null;
-  const birdsData =  getChartData(speciesData, 'birds', 0);
-  const reptilesData = getChartData(speciesData, 'reptiles', 90);
-  const mammalsData = getChartData(speciesData, 'mammals', 180)
-  const amphibiansData = getChartData(speciesData, 'amphibians', 270);
+  const birdsData = getChartData(speciesData, 'bird', 0);
+  const reptilesData = getChartData(speciesData, 'reptile', 90);
+  const mammalsData = getChartData(speciesData, 'mammal', 180)
+  const amphibiansData = getChartData(speciesData, 'amphibian', 270);
   const speciesChartData = [...birdsData, ...reptilesData, ...mammalsData, ...amphibiansData];
   return speciesChartData.length ? speciesChartData : null;
 });

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -11,7 +11,7 @@ import { LAYERS_URLS } from 'constants/layers-urls';
 
 const actions = { ...setSpeciesActions, ...urlActions };
 
-const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, marineCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
+const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
   const [speciesLayer, setLayer] = useState(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -46,16 +46,15 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, marineCellData, da
     updateSelectedSpecies(newIndex);
   }
 
-  const querySpeciesData = (terrestrialCells, marineCells) => {
+  const querySpeciesData = (terrestrialCells) => {
     setSpeciesData({ data: null, loading: true });
-    const cellData = [...terrestrialCells, ...marineCells];
     const query = speciesLayer.createQuery();
     query.outFields = [ "HBWID", "species_name", "taxa", "status", "RANGE_AREA_KM2", "PROP_RANGE_PROT", "url_sp", "common_name", "iucn_cat", "raw_name"];
-    query.where = `HBWID IN (${cellData.map(i => i.ID || i.CELL_ID).join(', ')})`;
+    query.where = `HBWID IN (${terrestrialCells.map(i => i.ID).join(', ')})`;
     speciesLayer.queryFeatures(query).then(function(results){
       const { features } = results;
       setSpeciesData({ data: features.map(c => c.attributes), loading: false });
-    });
+    }).catch(err => console.error(err.message));
   };
 
   const fetchSpeciesLayer = () => {
@@ -73,14 +72,14 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, marineCellData, da
   }, []);
  
   useEffect(() => {
-    if (speciesLayer && (terrestrialCellData || marineCellData)) {
-      if(terrestrialCellData.length || marineCellData.length) {
-        querySpeciesData(terrestrialCellData, marineCellData);
+    if (speciesLayer && terrestrialCellData) {
+      if(terrestrialCellData.length) {
+        querySpeciesData(terrestrialCellData);
       } else {
         setSpeciesData({ data: null })
       }
     }
-  }, [speciesLayer, terrestrialCellData, marineCellData])
+  }, [speciesLayer, terrestrialCellData])
 
   useEffect(() => {
     if(data) {

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -11,7 +11,7 @@ import { LAYERS_URLS } from 'constants/layers-urls';
 
 const actions = { ...setSpeciesActions, ...urlActions };
 
-const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
+const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, marineCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
   const [speciesLayer, setLayer] = useState(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -46,11 +46,12 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
     updateSelectedSpecies(newIndex);
   }
 
-  const querySpeciesData = () => {
+  const querySpeciesData = (terrestrialCells, marineCells) => {
     setSpeciesData({ data: null, loading: true });
+    const cellData = [...terrestrialCells, ...marineCells];
     const query = speciesLayer.createQuery();
     query.outFields = [ "HBWID", "species_name", "taxa", "status", "RANGE_AREA_KM2", "PROP_RANGE_PROT", "url_sp", "common_name", "iucn_cat", "raw_name"];
-    query.where = `HBWID IN (${terrestrialCellData.map(i => i.ID).join(', ')})`;
+    query.where = `HBWID IN (${cellData.map(i => i.ID || i.CELL_ID).join(', ')})`;
     speciesLayer.queryFeatures(query).then(function(results){
       const { features } = results;
       setSpeciesData({ data: features.map(c => c.attributes), loading: false });
@@ -72,14 +73,14 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
   }, []);
  
   useEffect(() => {
-    if (speciesLayer && terrestrialCellData) {
-      if(terrestrialCellData.length) {
-        querySpeciesData();
+    if (speciesLayer && (terrestrialCellData || marineCellData)) {
+      if(terrestrialCellData.length || marineCellData.length) {
+        querySpeciesData(terrestrialCellData, marineCellData);
       } else {
         setSpeciesData({ data: null })
       }
     }
-  }, [speciesLayer, terrestrialCellData])
+  }, [speciesLayer, terrestrialCellData, marineCellData])
 
   useEffect(() => {
     if(data) {

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -6,14 +6,14 @@ import SpeciesWidgetComponent from './species-widget-component';
 import mapStateToProps from './species-widget-selectors';
 import { loadModules } from 'esri-loader';
 import * as urlActions from 'actions/url-actions';
-import { layersConfig } from 'constants/mol-layers-configs';
 import { GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER } from 'constants/layers-slugs';
+import { LAYERS_URLS } from 'constants/layers-urls';
 
 const actions = { ...setSpeciesActions, ...urlActions };
 
 const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe, selectedSpeciesData, loading }) => {
   const [speciesLayer, setLayer] = useState(null);
-  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [selectedIndex, setSelectedIndex] = useState(0);
 
   const updateSelectedSpecies = (index) => {
     const { name } = data[index];
@@ -49,8 +49,8 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
   const querySpeciesData = () => {
     setSpeciesData({ data: null, loading: true });
     const query = speciesLayer.createQuery();
-    query.where = `HBWID IN (${terrestrialCellData.map(i => i.CELL_ID).join(', ')})`;
-    query.outFields = [ "HBWID", "scntfcn", "taxa", "RANGE_A", "PROP_RA", "url_sp", "cmmn_nm", "iucn_ct"];
+    query.outFields = [ "HBWID", "species_name", "taxa", "status", "RANGE_AREA_KM2", "PROP_RANGE_PROT", "url_sp", "common_name", "iucn_cat", "raw_name"];
+    query.where = `HBWID IN (${terrestrialCellData.map(i => i.ID).join(', ')})`;
     speciesLayer.queryFeatures(query).then(function(results){
       const { features } = results;
       setSpeciesData({ data: features.map(c => c.attributes), loading: false });
@@ -61,7 +61,7 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
     loadModules(["esri/layers/FeatureLayer"]).then(([FeatureLayer]) => {
       const _speciesLayer = new FeatureLayer({
         // URL to the service
-        url: layersConfig[GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER].url,
+        url: LAYERS_URLS[GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER],
       });
       setLayer(_speciesLayer)
     })

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -72,7 +72,7 @@ export const LAYERS_URLS = {
   [RAISIG_AREAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/RAISG_Tls/FeatureServer',
   [RAISIG_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Territorios_Ind%C3%ADgenas_RAISG/VectorTileServer',
   [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ConsProp/FeatureServer',
-  [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/TerrestrialVertebrateSpeciesSHP/FeatureServer',
+  [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/species_data_55km/FeatureServer',
   [GRID_CELLS_LAND_HUMAN_PRESSURES_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/human_pressure_55km/FeatureServer',
   [URBAN_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/gHM_Urban_levels_1_to_6/MapServer',
   [IRRIGATED_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/gHM_Irrigated_levels_1_to_6/MapServer',


### PR DESCRIPTION
[PIVOTAL](https://www.pivotaltracker.com/story/show/171566930)

This PR adapts the landscape Species widget to the new aggregated grid cells and uses the recomputed species data (driven by the new 55km grid).

![image](https://user-images.githubusercontent.com/6906348/76836354-fc5e9f80-6830-11ea-85ed-456876eb445d.png)
