### PR TITLE
Feature/fix metadata modal titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react-copy-to-clipboard": "^5.0.1",
     "react-dom": "^16.8.6",
     "react-hot-loader": "^4.8.2",
-    "react-markdown": "4.0.8",
+    "react-markdown": "^4.3.1",
     "react-redux": "^6.0.1",
     "react-responsive": "^8.0.1",
     "react-scripts": "2.1.8",

--- a/src/components/checkbox-group/checkbox/checkbox-component.jsx
+++ b/src/components/checkbox-group/checkbox/checkbox-component.jsx
@@ -22,7 +22,7 @@ const Checkbox = ({ option, onChange, checked, theme, handleInfoClick }) => {
         onChange={(e) => onChange(e, option)}
       />
       <label htmlFor={option.value} className={cx(styles.checkbox, { [styles.checkboxSelected]: checked })}>
-        <span className={styles.label}>{option.name}</span>
+        <span className={styles.label}>{option.label || option.name}</span>
         {option.rightDot && !checked && <span className={styles.rightDot} style={{ background: option.rightDot }} />}
       </label>
       {checked && (

--- a/src/components/checkbox-group/checkbox/checkbox-component.jsx
+++ b/src/components/checkbox-group/checkbox/checkbox-component.jsx
@@ -22,7 +22,7 @@ const Checkbox = ({ option, onChange, checked, theme, handleInfoClick }) => {
         onChange={(e) => onChange(e, option)}
       />
       <label htmlFor={option.value} className={cx(styles.checkbox, { [styles.checkboxSelected]: checked })}>
-        <span className={styles.label}>{option.label || option.name}</span>
+        <span className={styles.label}>{option.name}</span>
         {option.rightDot && !checked && <span className={styles.rightDot} style={{ background: option.rightDot }} />}
       </label>
       {checked && (

--- a/src/components/checkbox-group/checkbox/checkbox.js
+++ b/src/components/checkbox-group/checkbox/checkbox.js
@@ -12,7 +12,7 @@ const CheckboxContainer = props => {
     const { setModalMetadata, openLayerInfoModalAnalyticsEvent } = props;
     setModalMetadata({
       slug: `${option.slug}`,
-      title: `${option.name} metadata`,
+      title: `${option.metadataTitle || option.name} metadata`,
       isOpen: true
     });
     openLayerInfoModalAnalyticsEvent({ slug: `${option.slug}` });

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -103,8 +103,8 @@ const getProtectedLayers = createSelector(
     if (!dataFormatted) return [];
     const protectedLayers = WDPALayers.map(layer => ({
       ...layer,
-      name: layer.name,
-      label: layer.name === 'Protected areas' ? `${layer.name} ${dataFormatted.protected}%` : `${layer.name} ${dataFormatted.community}%`,
+      name: layer.name === 'Protected areas' ? `${layer.name} ${dataFormatted.protected}%` : `${layer.name} ${dataFormatted.community}%`,
+      metadataTitle: layer.metadataTitle,
       rightDot: layer.name === 'Protected areas' ? COLORS[PROTECTED] : COLORS[COMMUNITY_BASED]
     })) || [];
     return protectedLayers;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -103,7 +103,8 @@ const getProtectedLayers = createSelector(
     if (!dataFormatted) return [];
     const protectedLayers = WDPALayers.map(layer => ({
       ...layer,
-      name: layer.name === 'Protected areas' ? `${layer.name} ${dataFormatted.protected}%` : `${layer.name} ${dataFormatted.community}%`,
+      name: layer.name,
+      label: layer.name === 'Protected areas' ? `${layer.name} ${dataFormatted.protected}%` : `${layer.name} ${dataFormatted.community}%`,
       rightDot: layer.name === 'Protected areas' ? COLORS[PROTECTED] : COLORS[COMMUNITY_BASED]
     })) || [];
     return protectedLayers;

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
@@ -96,7 +96,8 @@ const getPressureOptions = createSelector(getPressureData, humanPressureData => 
   const data = humanPressureData
     .map(({ name, slug, value, pressureValue }) => (
       {
-        name: `${name} ${format(".2%")(pressureValue / 100)}`,
+        name: `${name}`,
+        label: `${name} ${format(".2%")(pressureValue / 100)}`,
         slug,
         value
       }

--- a/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
+++ b/src/components/landscape-sidebar/human-pressure-widget/human-pressure-selectors.js
@@ -96,10 +96,10 @@ const getPressureOptions = createSelector(getPressureData, humanPressureData => 
   const data = humanPressureData
     .map(({ name, slug, value, pressureValue }) => (
       {
-        name: `${name}`,
-        label: `${name} ${format(".2%")(pressureValue / 100)}`,
+        name: `${name} ${format(".2%")(pressureValue / 100)}`,
         slug,
-        value
+        value,
+        metadataTitle: name
       }
     )
   );

--- a/src/components/modal-metadata/modal-metadata-component.jsx
+++ b/src/components/modal-metadata/modal-metadata-component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { Modal, Loading } from 'he-components';
 import MolLogo from 'logos/mol.png';
+import ReactMarkdown from 'react-markdown';
 import styles from './modal-metadata-styles.module.scss';
 
 const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata }) => {
@@ -53,8 +54,7 @@ const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata }) => {
             {
               metadata && metadata.source && (
               <p className={styles.metadataSource}>
-                    Source:{' '}
-                {metadata.source}
+                <ReactMarkdown source={`Source: ${metadata.source}`} escapeHtml={false}/>
                 {' '}
                 {
                       metadata.sourceUrl && (

--- a/src/constants/protected-areas.js
+++ b/src/constants/protected-areas.js
@@ -12,7 +12,8 @@ export const WDPALayers = [
     id: PROTECTED_AREAS_VECTOR_TILE_LAYER,
     title: PROTECTED_AREAS_VECTOR_TILE_LAYER,
     theme: 'overrideCheckbox-protected-areas',
-    slug: PROTECTED_AREAS_VECTOR_TILE_LAYER
+    slug: PROTECTED_AREAS_VECTOR_TILE_LAYER,
+    metadataTitle: 'Protected areas'
   },
   {
     name: 'Community-based',
@@ -21,7 +22,9 @@ export const WDPALayers = [
     title: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
     theme: 'overrideCheckbox-community-areas',
     slug: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
-    groupedLayer: true
+    groupedLayer: true,
+    metadataTitle: 'Community-based protected areas'
+
   }
 ]
 
@@ -46,7 +49,7 @@ export const legendConfigs = {
         color: PROTECTED_AREAS_COLOR
       }
     ],
-    title: "All protected areas",
+    title: "Protected areas",
     slug: PROTECTED_AREAS_VECTOR_TILE_LAYER
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6837,21 +6837,6 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-pre-gyp@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
@@ -8459,17 +8444,24 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.4:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
 
+react-is@^16.8.6:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-markdown@4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.0.8.tgz#e3621b5becaac82a651008d7bc8390d3e4e438c0"
+react-markdown@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
   dependencies:
     html-to-react "^1.3.4"
     mdast-add-list-metadata "1.0.1"
     prop-types "^15.7.2"
+    react-is "^16.8.6"
     remark-parse "^5.0.0"
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
@@ -9841,7 +9833,7 @@ tar@^2.0.0:
     fstream "^1.0.12"
     inherits "2"
 
-tar@^4, tar@^4.4.2:
+tar@^4:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   dependencies:


### PR DESCRIPTION
This PR solves three issues related to the metadata modal:
[PIVOTAL](https://www.pivotaltracker.com/story/show/172289471)

- Enables parsing the markup syntax in the metadata modal footer (you can test it by opening the `Community-based` layer modal):
**BEFORE**
![image](https://user-images.githubusercontent.com/15097138/79244244-93d60300-7e6e-11ea-981b-cb54dc2be335.png)
**AFTER**
![image](https://user-images.githubusercontent.com/15097138/79244068-5a04fc80-7e6e-11ea-9d40-2ce89a690395.png)

- Now we can pass custom metadata modal title to the checkbox component by specifying `metadataTitle` field. If the value for this field is not present, the value from the `name` field is set as a modal title:
![image](https://user-images.githubusercontent.com/15097138/79244958-5d4cb800-7e6f-11ea-99af-e389faf8aa46.png)
this solves two problems that has been described in the pivotal ticket:
  - Titles on the metadata modals from the sidebar and the legend don't match,
_bug:_
![image](https://user-images.githubusercontent.com/15097138/79245505-17dcba80-7e70-11ea-9044-ee6e61b67dcc.png)
  - Opening the metadata modal from the landscape sidebar copies the percentage value to the title, both protected areas and the human pressures widget,
_bug:_
![image](https://user-images.githubusercontent.com/15097138/79245409-f54aa180-7e6f-11ea-91fb-e45df007e0ca.png)

BTW I noticed that tooltips in HE seem to be broken, they display in a weird way:
![image](https://user-images.githubusercontent.com/15097138/79245802-7e61d880-7e70-11ea-8a59-e17508a1825f.png)
[Here](https://www.pivotaltracker.com/story/show/172315143) is the pivotal ticket for this issue.