### PR TITLE
Feature/metadata service migration

### DIFF
--- a/src/components/legend/legend.js
+++ b/src/components/legend/legend.js
@@ -8,7 +8,7 @@ import * as urlActions from 'actions/url-actions';
 import { changeLayerOpacityAnalyticsEvent, openLayerInfoModalAnalyticsEvent, removeLayerAnalyticsEvent, changeLayersOrderAnalyticsEvent } from 'actions/google-analytics-actions';
 import { VIEW_MODE } from 'constants/google-analytics-constants';
 import { LEGEND_GROUPED_LAYERS_GROUPS } from 'constants/layers-groups';
-
+import { MERGED_LAND_HUMAN_PRESSURES } from 'constants/layers-slugs';
 import mapStateToProps from './legend-selectors';
 
 const actions = {...metadataActions, ...urlActions, changeLayerOpacityAnalyticsEvent, openLayerInfoModalAnalyticsEvent, removeLayerAnalyticsEvent, changeLayersOrderAnalyticsEvent };
@@ -36,7 +36,7 @@ const LegendContainer = props => {
   }
 
   const getSlug = (layer) => {
-    if(layer.title.includes('human_pressures')) return 'human-pressures-all';
+    if(layer.title.includes('human_pressures')) return MERGED_LAND_HUMAN_PRESSURES;
     return layer.legendConfig.slug || layer.title;
   }
 

