### PR TITLE
Chore/separate webscenes for local and global view

### DIFF
--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -81,7 +81,7 @@ const CountryLabelsLayerComponent = props => {
     return function cleanUp() {
       if (graphicLayer) { graphicLayer.remove(countryPinMarker)}
     }
-  }, [layerReady, countryExtent, countryISO])
+  }, [layerReady, countryExtent])
 
   useEffect(() => {
     if (layerReady) {

--- a/src/components/country-labels-layer/country-labels-layer-component.jsx
+++ b/src/components/country-labels-layer/country-labels-layer-component.jsx
@@ -8,7 +8,7 @@ import mapPinIcon from 'icons/map_pin.svg'
 import { layersConfig } from 'constants/mol-layers-configs';
 
 const CountryLabelsLayerComponent = props => {
-  const { map, isLandscapeMode, isCountryMode, countryName, countryISO, countryExtent } = props;
+  const { map, isLandscapeMode, countryName, countryISO, countryExtent } = props;
 
   const [labelingInfo, setLabelingInfo] = useState(null)
   const [layerReady, setLayerReady] = useState(false)
@@ -21,7 +21,6 @@ const CountryLabelsLayerComponent = props => {
         labelExpressionInfo: {
           expression: "$feature.NAME_0"
         },
-        where: countryName && isCountryMode ? `NAME_0 <> '${countryName}'` : null,
         symbol: {
           type: "text",
           color: [213,207,202],
@@ -36,7 +35,7 @@ const CountryLabelsLayerComponent = props => {
       });
       setLabelingInfo(_labelingInfo);
     })
-  }, [countryName, isCountryMode]);
+  }, [countryName]);
 
   useEffect(() => {
       if (labelingInfo) {
@@ -63,7 +62,7 @@ const CountryLabelsLayerComponent = props => {
   useEffect(() => {
     let graphicLayer;
     let countryPinMarker;
-    if (layerReady && countryISO && !isCountryMode) {
+    if (layerReady && countryISO) {
       loadModules(["esri/Graphic"])
       .then(([Graphic]) => {
         graphicLayer = findLayerInMap(GRAPHIC_LAYER, map);
@@ -75,14 +74,14 @@ const CountryLabelsLayerComponent = props => {
             geometry: features[0].geometry,
             symbol: simplePictureMarker(mapPinIcon, { height: 24, width: 24, yoffset: -10 })
           });
-          graphicLayer.add(countryPinMarker)
+          if(graphicLayer) graphicLayer.add(countryPinMarker);
         })
       })
     }
     return function cleanUp() {
       if (graphicLayer) { graphicLayer.remove(countryPinMarker)}
     }
-  }, [layerReady, countryExtent, isCountryMode, countryISO])
+  }, [layerReady, countryExtent, countryISO])
 
   useEffect(() => {
     if (layerReady) {

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -27,7 +27,7 @@ const DoubleSceneComponent = props => {
           {loadState === 'loaded' && 
             ReactDOM.createPortal(
               React.Children.map(children || null, (child, i) => {
-                return child && <child.type key={i} map={globalMap} maps={[localMap, globalMap]} view={viewGlobal} viewLocal={viewLocal} spatialReference={spatialReference} {...child.props}/>;
+                return child && <child.type key={i} map={globalMap} localMap={localMap} view={viewGlobal} viewLocal={viewLocal} spatialReference={spatialReference} {...child.props}/>;
               })
               ,
               document.getElementById("root")

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -6,7 +6,8 @@ import styles from 'styles/themes/scene-theme.module.scss';
 
 const DoubleSceneComponent = props => {
   const {
-    map,
+    localMap,
+    globalMap,
     viewGlobal,
     viewLocal,
     spatialReference,
@@ -27,7 +28,7 @@ const DoubleSceneComponent = props => {
           {loadState === 'loaded' && 
             ReactDOM.createPortal(
               React.Children.map(children || null, (child, i) => {
-                return child && <child.type key={i} map={map} view={viewGlobal} viewLocal={viewLocal} spatialReference={spatialReference} {...child.props}/>;
+                return child && <child.type key={i} map={globalMap} maps={[localMap, globalMap]} view={viewGlobal} viewLocal={viewLocal} spatialReference={spatialReference} {...child.props}/>;
               })
               ,
               document.getElementById("root")

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Spinner from 'components/spinner';
-import { LOCAL_SCENE, GLOBAL_SCENE } from 'constants/view-props';
 import styles from 'styles/themes/scene-theme.module.scss';
 
 const DoubleSceneComponent = props => {
@@ -17,13 +16,13 @@ const DoubleSceneComponent = props => {
     children,
     interactionsDisabled,
     style,
-    sceneMode
+    isCountryMode
   } = props;
   
   return (
     <>
       {loadState === 'loading' && <Spinner spinnerWithOverlay initialLoading display={spinner}/>}
-      <div style={{ height: '100%', position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', display: sceneMode === GLOBAL_SCENE ? 'initial' : 'none'}}>
+      <div style={{ height: '100%', position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', display: !isCountryMode ? 'initial' : 'none'}}>
         <div id={`scene-global-container-${sceneId}`} className={styles.sceneContainer} style={{width: '100%', height:'100%', ...style}}>
           {loadState === 'loaded' && 
             ReactDOM.createPortal(
@@ -36,7 +35,7 @@ const DoubleSceneComponent = props => {
           }
         </div>
       </div>
-      <div style={{ height: '100%',  position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', display: sceneMode === LOCAL_SCENE ? 'initial' : 'none'}}>
+      <div style={{ height: '100%',  position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', opacity: isCountryMode ? 'initial' : 'none'}}>
         <div id={`scene-local-container-${sceneId}`} style={{width:'100%', height:'100%', ...style}}></div>
       </div>
     </>

--- a/src/components/double-scene/double-scene-component.jsx
+++ b/src/components/double-scene/double-scene-component.jsx
@@ -35,7 +35,7 @@ const DoubleSceneComponent = props => {
           }
         </div>
       </div>
-      <div style={{ height: '100%',  position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', opacity: isCountryMode ? 'initial' : 'none'}}>
+      <div style={{ height: '100%',  position: 'relative', width: '100%', pointerEvents: interactionsDisabled ? 'none' : 'unset', display: isCountryMode ? 'initial' : 'none'}}>
         <div id={`scene-local-container-${sceneId}`} style={{width:'100%', height:'100%', ...style}}></div>
       </div>
     </>

--- a/src/components/double-scene/double-scene.js
+++ b/src/components/double-scene/double-scene.js
@@ -31,7 +31,8 @@ const DoubleScene = props => {
     sceneSettings,
     onMapLoad = null,
     onViewLoad = null,
-    countryExtent
+    countryExtent,
+    isCountryMode
   } = props;
 
   const [globalMap, setGlobalMap] = useState(null);
@@ -111,17 +112,6 @@ const DoubleScene = props => {
         });
     }
   },[localMap]);
-
-  useEffect(() => {
-    if(viewLocal && spatialReference && countryExtent) {
-      const expandedCountryExtent = countryExtent.clone().expand(1.01);
-      viewLocal.clippingArea = expandedCountryExtent;
-      viewLocal.extent = expandedCountryExtent;
-      viewLocal.when(() => {
-        viewLocal.goTo({ target: expandedCountryExtent, tilt: 40 }, { animate: false });
-      });
-    };
-  },[countryExtent]);
   
   useEffect(() => {
     if (globalMap && localMap && viewGlobal && viewLocal) {
@@ -129,6 +119,18 @@ const DoubleScene = props => {
       onViewLoad && onViewLoad(globalMap, viewGlobal)
     }
   }, [globalMap, viewGlobal, viewLocal, localMap]);
+
+
+  useEffect(() => {
+    if(viewLocal && spatialReference && countryExtent && isCountryMode) {
+      const expandedCountryExtent = countryExtent.clone().expand(1.01);
+      viewLocal.clippingArea = expandedCountryExtent;
+      viewLocal.extent = expandedCountryExtent;
+      viewLocal.when(() => {
+        viewLocal.goTo({ target: expandedCountryExtent, tilt: 40 }, { animate: false });
+      });
+    };
+  },[isCountryMode, countryExtent]);
 
   return (
     <Component

--- a/src/components/mask-country-manager/mask-country-manager.js
+++ b/src/components/mask-country-manager/mask-country-manager.js
@@ -5,9 +5,12 @@ import { LAYERS_URLS } from 'constants/layers-urls';
 import { MASK_STYLES } from 'constants/graphic-styles';
 import { createGraphic, createGraphicLayer } from 'utils/graphic-layer-utils';
 
-const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode) => {
+const queryCountryData = (countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer) => {
   loadModules(['esri/geometry/Polygon',"esri/Graphic", "esri/geometry/geometryEngine"]).then(([Polygon, Graphic, geometryEngine]) => {
-    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.02));
+    const extentGeometry = Polygon.fromExtent(countryExtent.clone().expand(1.1));
+    const maskGraphic = createGraphic(Graphic, MASK_STYLES, extentGeometry);
+    graphicsLayer.graphics = [maskGraphic];
+
     const query = countryLayer.createQuery();
     query.outSpatialReference = spatialReference;
     query.geometry = extentGeometry;
@@ -27,7 +30,7 @@ const queryCountryData = (countryLayer, countryISO, spatialReference, countryExt
 };
 
 const MaskCountryManager = props => {
-  const { viewLocal, spatialReference, countryISO, countryExtent, isCountryMode, sceneMode } = props;
+  const { viewLocal, spatialReference, countryISO, countryExtent, isCountryMode } = props;
   const [countryLayer, setCountryLayer] = useState(null);
   const [graphicsLayer, setGraphicsLayer] = useState(null);
 
@@ -50,23 +53,10 @@ const MaskCountryManager = props => {
   }, []);
 
   useEffect(() => {
-    if(graphicsLayer) {
-      graphicsLayer.visible = isCountryMode;
-    }
-  }, [countryExtent, isCountryMode]);
-
-  useEffect(() => {
     if (countryLayer && countryISO  && spatialReference && countryExtent && graphicsLayer && isCountryMode) {
-      graphicsLayer.graphics = [];
       queryCountryData(countryLayer, countryISO, spatialReference, countryExtent, graphicsLayer, isCountryMode);
     }
   }, [countryExtent, isCountryMode]);
-
-  useEffect(() => {
-    if (graphicsLayer && (!countryISO || !isCountryMode)) {
-      graphicsLayer.graphics = [];
-    }
-  },[countryISO, sceneMode]);
 
   return null
 }

--- a/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
+++ b/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { loadModules } from 'esri-loader';
 
-const exaggeratedElevationLayerComponent = ({ maps, exaggeration = 2}) => {
+const exaggeratedElevationLayerComponent = ({ map, localMap, exaggeration = 2}) => {
 
   useEffect(() => {
     loadModules(["esri/layers/ElevationLayer", "esri/layers/BaseElevationLayer"]).then(([ElevationLayer, BaseElevationLayer]) => {
@@ -34,11 +34,11 @@ const exaggeratedElevationLayerComponent = ({ maps, exaggeration = 2}) => {
             }.bind(this));
         }
       });
-      maps.forEach(map => map.ground.layers = [new ExaggeratedElevationLayer()]);
+      [map, localMap].forEach(map => map.ground.layers = [new ExaggeratedElevationLayer()]);
     })
 
     return () => {
-      maps.forEach(map => map.ground.layers = []);
+      [map, localMap].forEach(map => map.ground.layers = []);
     }
   }, [])
 

--- a/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
+++ b/src/components/terrain-exaggeration-layer/terrain-exaggeration-layer-component.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { loadModules } from 'esri-loader';
 
-const exaggeratedElevationLayerComponent = ({ map, exaggeration = 2}) => {
+const exaggeratedElevationLayerComponent = ({ maps, exaggeration = 2}) => {
 
   useEffect(() => {
     loadModules(["esri/layers/ElevationLayer", "esri/layers/BaseElevationLayer"]).then(([ElevationLayer, BaseElevationLayer]) => {
@@ -34,12 +34,11 @@ const exaggeratedElevationLayerComponent = ({ map, exaggeration = 2}) => {
             }.bind(this));
         }
       });
-    
-      map.ground.layers = [new ExaggeratedElevationLayer()];
+      maps.forEach(map => map.ground.layers = [new ExaggeratedElevationLayer()]);
     })
 
     return () => {
-      map.ground.layers = [];
+      maps.forEach(map => map.ground.layers = []);
     }
   }, [])
 

--- a/src/constants/graphic-styles.js
+++ b/src/constants/graphic-styles.js
@@ -1,8 +1,8 @@
 export const MASK_STYLES = {
   fillColor: [0, 0, 0],
   fillOpacity: 1,
-  outlineColor: [0, 0, 0],
-  outlineOpacity: 0,
+  outlineColor: [147, 255, 95],
+  outlineOpacity: 0.9,
   outlineWidth: 2
 }
 

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -66,6 +66,7 @@ const DataGlobeComponent = ({
         onMapLoad={(map) => handleMapLoad(map, activeLayers)}
         sceneMode={sceneMode}
         countryExtent={countryExtent}
+        isCountryMode={isCountryMode}
       >
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>
@@ -124,7 +125,7 @@ const DataGlobeComponent = ({
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}
         <LabelsLayer isLandscapeMode={isLandscapeMode} isCountryMode={isCountryMode} countryName={countryName}/>
-        <MaskCountryManager countryISO={countryISO} countryExtent={countryExtent} isCountryMode={isCountryMode} sceneMode={sceneMode}/>
+        <MaskCountryManager countryISO={countryISO} countryExtent={countryExtent} isCountryMode={isCountryMode}/>
         {isLandscapeMode && <ProtectedAreasTooltips activeLayers={activeLayers} isLandscapeMode={isLandscapeMode} />}
       </DoubleScene>
       <TutorialModal />

--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -115,11 +115,11 @@ const DataGlobeComponent = ({
             isLandscapeSidebarCollapsed={isLandscapeSidebarCollapsed}
           />
         }
-        <Legend
+        {!isCountryMode && <Legend
           isFullscreenActive={isFullscreenActive}
           activeLayers={activeLayers}
-        />
-        <CountryBorderLayer countryISO={countryISO} isCountryMode={isCountryMode}/>
+        />}
+        <CountryBorderLayer countryISO={countryISO}/>
         <CountryLabelsLayer countryISO={countryISO} isCountryMode={isCountryMode} isLandscapeMode={isLandscapeMode} countryName={countryName} countryExtent={countryExtent}/>
         {isLandscapeMode && <GridLayer handleGlobeUpdating={handleGlobeUpdating}/>}
         {(isLandscapeMode || isCountryMode) && <TerrainExaggerationLayer exaggeration={isCountryMode ? 20 : 3}/>}

--- a/src/pages/data-globe/data-globe.js
+++ b/src/pages/data-globe/data-globe.js
@@ -10,13 +10,10 @@ const actions = {...urlActions};
 
 const DataGlobeContainer = props => {
 
-
-const handleGlobeUpdating = (updating) => props.changeGlobe({ isGlobeUpdating: updating });
-
+  const handleGlobeUpdating = (updating) => props.changeGlobe({ isGlobeUpdating: updating });
   const handleMapLoad = (map, activeLayers) => {
     activateLayersOnLoad(map, activeLayers, layersConfig);
   }
-
 
   return (
     <DataGlobeComponent


### PR DESCRIPTION
## [[HE-43] Implement two separate Web Scenes for global and local Scene View](https://half-earth-map.atlassian.net/browse/HE-43?atlOrigin=eyJpIjoiZGI2MTcwZjI0NzcyNDk1Yjg4MDQxNDkxMmE4NGQ2ZjAiLCJwIjoiaiJ9)
### Description
This PR introduces two separate Web Scenes for each global and local Scene View. This change is important for further local scene development, as we no longer need a connection between local and global scene views.
### Testing instructions
Go to the `Explore Data` and test the local scene map by trying different countries; just make sure that everything works as it supposes to.
### Feature relevant tickets
It needs to be merged before starting the [labels on the local scene task](https://half-earth-map.atlassian.net/browse/HE-44).