### PR TITLE
Feature/update protection data for disolved grid

### DIFF
--- a/src/components/legend/legend-styles.module.scss
+++ b/src/components/legend/legend-styles.module.scss
@@ -5,7 +5,7 @@
 
 $site-gutter: 20px;
 $map-attribution-height: 30px;
-$legend-item-height: 82px;
+$legend-item-height: 85px;
 $legend-width: 260px;
 
 %legend-ramp-text {

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -71,7 +71,7 @@ export const LAYERS_URLS = {
   [COMMUNITY_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/community_based/VectorTileServer',
   [RAISIG_AREAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/RAISG_Tls/FeatureServer',
   [RAISIG_AREAS_VECTOR_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Territorios_Ind%C3%ADgenas_RAISG/VectorTileServer',
-  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/grid_55km_prot_prop/FeatureServer',
+  [GRID_CELLS_PROTECTED_AREAS_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/prot_prop_grid_55k_dis/FeatureServer',
   [GRID_CELLS_FOCAL_SPECIES_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/species_data_55km/FeatureServer',
   [GRID_CELLS_LAND_HUMAN_PRESSURES_PERCENTAGE]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/human_pressure_55km/FeatureServer',
   [URBAN_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/gHM_Urban_0_to_8/MapServer',


### PR DESCRIPTION
## Update protected areas proportions service URL
### Description
This PR updates the URL of the layer that gets queried to retrieve the data of the percentage of protected areas per grid cell. This update is needed due to the l[ast changes on the grid layer](https://github.com/Vizzuality/half-earth-v3/pull/192)

A small change on the legend item `height` has also been made to avoid the scroll bar to be displayed on a single item.
### Designs
No designs needed for this task
### Testing instructions
Go to a marine area and check if the percentage of protected areas, on the landscape sidebar widget, is accurate.
### Feature relevant tickets
https://www.pivotaltracker.com/n/projects/2321903/stories/172643383