--- a/src/components/modal-metadata/modal-metadata-component.jsx
+++ b/src/components/modal-metadata/modal-metadata-component.jsx
@@ -67,7 +67,7 @@ const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata }) => {
                 )
             }
             {
-              metadata && metadata.molLogo && (
+              metadata && metadata.molLogo === "true" && (
               <div className={styles.logoContainer}>
                 <a href="https://mol.org/" target="_blank" rel="noopener noreferrer">
                   <img

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -54,7 +54,7 @@ import {
 export const TERRESTRIAL_GRID_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Global_Terrestrial_Species_Richness_and_Rarity_Patterns_for_Select_Taxa/FeatureServer";
 export const MARINE_GRID_URL = "https://utility.arcgis.com/usrsvcs/servers/e6c05ee3ee7b45af9577904bf9238529/rest/services/Biodiversity_Facets_Dissolved/FeatureServer/0";
 export const PLEDGES_LAYER_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer";
-
+export const METADATA_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Metadata2/FeatureServer/0';
 
 export const LAYERS_URLS = {
   [LANDSCAPE_FEATURES_LABELS_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/LandscapeUniqueRivers/FeatureServer',

--- a/src/constants/mol-layers-configs.js
+++ b/src/constants/mol-layers-configs.js
@@ -575,7 +575,7 @@ export const legendConfigs = {
   },
   [SA_AMPHIB_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '25 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Amphibian regional richness"
   },
   [SA_DRAGONFLIES_RARITY]: {
@@ -585,7 +585,7 @@ export const legendConfigs = {
   },
   [SA_DRAGONFLIES_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '3', '68 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Dragonflies richness"
   },
   [SA_MAMMALS_RARITY]: {
@@ -595,7 +595,7 @@ export const legendConfigs = {
   },
   [SA_MAMMALS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '49 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Mammals regional richness"
   },
   [SA_BIRDS_RARITY]: {
@@ -605,7 +605,7 @@ export const legendConfigs = {
   },
   [SA_BIRDS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '375 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Birds regional richness"
   },
   [SA_RESTIO_RARITY]: {
@@ -615,7 +615,7 @@ export const legendConfigs = {
   },
   [SA_RESTIO_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '166 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Restio regional richness"
   },
   [SA_PROTEA_RARITY]: {
@@ -623,7 +623,7 @@ export const legendConfigs = {
     items: [
     {
     color: "#0664f6",
-    value: "-10.9"
+    value: "low"
     },
     {
     color: "#0572d6",
@@ -655,14 +655,14 @@ export const legendConfigs = {
     },
     {
     color: "#fde300",
-    value: "-6.2"
+    value: "high"
     }
     ],
     title: "Protea regional rarity"
   },
   [SA_PROTEA_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '68 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Protea regional richness"
   },
   [SA_REPTILES_RARITY]: {
@@ -672,13 +672,13 @@ export const legendConfigs = {
   },
   [SA_REPTILES_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '57 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Reptiles regional richness"
   },
   // Hummingbirds
   [HUMMINGBIRDS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '92 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Hummingbirds richness"
   },
   [HUMMINGBIRDS_RARITY]: {
@@ -694,7 +694,7 @@ export const legendConfigs = {
   },
   [MAMMALS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '225 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Mammals richness"
   },
   [FISHES_RARITY]: {
@@ -704,7 +704,7 @@ export const legendConfigs = {
   },
   [FISHES_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '3,469 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Fishes richness"
   },
   [CONIFERS_RARITY]: {
@@ -714,7 +714,7 @@ export const legendConfigs = {
   },
   [CONIFERS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '49 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Conifers richness"
   },
   [CACTI_RARITY]: {
@@ -724,7 +724,7 @@ export const legendConfigs = {
   },
   [CACTI_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '93 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Cacti richness"
   },
   [AMPHIB_RARITY]: {
@@ -734,12 +734,12 @@ export const legendConfigs = {
   },
   [AMPHIB_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '180 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Amphibian richness"
   },
   [REPTILES_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', 'xxxx species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Reptile richness"
   },
   [REPTILES_RARITY]: {
@@ -754,7 +754,7 @@ export const legendConfigs = {
   },
   [BIRDS_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '0', '1,010 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Birds richness"
   },
   [ALL_TAXA_RARITY]: {
@@ -764,7 +764,7 @@ export const legendConfigs = {
   },
   [ALL_TAXA_RICHNESS]: {
     type: "gradient",
-    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, '1', '3,469 species'),
+    items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "All groups richness"
   }
 }

--- a/src/constants/protected-areas.js
+++ b/src/constants/protected-areas.js
@@ -12,7 +12,7 @@ export const WDPALayers = [
     id: PROTECTED_AREAS_VECTOR_TILE_LAYER,
     title: PROTECTED_AREAS_VECTOR_TILE_LAYER,
     theme: 'overrideCheckbox-protected-areas',
-    slug: 'biosphere-reserves'
+    slug: PROTECTED_AREAS_VECTOR_TILE_LAYER
   },
   {
     name: 'Community-based',
@@ -20,7 +20,7 @@ export const WDPALayers = [
     id: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
     title: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
     theme: 'overrideCheckbox-community-areas',
-    slug: 'community-conservation',
+    slug: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
     groupedLayer: true
   }
 ]
@@ -35,7 +35,7 @@ export const legendConfigs = {
       }
     ],
     title: "Community-based protected areas",
-    slug: "community-conservation",
+    slug: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
     groupedLayer: true
   },
   [PROTECTED_AREAS_VECTOR_TILE_LAYER]: {
@@ -47,6 +47,6 @@ export const legendConfigs = {
       }
     ],
     title: "All protected areas",
-    slug: "biosphere-reserves"
+    slug: PROTECTED_AREAS_VECTOR_TILE_LAYER
   }
 }

--- a/src/redux-modules/metadata/metadata-actions.js
+++ b/src/redux-modules/metadata/metadata-actions.js
@@ -1,5 +1,5 @@
 import { createAction, createThunkAction } from 'redux-tools';
-import CONTENTFUL from 'services/contentful';
+import MetadataService from 'services/metadata-service';
 
 export const setModalMetadataParams = createAction('setModalMetadataParams');
 
@@ -17,7 +17,7 @@ export const fetchModalMetaDataFail = createAction('fetchModalMetaDataFail');
 export const fetchModalMetaDataReady = createAction('fetchModalMetaDataReady');
 export const fetchModalMetaData = createThunkAction('fetchModalMetaData', slug => async dispatch => {
   try {
-    const data = await CONTENTFUL.getMetadata(slug);
+    const data = await MetadataService.getMetadata(slug);
     dispatch(fetchModalMetaDataReady({ slug, data }));
   } catch (e) {
     console.warn(e);

--- a/src/services/metadata-service.js
+++ b/src/services/metadata-service.js
@@ -1,0 +1,25 @@
+import { loadModules } from 'esri-loader';
+import { METADATA_SERVICE_URL } from 'constants/layers-urls';
+
+function getMetadata(slug) {
+  return new Promise((resolve, reject) => {
+    loadModules(["esri/tasks/QueryTask", "esri/tasks/support/Query"]).then(([QueryTask, Query]) => {
+      var queryTask = new QueryTask({
+        url: METADATA_SERVICE_URL
+      });
+      var query = new Query();
+      query.outFields = ["*"];
+      query.where = `layerSlug = '${slug}'`;
+      queryTask.execute(query).then(function(results){
+          if (results && results.features && results.features.length > 0) {
+            resolve(results.features[0].attributes);
+          }
+          resolve(null);
+      });
+    }).catch(error => reject(error));
+  })
+}
+
+export default {
+  getMetadata
+}


### PR DESCRIPTION
## Move metadata service from Contentful to ESRI based service
### Description
This PR changes the metadata service to request layers metadata from an ESRI based service (a Feature service layer that acts as a table).
[Here](https://eowilson.maps.arcgis.com/home/item.html?id=d899a4364fe5431b8c5bef826ad4430d#data) you can check the service item with the associated data stored on the table.
This PR also updates the legend for biodiversity richness layers. More context on this [basecamp thread](https://eowilson.maps.arcgis.com/home/item.html?id=d899a4364fe5431b8c5bef826ad4430d#data).
### Testing instructions
Display layers metadata modal by clicking on the `info` button displayed on layers selectors after toggling on a given layer. Also check the metadata modal by activating it through the legend items.
### Feature relevant tickets
[Legend update ticket](https://www.pivotaltracker.com/story/show/172101315)
[Metadata service layer](https://www.pivotaltracker.com/story/show/171566880)