### PR TITLE
Use new `marine_and_land_grid_55km` service for feeding the conservation widget data

### DIFF
--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -1,7 +1,6 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { sumBy } from 'lodash';
 import { WDPALayers } from 'constants/protected-areas';
-import { getTerrestrialCellData } from 'selectors/grid-cell-selectors';
 
 export const COMMUNITY_BASED = 'community';
 export const PROTECTED = 'protected';
@@ -15,6 +14,7 @@ const COLORS = () => ({
 
 const conservationEffortsData = ({ conservationEffortsData }) => conservationEffortsData && conservationEffortsData.data;
 const conservationEffortsLoading = ({ conservationEffortsData }) => conservationEffortsData && conservationEffortsData.loading;
+const gridCellData = ({ gridCellData }) => (gridCellData && gridCellData.data) || null;
 
 const getActiveLayersFromProps = (state, props) => props.activeLayers;
 
@@ -128,7 +128,7 @@ const getActiveSlices = createSelector(
 });
 
 export default createStructuredSelector({
-  terrestrialCellData: getTerrestrialCellData,
+  cellData: gridCellData,
   pieChartData: getConservationEfforts,
   dataFormatted: getConservationAreasFormatted,
   rawData: getConservationAreasLogic, 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget-selectors.js
@@ -127,8 +127,19 @@ const getActiveSlices = createSelector(
     return activeSlices;
 });
 
+const getSelectedCellsIds = createSelector(
+  [gridCellData],
+  (cellData) => {
+  if(!cellData) return null;
+  const selectedCellsIDs = cellData.map(i => {
+    const id = i.ID || i.CELL_ID;
+    return `'${id}'`;
+  });
+  return selectedCellsIDs;
+});
+
 export default createStructuredSelector({
-  cellData: gridCellData,
+  selectedCellsIDs: getSelectedCellsIds,
   pieChartData: getConservationEfforts,
   dataFormatted: getConservationAreasFormatted,
   rawData: getConservationAreasLogic, 

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -27,7 +27,7 @@ const ConservationEffortsWidget = (props) => {
   const {
     alreadyChecked,
     colors,
-    terrestrialCellData,
+    cellData,
     setConservationEfforts
   } = props;
 
@@ -70,15 +70,19 @@ const ConservationEffortsWidget = (props) => {
   }, [orangeActive, yellowActive])
 
   useEffect(() => {
-    if (terrestrialCellData && queryParams) {
+    if (cellData && queryParams) {
       setConservationEfforts({ data: null, loading: true });
-      queryParams.where = `ID IN (${terrestrialCellData.map(i => i.ID).join(', ')})`;
+      const queriedCellsIDs = cellData.map(i => {
+        const id = i.ID || i.CELL_ID;
+        return `'${id}'`;
+      }).join(', ');
+      queryParams.where = `ID IN (${queriedCellsIDs})`;
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
         setConservationEfforts({ data: features.map(c => c.attributes), loading: false });
       }).catch(() => setConservationEfforts({ data: null, loading: false }));
     }
-  }, [terrestrialCellData])
+  }, [cellData])
 
   const handleLayerToggle = async (layersPassed, option) => {
     const { removeLayerAnalyticsEvent, activeLayers, changeGlobe, map } = props;

--- a/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
+++ b/src/components/landscape-sidebar/conservation-efforts-widget/conservation-efforts-widget.js
@@ -27,7 +27,7 @@ const ConservationEffortsWidget = (props) => {
   const {
     alreadyChecked,
     colors,
-    cellData,
+    selectedCellsIDs,
     setConservationEfforts
   } = props;
 
@@ -70,19 +70,15 @@ const ConservationEffortsWidget = (props) => {
   }, [orangeActive, yellowActive])
 
   useEffect(() => {
-    if (cellData && queryParams) {
+    if (selectedCellsIDs && queryParams) {
       setConservationEfforts({ data: null, loading: true });
-      const queriedCellsIDs = cellData.map(i => {
-        const id = i.ID || i.CELL_ID;
-        return `'${id}'`;
-      }).join(', ');
-      queryParams.where = `ID IN (${queriedCellsIDs})`;
+      queryParams.where = `ID IN (${selectedCellsIDs.join(', ')})`;
       conservationPropsLayer.queryFeatures(queryParams).then(function(results){
         const { features } = results;
         setConservationEfforts({ data: features.map(c => c.attributes), loading: false });
       }).catch(() => setConservationEfforts({ data: null, loading: false }));
     }
-  }, [cellData])
+  }, [selectedCellsIDs])
 
   const handleLayerToggle = async (layersPassed, option) => {
     const { removeLayerAnalyticsEvent, activeLayers, changeGlobe, map } = props;

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -74,7 +74,7 @@ export const LAYERS_URLS = {
   [COMMUNITY_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/community_based/VectorTileServer',
   [RAISIG_AREAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/RAISG_Tls/FeatureServer',
   [RAISIG_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Territorios_Ind%C3%ADgenas_RAISG/VectorTileServer',
-  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/grid_55km_prot_prop/FeatureServer',
+  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/ArcGIS/rest/services/marine_and_land_grid_55km_prot_prop/FeatureServer',
   [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/species_data_55km/FeatureServer',
   [GRID_CELLS_LAND_HUMAN_PRESSURES_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/human_pressure_55km/FeatureServer',
   [URBAN_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/gHM_Urban_0_to_8/MapServer',


### PR DESCRIPTION
This PR updates the `GRID_CELLS_PROTECTED_AREAS_PERCENTAGE` service URL and adds a few tweaks to the `conservation-efforts` widget to enable displaying the data from both types of cell: marine and terrestrial.
[PIVOTAL](https://www.pivotaltracker.com/story/show/171836483)
![image](https://user-images.githubusercontent.com/15097138/80110051-8ca1aa00-857e-11ea-905f-04489e799461.png)
