### PR TITLE
Fix/national report cards bugs

### DIFF
--- a/src/components/data-global-sidebar/data-global-sidebar-styles.module.scss
+++ b/src/components/data-global-sidebar/data-global-sidebar-styles.module.scss
@@ -6,7 +6,7 @@
   @extend %verticalScrollBar;
   @include animationFunction($propertyToAnimate: all);
   position: absolute;
-  height: 100vh;
+  height: calc(100vh - #{$sidebar-top-margin});
   width: calc(#{$sidebar-width} + 15px);
   top: $sidebar-top-margin;
   left: $site-gutter;

--- a/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
@@ -63,7 +63,7 @@ const getChartData = (speciesData, taxa, startAngle)  => {
     const angle = startAngle + angleOffset + angleOffset * i;
     return {
       id: s.HBWID,
-      name: s.common_name !== " " ? s.common_name : s.species_name,
+      name: s.common_name !== "NA" ? s.common_name : s.species_name,
       scientificName: s.species_name,
       rangeArea: formatRangeArea(s.RANGE_AREA_KM2),
       proportion: format(".2%")(s.PROP_RANGE_PROT),

--- a/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget-selectors.js
@@ -90,8 +90,7 @@ const getData = createSelector(getUniqeSpeciesData, speciesData => {
 const getSelectedSpeciesData = createSelector([getData, getSelectedSpeciesName],
   (data, selectedSpeciesName) => {
   if (!data) return null;
-  
-  const selectedSpecies = data.find(({ name }) => name === selectedSpeciesName) || data[0];
+  const selectedSpecies = data.find(({ scientificName }) => scientificName === selectedSpeciesName) || data[0];
   return selectedSpecies;
 });
 

--- a/src/components/landscape-sidebar/species-widget/species-widget.js
+++ b/src/components/landscape-sidebar/species-widget/species-widget.js
@@ -16,8 +16,8 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const updateSelectedSpecies = (index) => {
-    const { name } = data[index];
-    changeGlobe({ selectedSpecies: name });
+    const { scientificName } = data[index];
+    changeGlobe({ selectedSpecies: scientificName });
     setSelectedIndex(index);
   }
 
@@ -42,7 +42,7 @@ const SpeciesWidget = ({ setSpeciesData, terrestrialCellData, data, changeGlobe,
   }
 
   const handleSelectSpecies = (species) => {
-    const newIndex = data.findIndex(({ name }) => name === species.name)
+    const newIndex = data.findIndex(({ scientificName }) => scientificName === species.scientificName)
     updateSelectedSpecies(newIndex);
   }
 

--- a/src/hooks/esri.js
+++ b/src/hooks/esri.js
@@ -51,6 +51,9 @@ export const useSearchWidgetLogic = (view, openPlacesSearchAnalyticsEvent, searc
 
   const addSearchWidgetToView = async () => {
     await view.ui.add(searchWidget, "top-left");
+    const esriSearch = document.querySelector('.esri-search');
+    const rootNode = document.getElementById("root");
+    if(esriSearch) { rootNode.appendChild(esriSearch); }
     document.querySelector(".esri-search__input").focus();
   }
 


### PR DESCRIPTION
This PR fixes four issues that we found recently;

- [Several points glow when clicking on species widget](https://www.pivotaltracker.com/story/show/172405293)
For those species that don't have a `common-name`, the dataset sets the `NA` placeholder. The problem was that the species widget was using a `common-name` as a unique identifier, so once we select a species without a common name (`NA`), all other species with `NA` placeholder will highlight. The solution was to use the  `scientificName` field as an identifier.
_bug:_
![Pasted Image at 2020_04_20_11_40 am](https://user-images.githubusercontent.com/15097138/79775476-9768fe80-8334-11ea-8152-e9efd3b78426.png)

- [Provide scientific name when a common name is not available](https://www.pivotaltracker.com/story/show/172405463)
We replace `NA` placeholder for species without `common-name` with their scientific name:
![image](https://user-images.githubusercontent.com/15097138/79776059-72c15680-8335-11ea-8c60-625e8da1308c.png)

- [Viewport clips the last option of the `human-pressures` radio group on the sidebar](https://www.pivotaltracker.com/story/show/172384011)
The problem which I spotted on every browser, at least on Windows, @weberjavi please check if on your machine it doesn't break anything:
_bug:_
![Pasted Image at 2020_04_17_06_20 pm_big](https://user-images.githubusercontent.com/15097138/79776492-1f9bd380-8336-11ea-8f6d-a829d54ad73b.png)

- [Fix z-index of the search modal](https://www.pivotaltracker.com/story/show/172383916)
The problem appears since using the react portal solution for the local scene - the search widget is rendered in a different way than other widgets. We don't add it as a React component; instead, we add this as the esri widget to view, by using `view.ui.add()`. This means that even with the position `fixed` and greatest `z-index`, the search widget is displayed bellow other components, that are higher in DOM hierarchy. I fixed it by manipulating DOM and moving the search widget from the esri ui parent to the 'root' div, where other widgets exist. It's not a very reactive solution, but the quickest we can get I think.
_bug:_
![Screenshot_1_big](https://user-images.githubusercontent.com/15097138/79777381-748c1980-8337-11ea-8265-af3e9b30d9ff.png)
