### PR TITLE
Feature/display country on local scene

### DIFF
--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -37,10 +37,10 @@ const CountryBorderLayer = props => {
       .then(async function(results){
         const { features } = results;
         const { geometry } = features[0];
+        view.goTo(geometry);
         const borderPolygon = await createPolygonGeometry(geometry);
         if (borderGraphic) { borderGraphic.geometry = borderPolygon };
         setCountryExtentReady(geometry.extent);
-        view.goTo(geometry);
       })
       .catch((error) => {
         setCountryExtentError()

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -3,6 +3,8 @@ import { loadModules } from 'esri-loader';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER, GRAPHIC_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
 import { gridCellDefaultStyles } from 'constants/landscape-view-constants';
+import { connect } from 'react-redux';
+import actions from 'redux_modules/country-extent';
 
 import {
   createGraphic,
@@ -11,21 +13,26 @@ import {
 } from 'utils/graphic-layer-utils';
 
 const CountryBorderLayer = props => {
-  const { view, countryISO } = props;
+  const { view, countryISO, setCountryExtentLoading, setCountryExtentReady, setCountryExtentError } = props;
 
   const [countryLayer, setCountryLayer] = useState(null);
   const [borderGraphic, setBorderGraphic] = useState(null);
+  const [spatialReference, setSpatialReference] = useState(null);
 
   //Create the graphics layer on mount
   useEffect(() => {
     loadModules(
       [
         "esri/Graphic",
-        "esri/layers/GraphicsLayer"
-      ]).then(([Graphic, GraphicsLayer]) => {
+        "esri/layers/GraphicsLayer",
+        "esri/geometry/SpatialReference"
+      ]).then(([Graphic, GraphicsLayer, SpatialReference]) => {
         const _borderGraphic = createGraphic(Graphic, gridCellDefaultStyles);
         const graphicsLayer = createGraphicLayer(GraphicsLayer, _borderGraphic, GRAPHIC_LAYER);
         setBorderGraphic(_borderGraphic);
+        const _spatialReference = new SpatialReference();
+        _spatialReference.wkid = 102100;
+        setSpatialReference(_spatialReference);
         view.map.add(graphicsLayer);
       })
   }, [])
@@ -33,15 +40,19 @@ const CountryBorderLayer = props => {
   const queryCountryData = () => {
     const query = countryLayer.createQuery();
     query.where = `GID_0 = '${countryISO}'`;
+    query.outSpatialReference = spatialReference;
+    setCountryExtentLoading();
     countryLayer.queryFeatures(query)
       .then(async function(results){
         const { features } = results;
         const { geometry } = features[0];
         const borderPolygon = await createPolygonGeometry(geometry);
         if (borderGraphic) { borderGraphic.geometry = borderPolygon };
+        setCountryExtentReady(geometry.extent);
         view.goTo(geometry);
       })
       .catch((error) => {
+        setCountryExtentError()
         console.warn(error);
       });
   };
@@ -66,4 +77,4 @@ const CountryBorderLayer = props => {
   return null
 }
 
-export default CountryBorderLayer;
+export default connect(null, actions)(CountryBorderLayer);

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -13,26 +13,17 @@ import {
 } from 'utils/graphic-layer-utils';
 
 const CountryBorderLayer = props => {
-  const { view, countryISO, setCountryExtentLoading, setCountryExtentReady, setCountryExtentError } = props;
+  const { view, spatialReference, countryISO, setCountryExtentLoading, setCountryExtentReady, setCountryExtentError } = props;
 
   const [countryLayer, setCountryLayer] = useState(null);
   const [borderGraphic, setBorderGraphic] = useState(null);
-  const [spatialReference, setSpatialReference] = useState(null);
 
   //Create the graphics layer on mount
   useEffect(() => {
-    loadModules(
-      [
-        "esri/Graphic",
-        "esri/layers/GraphicsLayer",
-        "esri/geometry/SpatialReference"
-      ]).then(([Graphic, GraphicsLayer, SpatialReference]) => {
+    loadModules(["esri/Graphic","esri/layers/GraphicsLayer"]).then(([Graphic, GraphicsLayer]) => {
         const _borderGraphic = createGraphic(Graphic, gridCellDefaultStyles);
         const graphicsLayer = createGraphicLayer(GraphicsLayer, _borderGraphic, GRAPHIC_LAYER);
         setBorderGraphic(_borderGraphic);
-        const _spatialReference = new SpatialReference();
-        _spatialReference.wkid = 102100;
-        setSpatialReference(_spatialReference);
         view.map.add(graphicsLayer);
       })
   }, [])
@@ -68,10 +59,10 @@ const CountryBorderLayer = props => {
   }, []);
 
   useEffect(() => {
-    if (countryLayer) {
+    if (countryLayer && spatialReference) {
       queryCountryData();
     }
-  }, [countryLayer, countryISO, borderGraphic]);
+  }, [countryLayer, countryISO, borderGraphic, spatialReference]);
 
 
   return null

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -1,82 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-import { loadModules } from 'esri-loader';
 import Spinner from 'components/spinner';
 import styles from 'styles/themes/scene-theme.module.scss';
 
-const DoubleSceneComponent = ({ sceneId, children, loaderOptions, sceneSettings, onMapLoad = null, onViewLoad = null, style, spinner = true, interactionsDisabled = false, sceneMode, countryExtent }) => {
-  const [map, setMap] = useState(null);
-  const [viewGlobal, setViewGlobal] = useState(null);
-  const [viewLocal, setViewLocal] = useState(null);
-  const [loadState, setLoadState] = useState('loading');
-  const [spatialReference, setSpatialReference] = useState(null);
-
-  useEffect(() => {
-    loadModules(["esri/WebScene"], loaderOptions)
-      .then(([WebScene]) => {
-        const _map = new WebScene({
-          portalItem: {
-            id: sceneId
-          }
-        });
-        _map.load().then(map => { 
-          setMap(map);
-          onMapLoad && onMapLoad(map);
-        })
-      })
-      .catch(err => {
-        console.error(err);
-      });
-  }, [])
-
-  useEffect(() => {
-    if (map) {
-      loadModules(["esri/views/SceneView", "esri/geometry/SpatialReference"], loaderOptions)
-        .then(([SceneView, SpatialReference]) => {
-
-          const _spatialReference = new SpatialReference();
-          _spatialReference.wkid = 102100;
-          setSpatialReference(_spatialReference);
-
-          const _viewGlobal = new SceneView({
-            map: map,
-            container: `scene-global-container-${sceneId}`,
-            ...sceneSettings,
-            spatialReference
-          });
-          setViewGlobal(_viewGlobal);
-
-          const _viewLocal = new SceneView({
-            map: map,
-            container: `scene-local-container-${sceneId}`,
-            ...sceneSettings,
-            viewingMode: 'local',
-            spatialReference,
-          });
-          setViewLocal(_viewLocal);
-        })
-        .catch(err => {
-          console.error(err);
-        });
-    }
-  },[map]);
-
-  useEffect(() => {
-    if(viewLocal && spatialReference && countryExtent) {
-      const expandedCountryExtent = countryExtent.clone().expand(1.5); //add paddings around country borders
-      viewLocal.clippingArea = expandedCountryExtent;
-      viewLocal.extent = expandedCountryExtent;
-      viewLocal.goTo({ target: expandedCountryExtent, tilt: 40, }, { animate: false });
-    };
-  },[countryExtent]);
+const DoubleSceneComponent = props => {
+  const {
+    map,
+    viewGlobal,
+    viewLocal,
+    spatialReference,
+    spinner,
+    loadState,
+    sceneId,
+    children,
+    interactionsDisabled,
+    style,
+    sceneMode
+  } = props;
   
-  useEffect(() => {
-    if (map && viewGlobal && viewLocal) {
-      setLoadState('loaded');
-      onViewLoad && onViewLoad(map, viewGlobal)
-    }
-  }, [map, viewGlobal, viewLocal]);
-
   return (
     <>
       {loadState === 'loading' && <Spinner spinnerWithOverlay initialLoading display={spinner}/>}

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -66,6 +66,7 @@ const DoubleSceneComponent = ({ sceneId, children, loaderOptions, sceneSettings,
       const expandedCountryExtent = countryExtent.clone().expand(1.5); //add paddings around country borders
       viewLocal.clippingArea = expandedCountryExtent;
       viewLocal.extent = expandedCountryExtent;
+      viewLocal.goTo({ target: expandedCountryExtent, tilt: 40, }, { animate: false });
     };
   },[countryExtent]);
   
@@ -84,7 +85,7 @@ const DoubleSceneComponent = ({ sceneId, children, loaderOptions, sceneSettings,
           {loadState === 'loaded' && 
             ReactDOM.createPortal(
               React.Children.map(children || null, (child, i) => {
-                return child && <child.type key={i} map={map} view={viewGlobal} viewLocal={viewLocal} {...child.props}/>;
+                return child && <child.type key={i} map={map} view={viewGlobal} viewLocal={viewLocal} spatialReference={spatialReference} {...child.props}/>;
               })
               ,
               document.getElementById("root")

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -34,7 +34,7 @@ const DoubleScene = props => {
       .catch(err => {
         console.error(err);
       });
-  }, [])
+  }, []);
 
   useEffect(() => {
     if (map) {
@@ -58,7 +58,7 @@ const DoubleScene = props => {
             container: `scene-local-container-${sceneId}`,
             ...sceneSettings,
             viewingMode: 'local',
-            spatialReference,
+            spatialReference
           });
           setViewLocal(_viewLocal);
         })
@@ -73,7 +73,9 @@ const DoubleScene = props => {
       const expandedCountryExtent = countryExtent.clone().expand(1.5); //add paddings around country borders
       viewLocal.clippingArea = expandedCountryExtent;
       viewLocal.extent = expandedCountryExtent;
-      viewLocal.goTo({ target: expandedCountryExtent, tilt: 40, }, { animate: false });
+      viewLocal.when(() => {
+        viewLocal.goTo({ target: expandedCountryExtent, tilt: 40 }, { animate: false });
+      });
     };
   },[countryExtent]);
   

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -1,3 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { loadModules } from 'esri-loader';
 import Component from './double-scene-component';
 
-export default Component;
+const DoubleScene = props => {
+  const {
+    sceneId,
+    loaderOptions,
+    sceneSettings,
+    onMapLoad = null,
+    onViewLoad = null,
+    countryExtent
+  } = props;
+
+  const [map, setMap] = useState(null);
+  const [viewGlobal, setViewGlobal] = useState(null);
+  const [viewLocal, setViewLocal] = useState(null);
+  const [loadState, setLoadState] = useState('loading');
+  const [spatialReference, setSpatialReference] = useState(null);
+
+  useEffect(() => {
+    loadModules(["esri/WebScene"], loaderOptions)
+      .then(([WebScene]) => {
+        const _map = new WebScene({
+          portalItem: {
+            id: sceneId
+          }
+        });
+        _map.load().then(map => { 
+          setMap(map);
+          onMapLoad && onMapLoad(map);
+        })
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  }, [])
+
+  useEffect(() => {
+    if (map) {
+      loadModules(["esri/views/SceneView", "esri/geometry/SpatialReference"], loaderOptions)
+        .then(([SceneView, SpatialReference]) => {
+
+          const _spatialReference = new SpatialReference();
+          _spatialReference.wkid = 102100;
+          setSpatialReference(_spatialReference);
+
+          const _viewGlobal = new SceneView({
+            map: map,
+            container: `scene-global-container-${sceneId}`,
+            ...sceneSettings,
+            spatialReference
+          });
+          setViewGlobal(_viewGlobal);
+
+          const _viewLocal = new SceneView({
+            map: map,
+            container: `scene-local-container-${sceneId}`,
+            ...sceneSettings,
+            viewingMode: 'local',
+            spatialReference,
+          });
+          setViewLocal(_viewLocal);
+        })
+        .catch(err => {
+          console.error(err);
+        });
+    }
+  },[map]);
+
+  useEffect(() => {
+    if(viewLocal && spatialReference && countryExtent) {
+      const expandedCountryExtent = countryExtent.clone().expand(1.5); //add paddings around country borders
+      viewLocal.clippingArea = expandedCountryExtent;
+      viewLocal.extent = expandedCountryExtent;
+      viewLocal.goTo({ target: expandedCountryExtent, tilt: 40, }, { animate: false });
+    };
+  },[countryExtent]);
+  
+  useEffect(() => {
+    if (map && viewGlobal && viewLocal) {
+      setLoadState('loaded');
+      onViewLoad && onViewLoad(map, viewGlobal)
+    }
+  }, [map, viewGlobal, viewLocal]);
+
+  return (
+    <Component
+      {...props}
+      map={map}
+      viewGlobal={viewGlobal}
+      viewLocal={viewLocal}
+      loadState={loadState}
+      spatialReference={spatialReference}
+    />
+  );
+}
+
+export default DoubleScene;

--- a/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
+++ b/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
@@ -37,6 +37,10 @@ const exaggeratedElevationLayerComponent = ({ map, exaggeration = 2}) => {
     
       map.ground.layers = [new ExaggeratedElevationLayer()];
     })
+
+    return () => {
+      map.ground.layers = [];
+    }
   }, [])
 
   return null

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -8,7 +8,7 @@ import MinimapWidget from 'components/widgets/minimap-widget';
 
 import { isMobile } from 'constants/responsive';
 
-const WidgetsComponent = ({ map, view, isFullscreenActive, isHEModalOpen = false, isNotMapsList = true, hidden = false}) => {
+const WidgetsComponent = ({ map, view, viewLocal, isFullscreenActive, isHEModalOpen = false, isNotMapsList = true, hidden = false}) => {
   const isOnMobile = isMobile();
   const hiddenWidget = hidden || isOnMobile;
   return (
@@ -18,6 +18,12 @@ const WidgetsComponent = ({ map, view, isFullscreenActive, isHEModalOpen = false
       <MinimapWidget map={map} view={view} hidden={hiddenWidget} isHEModalOpen={isHEModalOpen} />
       {!isOnMobile && <SearchWidget map={map} view={view} hidden={hiddenWidget} />}
       <LocationWidget map={map} view={view} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
+      {viewLocal && (
+        <>
+          <ToggleUiWidget map={map} view={viewLocal} isFullscreenActive={isFullscreenActive} hidden={hiddenWidget}/>
+          <ZoomWidget map={map} view={viewLocal} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
+        </>
+      )}
     </>
   )
 }

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -57,6 +57,7 @@ const DataGlobeComponent = ({
 
   return (
     <>
+      {console.log(`land exaggeration: ${isLandscapeMode || sceneMode === 'local'}`)}
       <DoubleScene
         sceneId='e96f61b2e79442b698ec2cec68af6db9'
         sceneSettings={sceneSettings}

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -49,7 +49,8 @@ const DataGlobeComponent = ({
   activeOption,
   isHEModalOpen,
   countryISO,
-  sceneMode
+  sceneMode,
+  countryExtent
 }) => {
   
   const isOnMobile = isMobile();
@@ -62,6 +63,7 @@ const DataGlobeComponent = ({
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
         onMapLoad={(map) => handleMapLoad(map, activeLayers)}
         sceneMode={sceneMode}
+        countryExtent={countryExtent}
       >
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>
@@ -107,7 +109,7 @@ const DataGlobeComponent = ({
         <CountryLabelsLayer countryISO={countryISO} isLandscapeMode={isLandscapeMode}/>
         {countryISO && <CountryBorderLayer countryISO={countryISO}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
-        {isLandscapeMode && <TerrainExaggerationLayer exaggeration={3}/>}
+        {(isLandscapeMode || sceneMode === 'local') && <TerrainExaggerationLayer exaggeration={sceneMode === 'local' ? 10 : 3}/>}
         {isLandscapeMode && <LabelsLayer />}
         {isLandscapeMode && <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />}
       </DoubleScene>

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -57,7 +57,6 @@ const DataGlobeComponent = ({
 
   return (
     <>
-      {console.log(`land exaggeration: ${isLandscapeMode || sceneMode === 'local'}`)}
       <DoubleScene
         sceneId='e96f61b2e79442b698ec2cec68af6db9'
         sceneSettings={sceneSettings}

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -109,7 +109,7 @@ const DataGlobeComponent = ({
         <CountryLabelsLayer countryISO={countryISO} isLandscapeMode={isLandscapeMode}/>
         {countryISO && <CountryBorderLayer countryISO={countryISO}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
-        {(isLandscapeMode || sceneMode === 'local') && <TerrainExaggerationLayer exaggeration={sceneMode === 'local' ? 10 : 3}/>}
+        {(isLandscapeMode || sceneMode === 'local') && <TerrainExaggerationLayer exaggeration={sceneMode === 'local' ? 20 : 3}/>}
         {isLandscapeMode && <LabelsLayer />}
         {isLandscapeMode && <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />}
       </DoubleScene>

--- a/src/pages/data-globe/data-globe-initial-state.js
+++ b/src/pages/data-globe/data-globe-initial-state.js
@@ -9,6 +9,7 @@ import {
 
 import { DEFAULT_OPACITY, LAYERS_CATEGORIES } from 'constants/mol-layers-configs'
 
+
 export default {
   globe: {
     activeLayers: [
@@ -41,7 +42,7 @@ export default {
     },
     ui: {
       components: []
-    }
+    },
   },
   ui: {
     isSidebarOpen: false,

--- a/src/pages/data-globe/data-globe-selectors.js
+++ b/src/pages/data-globe/data-globe-selectors.js
@@ -6,6 +6,7 @@ import initialState from './data-globe-initial-state';
 
 const selectBiodiversityData = ({ biodiversityData }) => biodiversityData && (biodiversityData.data || null);
 const selectMetadataData = ({ metadata }) => metadata && (!isEmpty(metadata.data) || null);
+const selectCountryExtent = ({ countryExtent }) => countryExtent ? countryExtent.data : null;
 
 const getGlobeSettings = createSelector(selectGlobeUrlState, globeUrlState => {
   return {
@@ -58,5 +59,6 @@ export default createStructuredSelector({
   isHEModalOpen: getHalfEarthModalOpen,
   activeOption: getActiveOption, // mobile
   isLandscapeSidebarCollapsed: getLandscapeSidebarCollapsed, // mobile
-  sceneMode: getSceneMode
+  sceneMode: getSceneMode,
+  countryExtent: selectCountryExtent
 })

--- a/src/redux-modules/country-extent/country-extent-actions.js
+++ b/src/redux-modules/country-extent/country-extent-actions.js
@@ -1,0 +1,11 @@
+import { createAction } from 'redux-tools';
+
+export const setCountryExtentLoading = createAction(
+  'SET_COUNTRY_EXTENT_LOADING'
+);
+export const setCountryExtentReady = createAction(
+  'SET_COUNTRY_EXTENT_READY'
+);
+export const setCountryExtentError = createAction(
+  'SET_COUNTRY_EXTENT_ERROR'
+);

--- a/src/redux-modules/country-extent/country-extent-reducers.js
+++ b/src/redux-modules/country-extent/country-extent-reducers.js
@@ -1,0 +1,21 @@
+import * as actions from './country-extent-actions';
+
+export const initialState = { loading: false, error: false, data: null };
+
+function setCountryExtentLoading(state) {
+  return { ...state, loading: true };
+}
+
+function setCountryExtentReady(state, { payload }) {
+  return { ...state, error: false, loading: false, data: payload };
+}
+
+function setCountryExtentError(state, { payload }) {
+  return { ...state, loading: false, data: null, error: payload };
+}
+
+export default {
+  [actions.setCountryExtentLoading]: setCountryExtentLoading,
+  [actions.setCountryExtentReady]: setCountryExtentReady,
+  [actions.setCountryExtentError]: setCountryExtentError
+};

--- a/src/redux-modules/country-extent/country-extent.js
+++ b/src/redux-modules/country-extent/country-extent.js
@@ -1,0 +1,10 @@
+import reducerRegistry from 'reducerRegistry';
+
+import * as actions from './country-extent-actions';
+import reducers, { initialState } from './country-extent-reducers';
+
+const reduxConfig = { actions, reducers, initialState };
+
+reducerRegistry.registerModule('countryExtent', reduxConfig);
+
+export default actions;


### PR DESCRIPTION
This PR enables passing the country extent to the local scene. It's the first iteration of this task, in the second iteration I'd like to focus on the appearance and styles of the local scene. I added here a new redux state called `countryExtent` which enables passing current extent from CountryBorderLayer to the local scene. Another issue I faced here was the need for using the same spatial reference on both scenes and the border layer to make the entire flow work - it's good to know that for future reference.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171951583)

Other changes:
- Add zoom and toggle UI widgets to the local scene,
- Fix missing elevation layer

![v6pzy-co9gr](https://user-images.githubusercontent.com/15097138/77627308-9e237200-6f3e-11ea-9cd6-45c8c89f910b.gif)
