### PR TITLE
Bug/country labels display

### DIFF
--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -8,7 +8,7 @@ import mapPinIcon from 'icons/map_pin.svg'
 import { layersConfig } from 'constants/mol-layers-configs';
 
 const CountryLabelsLayerComponent = props => {
-  const { map, isLandscapeMode, countryISO, isCountryMode } = props;
+  const { map, isLandscapeMode, countryISO, isCountryMode, countryName } = props;
 
   const [labelingInfo, setLabelingInfo] = useState(null)
   const [layerReady, setLayerReady] = useState(false)
@@ -21,6 +21,7 @@ const CountryLabelsLayerComponent = props => {
         labelExpressionInfo: {
           expression: "$feature.NAME_0"
         },
+        where: countryName ? `NAME_0 <> '${countryName}'` : null,
         symbol: {
           type: "text",
           color: [213,207,202],
@@ -35,7 +36,7 @@ const CountryLabelsLayerComponent = props => {
       });
       setLabelingInfo(_labelingInfo);
     })
-  }, []);
+  }, [countryName]);
 
   useEffect(() => {
       if (labelingInfo) {
@@ -65,18 +66,6 @@ const CountryLabelsLayerComponent = props => {
       layerReady.labelsVisible = !isLandscapeMode;
     }
   }, [layerReady, isLandscapeMode])
-
-  useEffect(() => {
-    if (layerReady && labelingInfo) {
-      if (isCountryMode) {
-        labelingInfo.where = "NAME_0 <> 'Spain'";
-        layerReady.labelingInfo = [labelingInfo];
-      } else {
-        labelingInfo.where = null;
-        layerReady.labelingInfo = [labelingInfo];
-      }
-    }
-  }, [layerReady, labelingInfo, isCountryMode])
 
   useEffect(() => {
     let graphicLayer;

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -21,7 +21,7 @@ const CountryLabelsLayerComponent = props => {
         labelExpressionInfo: {
           expression: "$feature.NAME_0"
         },
-        where: countryName ? `NAME_0 <> '${countryName}'` : null,
+        where: countryName && isCountryMode ? `NAME_0 <> '${countryName}'` : null,
         symbol: {
           type: "text",
           color: [213,207,202],
@@ -36,7 +36,7 @@ const CountryLabelsLayerComponent = props => {
       });
       setLabelingInfo(_labelingInfo);
     })
-  }, [countryName]);
+  }, [countryName, isCountryMode]);
 
   useEffect(() => {
       if (labelingInfo) {

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -8,7 +8,7 @@ import mapPinIcon from 'icons/map_pin.svg'
 import { layersConfig } from 'constants/mol-layers-configs';
 
 const CountryLabelsLayerComponent = props => {
-  const { map, isLandscapeMode, countryISO } = props;
+  const { map, isLandscapeMode, countryISO, isCountryMode } = props;
 
   const [labelingInfo, setLabelingInfo] = useState(null)
   const [layerReady, setLayerReady] = useState(false)
@@ -65,6 +65,18 @@ const CountryLabelsLayerComponent = props => {
       layerReady.labelsVisible = !isLandscapeMode;
     }
   }, [layerReady, isLandscapeMode])
+
+  useEffect(() => {
+    if (layerReady && labelingInfo) {
+      if (isCountryMode) {
+        labelingInfo.where = "NAME_0 <> 'Spain'";
+        layerReady.labelingInfo = [labelingInfo];
+      } else {
+        labelingInfo.where = null;
+        layerReady.labelingInfo = [labelingInfo];
+      }
+    }
+  }, [layerReady, labelingInfo, isCountryMode])
 
   useEffect(() => {
     let graphicLayer;

--- a/src/components/country-labels-layer/country-labels-layer.js
+++ b/src/components/country-labels-layer/country-labels-layer.js
@@ -8,7 +8,7 @@ const actions = {...urlActions}
 
 const CountryLabelsLayerContainer = props => {
   const { view, changeGlobe, countryISO } = props;
-
+  
   const getLabelsLayer = (results) => {
     if (!results.length) return null;
     return results.find(result => result.graphic.layer.id === COUNTRIES_LABELS_FEATURE_LAYER)

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -118,7 +118,7 @@ const DataGlobeComponent = ({
         {isCountryMode && <LocalSceneSidebar countryISO={countryISO} countryName={countryName} isFullscreenActive={isFullscreenActive}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}
-        {isLandscapeMode && <LabelsLayer />}
+        <LabelsLayer isLandscapeMode={isLandscapeMode} isCountryMode={isCountryMode} countryName={countryName}/>
         {isLandscapeMode && <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />}
       </DoubleScene>
       <TutorialModal />

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -113,7 +113,7 @@ const DataGlobeComponent = ({
           setRasters={setRasters}
           selectedSpecies={selectedSpecies}
         />
-        <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode}/>
+        <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode} countryName={countryName}/>
         <CountryBorderLayer countryISO={countryISO}/>
         {isCountryMode && <LocalSceneSidebar countryISO={countryISO} countryName={countryName} isFullscreenActive={isFullscreenActive}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -113,7 +113,7 @@ const DataGlobeComponent = ({
           setRasters={setRasters}
           selectedSpecies={selectedSpecies}
         />
-        {!isCountryMode && <CountryLabelsLayer countryISO={countryISO} isLandscapeMode={isLandscapeMode}/>}
+        <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode}/>
         <CountryBorderLayer countryISO={countryISO}/>
         {isCountryMode && <LocalSceneSidebar countryISO={countryISO} countryName={countryName} isFullscreenActive={isFullscreenActive}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}

--- a/src/pages/data-globe/data-globe-initial-state.js
+++ b/src/pages/data-globe/data-globe-initial-state.js
@@ -2,7 +2,6 @@ import {
   FIREFLY_BASEMAP_LAYER,
   GRAPHIC_LAYER,
   LANDSCAPE_FEATURES_LABELS_LAYER,
-  COUNTRIES_LABELS_FEATURE_LAYER,
   CITIES_LABELS_LAYER,
   ALL_TAXA_RARITY
 } from 'constants/layers-slugs';
@@ -13,11 +12,10 @@ import { DEFAULT_OPACITY, LAYERS_CATEGORIES } from 'constants/mol-layers-configs
 export default {
   globe: {
     activeLayers: [
-      { title: FIREFLY_BASEMAP_LAYER }, 
+      { title: FIREFLY_BASEMAP_LAYER },
       { title: GRAPHIC_LAYER },
       { title: CITIES_LABELS_LAYER },
       { title: LANDSCAPE_FEATURES_LABELS_LAYER },
-      { title: COUNTRIES_LABELS_FEATURE_LAYER },
       { title: ALL_TAXA_RARITY, opacity: DEFAULT_OPACITY, category: LAYERS_CATEGORIES.BIODIVERSITY }
     ],
     zoom: 1,

--- a/src/pages/data-globe/data-globe-initial-state.js
+++ b/src/pages/data-globe/data-globe-initial-state.js
@@ -3,6 +3,7 @@ import {
   GRAPHIC_LAYER,
   LANDSCAPE_FEATURES_LABELS_LAYER,
   CITIES_LABELS_LAYER,
+  COUNTRIES_LABELS_FEATURE_LAYER,
   ALL_TAXA_RARITY
 } from 'constants/layers-slugs';
 
@@ -15,6 +16,7 @@ export default {
       { title: FIREFLY_BASEMAP_LAYER },
       { title: GRAPHIC_LAYER },
       { title: CITIES_LABELS_LAYER },
+      { title: COUNTRIES_LABELS_FEATURE_LAYER },
       { title: LANDSCAPE_FEATURES_LABELS_LAYER },
       { title: ALL_TAXA_RARITY, opacity: DEFAULT_OPACITY, category: LAYERS_CATEGORIES.BIODIVERSITY }
     ],


### PR DESCRIPTION
This PR loads country labels when landing in `local scene` (even on reload).
It also avoids displaying selected country label on `local scene` to avoid redundancy. [Check this message for context](https://vizzuality.slack.com/archives/C0DBNP1TM/p1585320952014600)

[PIVOTAL](https://www.pivotaltracker.com/story/show/172063704)