### PR TITLE
Feature/adjust local scene styles

### DIFF
--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -37,10 +37,10 @@ const CountryBorderLayer = props => {
       .then(async function(results){
         const { features } = results;
         const { geometry } = features[0];
+        setCountryExtentReady(geometry.extent);
         view.goTo(geometry);
         const borderPolygon = await createPolygonGeometry(geometry);
         if (borderGraphic) { borderGraphic.geometry = borderPolygon };
-        setCountryExtentReady(geometry.extent);
       })
       .catch((error) => {
         setCountryExtentError()

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER, GRAPHIC_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
-import { gridCellDefaultStyles } from 'constants/landscape-view-constants';
+import { GRID_CELL_STYLES } from 'constants/graphic-styles';
 import { connect } from 'react-redux';
 import actions from 'redux_modules/country-extent';
 
@@ -21,7 +21,7 @@ const CountryBorderLayer = props => {
   //Create the graphics layer on mount
   useEffect(() => {
     loadModules(["esri/Graphic","esri/layers/GraphicsLayer"]).then(([Graphic, GraphicsLayer]) => {
-        const _borderGraphic = createGraphic(Graphic, gridCellDefaultStyles);
+        const _borderGraphic = createGraphic(Graphic, GRID_CELL_STYLES);
         const graphicsLayer = createGraphicLayer(GraphicsLayer, [_borderGraphic], GRAPHIC_LAYER);
         setBorderGraphic(_borderGraphic);
         view.map.add(graphicsLayer);

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -37,11 +37,11 @@ const CountryBorderLayer = props => {
       .then(async function(results){
         const { features } = results;
         const { geometry } = features[0];
-        setCountryExtentReady(geometry.extent);
         view.goTo(geometry);
         if (borderGraphic) { 
           borderGraphic.geometry = await createPolygonGeometry(geometry);
         };
+        setCountryExtentReady(geometry.extent);
       })
       .catch((error) => {
         setCountryExtentError()

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -68,6 +68,7 @@ const CountryBorderLayer = props => {
   useEffect(() => {
     if (borderGraphic && !countryISO) {
       borderGraphic.geometry = null;
+      setCountryExtentReady(null);
     }
   },[countryISO])
 

--- a/src/components/country-border-layer/country-border-layer.js
+++ b/src/components/country-border-layer/country-border-layer.js
@@ -37,10 +37,10 @@ const CountryBorderLayer = props => {
       .then(async function(results){
         const { features } = results;
         const { geometry } = features[0];
-        setCountryExtentReady(geometry.extent);
         view.goTo(geometry);
         const borderPolygon = await createPolygonGeometry(geometry);
         if (borderGraphic) { borderGraphic.geometry = borderPolygon };
+        setCountryExtentReady(geometry.extent);
       })
       .catch((error) => {
         setCountryExtentError()

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -80,7 +80,7 @@ const CountryLabelsLayerComponent = props => {
           const { features } = results;
           countryPinMarker = new Graphic({
             geometry: features[0].geometry,
-            symbol: simplePictureMarker(mapPinIcon)
+            symbol: simplePictureMarker(mapPinIcon, { height: 24, width: 24 })
           });
           countryPinMarker.symbol.yoffset = -10;
           graphicLayer.add(countryPinMarker)

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -63,7 +63,7 @@ const CountryLabelsLayerComponent = props => {
   useEffect(() => {
     let graphicLayer;
     let countryPinMarker;
-    if (layerReady) {
+    if (layerReady && !isCountryMode) {
       loadModules(["esri/Graphic"])
       .then(([Graphic]) => {
         graphicLayer = findLayerInMap(GRAPHIC_LAYER, map);
@@ -82,7 +82,7 @@ const CountryLabelsLayerComponent = props => {
     return function cleanUp() {
       if (graphicLayer) { graphicLayer.remove(countryPinMarker)}
     }
-  }, [layerReady, countryExtent])
+  }, [layerReady, countryExtent, isCountryMode])
 
   useEffect(() => {
     if (layerReady) {

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -1,11 +1,14 @@
 import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import { handleLayerCreation } from 'utils/layer-manager-utils';
-import { COUNTRIES_LABELS_FEATURE_LAYER } from 'constants/layers-slugs';
+import { COUNTRIES_LABELS_FEATURE_LAYER, GRAPHIC_LAYER } from 'constants/layers-slugs';
+import { findLayerInMap } from 'utils/layer-manager-utils';
+import { simplePictureMarker } from 'utils/graphic-layer-utils';
+import mapPinIcon from 'icons/map_pin.svg'
 import { layersConfig } from 'constants/mol-layers-configs';
 
 const CountryLabelsLayerComponent = props => {
-  const { map, isLandscapeMode, isCountryMode, countryName } = props;
+  const { map, isLandscapeMode, isCountryMode, countryName, countryISO, countryExtent } = props;
 
   const [labelingInfo, setLabelingInfo] = useState(null)
   const [layerReady, setLayerReady] = useState(false)
@@ -52,11 +55,34 @@ const CountryLabelsLayerComponent = props => {
                 size: 0
               }
             }
-            console.log(layer)
             setLayerReady(layer);
           });
       }
   }, [labelingInfo])
+
+  useEffect(() => {
+    let graphicLayer;
+    let countryPinMarker;
+    if (layerReady) {
+      loadModules(["esri/Graphic"])
+      .then(([Graphic]) => {
+        graphicLayer = findLayerInMap(GRAPHIC_LAYER, map);
+        const query = layerReady.createQuery();
+        query.where = `GID_0 = '${countryISO}'`
+        layerReady.queryFeatures(query).then(results => {
+          const { features } = results;
+          countryPinMarker = new Graphic({
+            geometry: features[0].geometry,
+            symbol: simplePictureMarker(mapPinIcon, { height: 24, width: 24, yoffset: -10 })
+          });
+          graphicLayer.add(countryPinMarker)
+        })
+      })
+    }
+    return function cleanUp() {
+      if (graphicLayer) { graphicLayer.remove(countryPinMarker)}
+    }
+  }, [layerReady, countryExtent])
 
   useEffect(() => {
     if (layerReady) {

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -1,14 +1,11 @@
 import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import { handleLayerCreation } from 'utils/layer-manager-utils';
-import { COUNTRIES_LABELS_FEATURE_LAYER, GRAPHIC_LAYER } from 'constants/layers-slugs';
-import { findLayerInMap } from 'utils/layer-manager-utils';
-import { simplePictureMarker } from 'utils/graphic-layer-utils';
-import mapPinIcon from 'icons/map_pin.svg'
+import { COUNTRIES_LABELS_FEATURE_LAYER } from 'constants/layers-slugs';
 import { layersConfig } from 'constants/mol-layers-configs';
 
 const CountryLabelsLayerComponent = props => {
-  const { map, isLandscapeMode, countryISO, isCountryMode, countryName } = props;
+  const { map, isLandscapeMode, isCountryMode, countryName } = props;
 
   const [labelingInfo, setLabelingInfo] = useState(null)
   const [layerReady, setLayerReady] = useState(false)
@@ -55,6 +52,7 @@ const CountryLabelsLayerComponent = props => {
                 size: 0
               }
             }
+            console.log(layer)
             setLayerReady(layer);
           });
       }
@@ -66,31 +64,6 @@ const CountryLabelsLayerComponent = props => {
       layerReady.labelsVisible = !isLandscapeMode;
     }
   }, [layerReady, isLandscapeMode])
-
-  useEffect(() => {
-    let graphicLayer;
-    let countryPinMarker;
-    if (layerReady) {
-      loadModules(["esri/Graphic"])
-      .then(([Graphic]) => {
-        graphicLayer = findLayerInMap(GRAPHIC_LAYER, map);
-        const query = layerReady.createQuery();
-        query.where = `GID_0 = '${countryISO}'`
-        layerReady.queryFeatures(query).then(results => {
-          const { features } = results;
-          countryPinMarker = new Graphic({
-            geometry: features[0].geometry,
-            symbol: simplePictureMarker(mapPinIcon, { height: 24, width: 24 })
-          });
-          countryPinMarker.symbol.yoffset = -10;
-          graphicLayer.add(countryPinMarker)
-        })
-      })
-    }
-    return function cleanUp() {
-      if (graphicLayer) { graphicLayer.remove(countryPinMarker)}
-    }
-  }, [layerReady, countryISO])
 
   return null;
 }

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -49,7 +49,7 @@ const DoubleScene = props => {
             map: map,
             container: `scene-global-container-${sceneId}`,
             ...sceneSettings,
-            spatialReference
+            spatialReference,
           });
           setViewGlobal(_viewGlobal);
 
@@ -60,17 +60,15 @@ const DoubleScene = props => {
             viewingMode: 'local',
             spatialReference,
             constraints: {
-              // altitude: {
-              //   min: 35000000,
-              //   max: 36000000
-              // },
               tilt: {
                 max: 60
               }
             },
+            padding: {
+              left: 300,
+              bottom: 60
+            }
           });
-          _viewLocal.padding.left = 300;
-          _viewLocal.padding.bottom = 60;
           
           setViewLocal(_viewLocal);
         })

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -58,8 +58,20 @@ const DoubleScene = props => {
             container: `scene-local-container-${sceneId}`,
             ...sceneSettings,
             viewingMode: 'local',
-            spatialReference
+            spatialReference,
+            constraints: {
+              // altitude: {
+              //   min: 35000000,
+              //   max: 36000000
+              // },
+              tilt: {
+                max: 60
+              }
+            },
           });
+          _viewLocal.padding.left = 300;
+          _viewLocal.padding.bottom = 60;
+          
           setViewLocal(_viewLocal);
         })
         .catch(err => {

--- a/src/components/grid-layer/grid-layer-component.jsx
+++ b/src/components/grid-layer/grid-layer-component.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import { useWatchUtils } from 'hooks/esri';
 import { BIODIVERSITY_FACETS_SERVICE_URL } from 'constants/layers-urls';
 import { GRAPHIC_LAYER } from 'constants/layers-slugs';
-import { gridCellDefaultStyles } from 'constants/landscape-view-constants';
+import { GRID_CELL_STYLES } from 'constants/graphic-styles';
 
 import {
   calculateAggregatedCells,
@@ -45,7 +45,7 @@ const GridLayer = ({ view, setGridCellData, setGridCellGeometry }) => {
         "esri/Graphic",
         "esri/layers/GraphicsLayer"
       ]).then(([Graphic, GraphicsLayer]) => {
-        const _gridCellGraphic = createGraphic(Graphic, gridCellDefaultStyles);
+        const _gridCellGraphic = createGraphic(Graphic, GRID_CELL_STYLES);
         const graphicsLayer = createGraphicLayer(GraphicsLayer, [_gridCellGraphic], GRAPHIC_LAYER);
         setGridCellGraphic(_gridCellGraphic);
         view.map.add(graphicsLayer);

--- a/src/components/grid-layer/grid-layer-component.jsx
+++ b/src/components/grid-layer/grid-layer-component.jsx
@@ -46,7 +46,7 @@ const GridLayer = ({ view, setGridCellData, setGridCellGeometry }) => {
         "esri/layers/GraphicsLayer"
       ]).then(([Graphic, GraphicsLayer]) => {
         const _gridCellGraphic = createGraphic(Graphic, gridCellDefaultStyles);
-        const graphicsLayer = createGraphicLayer(GraphicsLayer, _gridCellGraphic, GRAPHIC_LAYER);
+        const graphicsLayer = createGraphicLayer(GraphicsLayer, [_gridCellGraphic], GRAPHIC_LAYER);
         setGridCellGraphic(_gridCellGraphic);
         view.map.add(graphicsLayer);
       })

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { loadModules } from 'esri-loader';
+import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER } from 'constants/layers-slugs';
+import { LAYERS_URLS } from 'constants/layers-urls';
+import { createGraphicLayer } from 'utils/graphic-layer-utils';
+import { connect } from 'react-redux';
+import actions from 'redux_modules/country-extent';
+
+const createGraphic = (Graphic, geometry) => {
+  return new Graphic({
+    geometry,
+    symbol: {
+      type: "polygon-3d",
+      symbolLayers: [
+        {
+          type: "fill",
+          material: {
+            color: [15, 43, 59, 1]
+          },
+          outline: {
+            color: [15, 255, 255, 1],
+            size: 2
+          }
+        }
+      ]
+    }
+  });
+}
+
+const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer) => {
+  loadModules(['esri/geometry/Polygon',"esri/Graphic"]).then(([Polygon, Graphic]) => {
+    console.log('inside query: countryExtent:',countryExtent, 'countryISO: ',countryISO)
+    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.2));
+    const query = countryLayer.createQuery();
+    query.where = `GID_0 <> '${countryISO}'`;
+    query.outSpatialReference = spatialReference;
+    query.geometry = extentGeometry;
+
+    countryLayer.queryFeatures(query)
+      .then(async function(results){
+        const { features } = results;
+        const geometries = features.map(gc => gc.geometry);
+        const graphics = geometries.map(geo => createGraphic(Graphic, geo));
+        graphicsLayer.graphics = graphics;
+      })
+      .catch((error) => {
+        console.warn(error);
+      });
+    });
+};
+
+const MaskCountryManager = props => {
+  const { viewLocal, spatialReference, countryISO, countryExtent, isCountryMode } = props;
+
+  const [countryLayer, setCountryLayer] = useState(null);
+  const [graphicsLayer, setGraphicsLayer] = useState(null);
+
+  useEffect(() => {
+    loadModules(["esri/layers/GraphicsLayer"]).then(([GraphicsLayer]) => {
+        const _graphicsLayer = createGraphicLayer(GraphicsLayer, [], 'mask-layer');
+        _graphicsLayer.visible = isCountryMode;
+        setGraphicsLayer(_graphicsLayer);
+        viewLocal.map.layers.add(_graphicsLayer);
+      })
+  }, [])
+
+  useEffect(() => {
+    if(graphicsLayer) {
+      graphicsLayer.visible = isCountryMode;
+    }
+  }, [isCountryMode])
+
+  useEffect(() => {
+    loadModules(["esri/layers/FeatureLayer"]).then(([FeatureLayer]) => {
+      const _countryLayer = new FeatureLayer({
+        url: LAYERS_URLS[COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER]
+      });
+      _countryLayer.outFields = ['*'];
+      setCountryLayer(_countryLayer)
+    });
+  }, []);
+
+  useEffect(() => {
+    if (countryLayer && countryISO  && spatialReference && countryExtent) {
+      queryCountryData(countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer);
+    }
+  }, [countryExtent]);
+
+  useEffect(() => {
+    if (graphicsLayer && !countryISO) {
+      graphicsLayer.graphics = [];
+    }
+  },[countryISO])
+
+
+  return null
+}
+
+export default connect(null, actions)(MaskCountryManager);

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -23,7 +23,6 @@ const queryCountryData = (countryLayer, countryISO, spatialReference, countryExt
         const graphics = borderGeometries.map(geo => createGraphic(Graphic, COUNTRY_BORDER_STYLES, geo));
         const maskGraphic = createGraphic(Graphic, MASK_STYLES, maskGeometry);
         graphicsLayer.graphics = [maskGraphic, ...graphics];
-        graphicsLayer.visible = isCountryMode;
       })
       .catch((error) => {
         console.warn(error);

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -61,11 +61,11 @@ const MaskCountryManager = props => {
   }, [isCountryMode]);
 
   useEffect(() => {
-    if (countryLayer && countryISO  && spatialReference && countryExtent && graphicsLayer) {
+    if (countryLayer && countryISO  && spatialReference && countryExtent && graphicsLayer && isCountryMode) {
       graphicsLayer.graphics = [];
       queryCountryData(countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode);
     }
-  }, [countryExtent]);
+  }, [countryExtent, isCountryMode]);
 
   useEffect(() => {
     if (graphicsLayer && !countryISO) {

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -2,37 +2,22 @@ import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
-import { createGraphicLayer } from 'utils/graphic-layer-utils';
+import { createGraphic, createGraphicLayer } from 'utils/graphic-layer-utils';
 
-const maskStyles = {
-  material: {
-    color: [0, 0, 0, 0.7]
-  },
-  outline: {
-    color: [216, 216, 216, 0]
-  }
+const MASK_STYLES = {
+  fillColor: [0, 0, 0],
+  fillOpacity: 0.7,
+  outlineColor: [216, 216, 216],
+  outlineOpacity: 0,
+  outlineWidth: 2
 }
 
-const createGraphic = (Graphic, geometry, styles) => {
-  return new Graphic({
-    geometry,
-    symbol: {
-      type: "polygon-3d",
-      symbolLayers: [
-        {
-          type: "fill",
-          material: {
-            color: [15, 43, 59, 0]
-          },
-          outline: {
-            color: [216, 216, 216, 1],
-            size: 0.5
-          },
-          ...styles
-        }
-      ]
-    }
-  });
+const COUNTRY_BORDER_STYLES = {
+  fillColor: [15, 43, 59],
+  fillOpacity: 0,
+  outlineColor: [216, 216, 216],
+  outlineOpacity: 1,
+  outlineWidth: 0.5
 }
 
 const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode) => {
@@ -50,8 +35,8 @@ const queryCountryData = (countryLayer, countryISO, spatialReference, countryExt
         const maskGeometry = await geometryEngine.difference(extentGeometry, countryGeometry);
         const borderGeometries = neighbourCountriesGeometry.map(gc => gc.geometry);
 
-        const graphics = borderGeometries.map(geo => createGraphic(Graphic, geo));
-        const maskGraphic = createGraphic(Graphic, maskGeometry, maskStyles);
+        const graphics = borderGeometries.map(geo => createGraphic(Graphic, COUNTRY_BORDER_STYLES, geo));
+        const maskGraphic = createGraphic(Graphic, MASK_STYLES, maskGeometry);
         graphicsLayer.graphics = [maskGraphic, ...graphics];
         graphicsLayer.visible = isCountryMode;
       })

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -83,7 +83,7 @@ const MaskCountryManager = props => {
       graphicsLayer.graphics = [];
       queryCountryData(countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer);
     }
-  }, [countryExtent, isCountryMode]);
+  }, [countryExtent]);
 
   useEffect(() => {
     if (graphicsLayer && !countryISO) {

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -57,7 +57,7 @@ const MaskCountryManager = props => {
 
           const graphics = borderGeometries.map(geo => createGraphic(Graphic, geo));
           const maskGraphic = createGraphic(Graphic, maskGeometry, maskStyles);
-
+          graphicsLayer.visible = isCountryMode;
           graphicsLayer.graphics = [maskGraphic, ...graphics];
         })
         .catch((error) => {
@@ -79,7 +79,6 @@ const MaskCountryManager = props => {
   useEffect(() => {
     loadModules(["esri/layers/GraphicsLayer"]).then(([GraphicsLayer]) => {
         const _graphicsLayer = createGraphicLayer(GraphicsLayer, [], 'mask-layer');
-        _graphicsLayer.visible = isCountryMode;
         setGraphicsLayer(_graphicsLayer);  
         viewLocal.map.layers.add(_graphicsLayer);
       })

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -2,23 +2,8 @@ import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
+import { MASK_STYLES, COUNTRY_BORDER_STYLES } from 'constants/graphic-styles';
 import { createGraphic, createGraphicLayer } from 'utils/graphic-layer-utils';
-
-const MASK_STYLES = {
-  fillColor: [0, 0, 0],
-  fillOpacity: 0.7,
-  outlineColor: [216, 216, 216],
-  outlineOpacity: 0,
-  outlineWidth: 2
-}
-
-const COUNTRY_BORDER_STYLES = {
-  fillColor: [15, 43, 59],
-  fillOpacity: 0,
-  outlineColor: [216, 216, 216],
-  outlineOpacity: 1,
-  outlineWidth: 0.5
-}
 
 const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode) => {
   loadModules(['esri/geometry/Polygon',"esri/Graphic", "esri/geometry/geometryEngine"]).then(([Polygon, Graphic, geometryEngine]) => {

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -3,8 +3,6 @@ import { loadModules } from 'esri-loader';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
 import { createGraphicLayer } from 'utils/graphic-layer-utils';
-import { connect } from 'react-redux';
-import actions from 'redux_modules/country-extent';
 
 const createGraphic = (Graphic, geometry) => {
   return new Graphic({
@@ -18,8 +16,8 @@ const createGraphic = (Graphic, geometry) => {
             color: [15, 43, 59, 1]
           },
           outline: {
-            color: [15, 255, 255, 1],
-            size: 2
+            color: [216, 216, 216, 1],
+            size: 0.5
           }
         }
       ]
@@ -27,48 +25,33 @@ const createGraphic = (Graphic, geometry) => {
   });
 }
 
-const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer) => {
-  loadModules(['esri/geometry/Polygon',"esri/Graphic"]).then(([Polygon, Graphic]) => {
-    console.log('inside query: countryExtent:',countryExtent, 'countryISO: ',countryISO)
-    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.2));
-    const query = countryLayer.createQuery();
-    query.where = `GID_0 <> '${countryISO}'`;
-    query.outSpatialReference = spatialReference;
-    query.geometry = extentGeometry;
-
-    countryLayer.queryFeatures(query)
-      .then(async function(results){
-        const { features } = results;
-        const geometries = features.map(gc => gc.geometry);
-        const graphics = geometries.map(geo => createGraphic(Graphic, geo));
-        graphicsLayer.graphics = graphics;
-      })
-      .catch((error) => {
-        console.warn(error);
-      });
-    });
-};
-
 const MaskCountryManager = props => {
   const { viewLocal, spatialReference, countryISO, countryExtent, isCountryMode } = props;
-
   const [countryLayer, setCountryLayer] = useState(null);
   const [graphicsLayer, setGraphicsLayer] = useState(null);
 
-  useEffect(() => {
-    loadModules(["esri/layers/GraphicsLayer"]).then(([GraphicsLayer]) => {
-        const _graphicsLayer = createGraphicLayer(GraphicsLayer, [], 'mask-layer');
-        _graphicsLayer.visible = isCountryMode;
-        setGraphicsLayer(_graphicsLayer);
-        viewLocal.map.layers.add(_graphicsLayer);
-      })
-  }, [])
-
-  useEffect(() => {
-    if(graphicsLayer) {
-      graphicsLayer.visible = isCountryMode;
-    }
-  }, [isCountryMode])
+  const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer) => {
+    loadModules(['esri/geometry/Polygon',"esri/Graphic"]).then(([Polygon, Graphic]) => {
+      
+      const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.2));
+      const query = countryLayer.createQuery();
+      query.where = `GID_0 <> '${countryISO}'`;
+      query.outSpatialReference = spatialReference;
+      query.geometry = extentGeometry;
+  
+      countryLayer.queryFeatures(query)
+        .then(async function(results){
+          const { features } = results;
+          const geometries = features.map(gc => gc.geometry);
+          const graphics = geometries.map(geo => createGraphic(Graphic, geo));
+          graphicsLayer.graphics = graphics;
+          graphicsLayer.visible = isCountryMode;
+        })
+        .catch((error) => {
+          console.warn(error);
+        });
+      });
+  };
 
   useEffect(() => {
     loadModules(["esri/layers/FeatureLayer"]).then(([FeatureLayer]) => {
@@ -76,24 +59,39 @@ const MaskCountryManager = props => {
         url: LAYERS_URLS[COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER]
       });
       _countryLayer.outFields = ['*'];
-      setCountryLayer(_countryLayer)
+      setCountryLayer(_countryLayer);
     });
   }, []);
 
   useEffect(() => {
-    if (countryLayer && countryISO  && spatialReference && countryExtent) {
+    loadModules(["esri/layers/GraphicsLayer"]).then(([GraphicsLayer]) => {
+        const _graphicsLayer = createGraphicLayer(GraphicsLayer, [], 'mask-layer');
+        _graphicsLayer.visible = isCountryMode;
+        setGraphicsLayer(_graphicsLayer);  
+        viewLocal.map.layers.add(_graphicsLayer);
+      })
+  }, []);
+
+  useEffect(() => {
+    if(graphicsLayer) {
+      graphicsLayer.visible = isCountryMode;
+    }
+  }, [isCountryMode]);
+
+  useEffect(() => {
+    if (countryLayer && countryISO  && spatialReference && countryExtent && graphicsLayer) {
+      graphicsLayer.graphics = [];
       queryCountryData(countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer);
     }
-  }, [countryExtent]);
+  }, [countryExtent, isCountryMode]);
 
   useEffect(() => {
     if (graphicsLayer && !countryISO) {
       graphicsLayer.graphics = [];
     }
-  },[countryISO])
-
+  },[countryISO]);
 
   return null
 }
 
-export default connect(null, actions)(MaskCountryManager);
+export default MaskCountryManager;

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -21,7 +21,7 @@ const WidgetsComponent = ({ map, view, viewLocal, isFullscreenActive, isHEModalO
       {viewLocal && (
         <>
           <ToggleUiWidget map={map} view={viewLocal} isFullscreenActive={isFullscreenActive} hidden={hiddenWidget}/>
-          <ZoomWidget map={map} view={viewLocal} isNotMapsList={isNotMapsList} hidden={hiddenWidget} />
+          <ZoomWidget map={map} view={viewLocal} isNotMapsList={isNotMapsList} hidden={hiddenWidget} disableStateUpdate={!!viewLocal}/>
         </>
       )}
     </>

--- a/src/components/widgets/zoom-widget/zoom-widget.js
+++ b/src/components/widgets/zoom-widget/zoom-widget.js
@@ -9,7 +9,7 @@ import ZoomWidgetComponent from './zoom-widget-component';
 import * as actions from 'actions/url-actions';
 
 const ZoomWidget = props => {
-  const { view, changeGlobe, hidden } = props;
+  const { view, changeGlobe, hidden, disableStateUpdate } = props;
   const [zoomWidget, setZoomWidget] = useState(null);
   const watchUtils = useWatchUtils();
   const handleZoomChange = (zoom) => changeGlobe({ zoom });
@@ -35,7 +35,7 @@ const ZoomWidget = props => {
 
   // Update zoom in URL
   useEffect(() => {
-    const watchHandle = watchUtils && zoomWidget && watchUtils.whenTrue(zoomWidget.view, "stationary", function() {
+    const watchHandle = watchUtils && zoomWidget && !disableStateUpdate && watchUtils.whenTrue(zoomWidget.view, "stationary", function() {
       handleZoomChange(zoomWidget.view.zoom);
     });
     return function cleanUp() {

--- a/src/constants/graphic-styles.js
+++ b/src/constants/graphic-styles.js
@@ -1,0 +1,23 @@
+export const MASK_STYLES = {
+  fillColor: [0, 0, 0],
+  fillOpacity: 0.7,
+  outlineColor: [216, 216, 216],
+  outlineOpacity: 0,
+  outlineWidth: 2
+}
+
+export const COUNTRY_BORDER_STYLES = {
+  fillColor: [15, 43, 59],
+  fillOpacity: 0,
+  outlineColor: [216, 216, 216],
+  outlineOpacity: 1,
+  outlineWidth: 0.5
+}
+
+export const GRID_CELL_STYLES = {
+  fillColor: [147, 255, 95],
+  fillOpacity: 0,
+  outlineColor: [147, 255, 95],
+  outlineOpacity: 0.9,
+  outlineWidth: 2,
+}

--- a/src/constants/landscape-view-constants.js
+++ b/src/constants/landscape-view-constants.js
@@ -1,8 +1,9 @@
 export const gridCellDefaultStyles = {
+  fillColor: [147, 255, 95],
   fillOpacity: 0,
+  outlineColor: [147, 255, 95],
   outlineOpacity: 0.9,
   outlineWidth: 2,
-  colorRGB: [147, 255, 95]
 }
 
 export const ZOOM_LEVEL_TRIGGER = 8;

--- a/src/constants/landscape-view-constants.js
+++ b/src/constants/landscape-view-constants.js
@@ -1,9 +1,1 @@
-export const gridCellDefaultStyles = {
-  fillColor: [147, 255, 95],
-  fillOpacity: 0,
-  outlineColor: [147, 255, 95],
-  outlineOpacity: 0.9,
-  outlineWidth: 2,
-}
-
 export const ZOOM_LEVEL_TRIGGER = 8;

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -115,8 +115,8 @@ const DataGlobeComponent = ({
           setRasters={setRasters}
           selectedSpecies={selectedSpecies}
         />
-        <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode} countryName={countryName}/>
         <CountryBorderLayer countryISO={countryISO} isCountryMode={isCountryMode}/>
+        <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode} countryName={countryName} countryExtent={countryExtent}/>
         {isCountryMode && <LocalSceneSidebar countryISO={countryISO} countryName={countryName} isFullscreenActive={isFullscreenActive}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -116,7 +116,7 @@ const DataGlobeComponent = ({
           selectedSpecies={selectedSpecies}
         />
         <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode} countryName={countryName}/>
-        <CountryBorderLayer countryISO={countryISO}/>
+        <CountryBorderLayer countryISO={countryISO} isCountryMode={isCountryMode}/>
         {isCountryMode && <LocalSceneSidebar countryISO={countryISO} countryName={countryName} isFullscreenActive={isFullscreenActive}/>}
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -53,8 +53,7 @@ const DataGlobeComponent = ({
   countryISO,
   countryName,
   sceneMode,
-  countryExtent,
-  countryExtentLoading
+  countryExtent
 }) => {
   
   const isOnMobile = isMobile();

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -22,6 +22,7 @@ import About from 'components/about';
 import UserDataModal from 'components/user-data-modal';
 import CountryLabelsLayer from 'components/country-labels-layer';
 import CountryBorderLayer from 'components/country-border-layer';
+import MaskCountryManager from 'components/mask-country-manager';
 
 const InfoModal = loadable(() => import('components/modal-metadata'));
 const GridLayer = loadable(() => import('components/grid-layer'));
@@ -52,7 +53,8 @@ const DataGlobeComponent = ({
   countryISO,
   countryName,
   sceneMode,
-  countryExtent
+  countryExtent,
+  countryExtentLoading
 }) => {
   
   const isOnMobile = isMobile();
@@ -119,6 +121,7 @@ const DataGlobeComponent = ({
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}
         <LabelsLayer isLandscapeMode={isLandscapeMode} isCountryMode={isCountryMode} countryName={countryName}/>
+        <MaskCountryManager countryISO={countryISO} countryExtent={countryExtent} isCountryMode={isCountryMode} />
         {isLandscapeMode && <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />}
       </DoubleScene>
       <TutorialModal />

--- a/src/pages/map-iframe/map-iframe.js
+++ b/src/pages/map-iframe/map-iframe.js
@@ -34,7 +34,7 @@ const addSignedPledgeToMap = (map, view, signedPledgeZIP, signedPledgeCountry) =
         const { x, y } = data;
         const signedPledgeLight = simplePictureMarker(signedPledgeLightIcon);
         const pointGraphic = createPointGraphic(Graphic, signedPledgeLight, x, y);
-        const signedPledgeGraphicLayer = createGraphicLayer(GraphicsLayer, pointGraphic, SIGNED_PLEDGE_GRAPHIC_LAYER);
+        const signedPledgeGraphicLayer = createGraphicLayer(GraphicsLayer, [pointGraphic], SIGNED_PLEDGE_GRAPHIC_LAYER);
         map.add(signedPledgeGraphicLayer);
         view.goTo({ center: [x, y] });
     }, (error) => {console.warn(error)})

--- a/src/utils/graphic-layer-utils.js
+++ b/src/utils/graphic-layer-utils.js
@@ -47,7 +47,8 @@ export const createPolygonGeometry = (gridCell) => {
     })
 }
 
-export const simplePictureMarker = asset => ({
+export const simplePictureMarker = (asset, symbol = {}) => ({
   type: "picture-marker",  // autocasts as new PictureMarkerSymbol()
-  url: asset
+  url: asset,
+  ...symbol
 })

--- a/src/utils/graphic-layer-utils.js
+++ b/src/utils/graphic-layer-utils.js
@@ -20,22 +20,28 @@ export const createPointGraphic = (GraphicConstructor, symbol, lon, lat) => {
   });
 }
 
-export const createGraphic = (Graphic, graphicStyles) => {
-  return new Graphic({
+export const createGraphic = (Graphic, graphicStyles, geometry) => {
+  const graphic = new Graphic({
     symbol: {
       type: "polygon-3d",
       symbolLayers: [
         {
           type: "fill",
-          material: { color: [...graphicStyles.colorRGB, graphicStyles.fillOpacity], },
+          material: { color: [...graphicStyles.fillColor, graphicStyles.fillOpacity], },
           outline: {
-            color: [...graphicStyles.colorRGB, graphicStyles.outlineOpacity],
+            color: [...graphicStyles.outlineColor, graphicStyles.outlineOpacity],
             size: graphicStyles.outlineWidth
           }
         }
       ]
     }
   });
+
+  if (geometry) {
+    graphic.geometry = geometry;
+  }
+
+  return graphic;
 }
 
 export const createPolygonGeometry = (gridCell) => {

--- a/src/utils/graphic-layer-utils.js
+++ b/src/utils/graphic-layer-utils.js
@@ -1,10 +1,10 @@
 import { loadModules } from 'esri-loader';
 
-export const createGraphicLayer = (GraphicsLayer, graphic, id = "graphicLayer") => {
+export const createGraphicLayer = (GraphicsLayer, graphics, id = "graphicLayer") => {
   return new GraphicsLayer({
     id: id,
     title: id,
-    graphics: [graphic]
+    graphics
   });
 }
 

--- a/src/utils/graphic-layer-utils.js
+++ b/src/utils/graphic-layer-utils.js
@@ -1,10 +1,10 @@
 import { loadModules } from 'esri-loader';
 
-export const createGraphicLayer = (GraphicsLayer, graphics, id = "graphicLayer") => {
+export const createGraphicLayer = (GraphicsLayer, graphicsArray, id = "graphicLayer") => {
   return new GraphicsLayer({
     id: id,
     title: id,
-    graphics
+    graphics: graphicsArray
   });
 }
 


### PR DESCRIPTION
This PR adds the countries mask layer to the local scene.
[PIVOTAL](https://www.pivotaltracker.com/story/show/172018109) | [PREVIEW](https://half-earth-v3-git-feature-adjust-local-scene-styles.vizzuality1.now.sh)
![om536-hsi2g](https://user-images.githubusercontent.com/15097138/78697270-76e28280-78f8-11ea-8a04-8d99cc675b1a.gif)

It also:
- increases the size of the red country marker,
- fixes missing marker after the first load of the page,


- sets the maximum tilt to 60,
- adds the left padding to the local scene,

Things that still need to be fixed:
- Sometimes when we click on the new country label and then quickly on "Explore this country", the country mask on the local scene doesn't appear - something is wrong with the layer visibility, haven't discovered what exactly,
- defining camera constraints for the local scene seems to be more complicated - the altitude constraints don't work on local scenes, also can't constrain the panning. I can only disable it completely, what as I understand it's not desired behavior either - need to dig deeper, maybe there is another solution for that
- Smarter elevation - for smaller countries the elevation level goes crazy, will check it in a different PR
