### PR TITLE
Feature/adjust local scene styles

### DIFF
--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -51,7 +51,7 @@ const DoubleScene = props => {
         _map.load().then(map => { 
           setMap(map);
           onMapLoad && onMapLoad(map);
-        })
+        });
       })
       .catch(err => {
         console.error(err);
@@ -92,7 +92,7 @@ const DoubleScene = props => {
 
   useEffect(() => {
     if(viewLocal && spatialReference && countryExtent) {
-      const expandedCountryExtent = countryExtent.clone();
+      const expandedCountryExtent = countryExtent.clone().expand(1.01);
       viewLocal.clippingArea = expandedCountryExtent;
       viewLocal.extent = expandedCountryExtent;
       viewLocal.when(() => {

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -2,6 +2,27 @@ import React, { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
 import Component from './double-scene-component';
 
+const LOCAL_SCENE_VIEW_SETTINGS = {
+  viewingMode: 'local',
+  constraints: {
+    tilt: {
+      max: 60
+    }
+  },
+  padding: {
+    left: 300,
+    bottom: 60
+  },
+  environment: {
+    background: {
+      type: "color",
+      color: [0, 0, 0, 1]
+    },
+    starsEnabled: false,
+    atmosphereEnabled: false
+  }
+}
+
 const DoubleScene = props => {
   const {
     sceneId,
@@ -57,19 +78,9 @@ const DoubleScene = props => {
             map: map,
             container: `scene-local-container-${sceneId}`,
             ...sceneSettings,
-            viewingMode: 'local',
             spatialReference,
-            constraints: {
-              tilt: {
-                max: 60
-              }
-            },
-            padding: {
-              left: 300,
-              bottom: 60
-            }
+            ...LOCAL_SCENE_VIEW_SETTINGS
           });
-          
           setViewLocal(_viewLocal);
         })
         .catch(err => {

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -20,7 +20,8 @@ const LOCAL_SCENE_VIEW_SETTINGS = {
     },
     starsEnabled: false,
     atmosphereEnabled: false
-  }
+  },
+
 }
 
 const DoubleScene = props => {
@@ -91,7 +92,7 @@ const DoubleScene = props => {
 
   useEffect(() => {
     if(viewLocal && spatialReference && countryExtent) {
-      const expandedCountryExtent = countryExtent.clone().expand(1.2); //add paddings around country borders
+      const expandedCountryExtent = countryExtent.clone();
       viewLocal.clippingArea = expandedCountryExtent;
       viewLocal.extent = expandedCountryExtent;
       viewLocal.when(() => {

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -1,14 +1,13 @@
 import { useEffect, useState } from 'react';
 import { loadModules } from 'esri-loader';
-import { GLOBAL_SCENE } from 'constants/view-props';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER, COUNTRY_MASK_LAYER } from 'constants/layers-slugs';
 import { LAYERS_URLS } from 'constants/layers-urls';
-import { MASK_STYLES, COUNTRY_BORDER_STYLES } from 'constants/graphic-styles';
+import { MASK_STYLES } from 'constants/graphic-styles';
 import { createGraphic, createGraphicLayer } from 'utils/graphic-layer-utils';
 
 const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode) => {
   loadModules(['esri/geometry/Polygon',"esri/Graphic", "esri/geometry/geometryEngine"]).then(([Polygon, Graphic, geometryEngine]) => {
-    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.2));
+    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.01));
     const query = countryLayer.createQuery();
     query.outSpatialReference = spatialReference;
     query.geometry = extentGeometry;
@@ -17,13 +16,9 @@ const queryCountryData = (countryLayer, countryISO, spatialReference, countryExt
     .then(async function(results){
         const { features } = results;
         const countryGeometry = features.find(({ attributes }) => attributes.GID_0 === countryISO).geometry;
-        const neighbourCountriesGeometry = features.filter(({ attributes }) => attributes.GID_0 !== countryISO);
         const maskGeometry = await geometryEngine.difference(extentGeometry, countryGeometry);
-        const borderGeometries = neighbourCountriesGeometry.map(gc => gc.geometry);
-
-        const graphics = borderGeometries.map(geo => createGraphic(Graphic, COUNTRY_BORDER_STYLES, geo));
         const maskGraphic = createGraphic(Graphic, MASK_STYLES, maskGeometry);
-        graphicsLayer.graphics = [maskGraphic, ...graphics];
+        graphicsLayer.graphics = [maskGraphic];
       })
       .catch((error) => {
         console.warn(error);

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -7,7 +7,7 @@ import { createGraphic, createGraphicLayer } from 'utils/graphic-layer-utils';
 
 const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode) => {
   loadModules(['esri/geometry/Polygon',"esri/Graphic", "esri/geometry/geometryEngine"]).then(([Polygon, Graphic, geometryEngine]) => {
-    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.01));
+    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.02));
     const query = countryLayer.createQuery();
     query.outSpatialReference = spatialReference;
     query.geometry = extentGeometry;

--- a/src/constants/graphic-styles.js
+++ b/src/constants/graphic-styles.js
@@ -1,7 +1,7 @@
 export const MASK_STYLES = {
   fillColor: [0, 0, 0],
-  fillOpacity: 0.7,
-  outlineColor: [216, 216, 216],
+  fillOpacity: 1,
+  outlineColor: [0, 0, 0],
   outlineOpacity: 0,
   outlineWidth: 2
 }


### PR DESCRIPTION
## [[HE-30] The user can see the country terrain on a black background](https://half-earth-map.atlassian.net/browse/HE-30)
### Description
This PR sets the black background on the local scene and displays only the area of the selected country. I achieved this effect by changing the opacity of the mask layer to 0.
![image](https://user-images.githubusercontent.com/15097138/88068105-b0699180-cb67-11ea-9b44-41ed7eb7eac3.png)

### Designs
[Local scene design with black background
](https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/421888343/preview?scrollOffset=4293)
### Testing instructions
Try different countries on the local scene
### Known issues
- The labels from other countries than selected are visible, we need to filter them by country somehow:
![image](https://user-images.githubusercontent.com/15097138/88069072-e52a1880-cb68-11ea-8276-739ec0908d21.png)

- After entering the local scene, for the first few seconds, we see the entire extent rectangle covered with the basemap, not only the country borders. It happens because the layers  require a few seconds to be ready - maybe we can avoid this by playing with the web scene styles:
![czl99-5skpq](https://user-images.githubusercontent.com/15097138/88069490-6ed9e600-cb69-11ea-906b-aec764d0d6fe.gif)

- As we no longer need a connection between local and global scene views, we can consider creating two separate maps (web scenes, each for scene view). This can help with customizing the local scene and may increase the performance of it.