### PR TITLE
Feature/sources metadata

### DIFF
--- a/src/components/legend/legend.js
+++ b/src/components/legend/legend.js
@@ -4,6 +4,7 @@ import { intersection } from 'lodash';
 import Component from './legend-component';
 import { layerManagerOrder, layerManagerOpacity, layerManagerVisibility, batchLayerManagerToggle, batchLayerManagerOpacity } from 'utils/layer-manager-utils';
 import metadataActions from 'redux_modules/metadata';
+import metadataConfig from 'constants/metadata';
 import * as urlActions from 'actions/url-actions';
 import { changeLayerOpacityAnalyticsEvent, openLayerInfoModalAnalyticsEvent, removeLayerAnalyticsEvent, changeLayersOrderAnalyticsEvent } from 'actions/google-analytics-actions';
 import { VIEW_MODE } from 'constants/google-analytics-constants';
@@ -42,12 +43,13 @@ const LegendContainer = props => {
 
   const handleInfoClick = layer => {
     const { setModalMetadata, openLayerInfoModalAnalyticsEvent } = props;
+    const slug = getSlug(layer);
     setModalMetadata({
-      slug: getSlug(layer),
-      title: `${layer.legendConfig.title} metadata`,
+      slug,
+      title: metadataConfig[slug].title,
       isOpen: true
     });
-    openLayerInfoModalAnalyticsEvent({ slug: getSlug(layer), query: { viewMode: VIEW_MODE.LEGEND }});
+    openLayerInfoModalAnalyticsEvent({ slug, query: { viewMode: VIEW_MODE.LEGEND }});
   };
   
   const spreadGroupLayers = (layers, activeLayers) => {

--- a/src/components/local-scene-sidebar/country-data-card/country-data-card-component.jsx
+++ b/src/components/local-scene-sidebar/country-data-card/country-data-card-component.jsx
@@ -10,6 +10,7 @@ const CountryDataCardComponent = ({
   countryName,
   indexStatement,
   vertebratesCount,
+  handleInfoClick,
   protectionNeeded,
   currentProtection,
   countryDescription,
@@ -25,7 +26,9 @@ const CountryDataCardComponent = ({
           <p className={styles.countryName}>{countryName}</p>
         </div>
         <div className={styles.overviewTextWrapper}>
-          <QuestionIcon />
+          <button onClick={handleInfoClick}>
+            <QuestionIcon />
+          </button>
           <p className={styles.overviewText}>The species protection index is:</p>
         </div>
         <div className={styles.indexWrapper}>

--- a/src/components/local-scene-sidebar/country-data-card/country-data-card.js
+++ b/src/components/local-scene-sidebar/country-data-card/country-data-card.js
@@ -1,3 +1,27 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import metadataActions from 'redux_modules/metadata';
+import metadataConfig from 'constants/metadata';
+import { SPECIES_PROTECTION_INDEX } from 'constants/metadata';
 import Component from './country-data-card-component';
 
-export default Component;
+const CountryDataCardContainer = props => {
+  const handleInfoClick = () => {
+    const { setModalMetadata } = props;
+    const md = metadataConfig[SPECIES_PROTECTION_INDEX]
+    setModalMetadata({
+      slug: md.slug,
+      title: md.title,
+      isOpen: true
+    });
+  }
+
+  return (
+  <Component
+    handleInfoClick={handleInfoClick}
+    {...props}
+  />
+  )
+}
+
+export default connect(null, metadataActions)(CountryDataCardContainer);

--- a/src/components/local-scene-sidebar/local-priority-card/local-priority-card-component.jsx
+++ b/src/components/local-scene-sidebar/local-priority-card/local-priority-card-component.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import LocalSceneCard from 'components/local-scene-card';
+import {
+  MERGED_PROTECTION,
+  COUNTRY_PRIORITY
+} from 'constants/metadata';
 import styles from './local-priority-card-styles.module.scss';
 
 const LocalPriorityCardComponent = ({
   sourceDate,
+  handleInfoClick,
   protectionNeeded,
-  currentProtection
+  currentProtection,
 }) => {
   return (
     <LocalSceneCard>
@@ -18,7 +23,7 @@ const LocalPriorityCardComponent = ({
               The green areas on the map represent
               the current protected areas.
             </p>
-            <p className={styles.datasetSource}>
+            <p className={styles.datasetSource} onClick={() => handleInfoClick(MERGED_PROTECTION)}>
               {`Source: The World Database on Protected Areas (WDPA) (${sourceDate}).`}
             </p>
           </div>
@@ -37,7 +42,7 @@ const LocalPriorityCardComponent = ({
             locations within the country that contribute more to the 
             conservation of species habitat.
             </p>
-            <p className={styles.datasetSource}>
+            <p className={styles.datasetSource} onClick={() => handleInfoClick(COUNTRY_PRIORITY)}>
               Source: Rinnan DS and Jetz W, (2020).
             </p>
           </div>

--- a/src/components/local-scene-sidebar/local-priority-card/local-priority-card-styles.module.scss
+++ b/src/components/local-scene-sidebar/local-priority-card/local-priority-card-styles.module.scss
@@ -58,4 +58,9 @@
   @extend %annotation;
   color: $_temporary-light-text;
   margin: 0;
+
+  &:hover {
+    cursor: pointer;
+    text-decoration: underline;
+  }
 }

--- a/src/components/local-scene-sidebar/local-priority-card/local-priority-card.js
+++ b/src/components/local-scene-sidebar/local-priority-card/local-priority-card.js
@@ -1,3 +1,26 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import metadataActions from 'redux_modules/metadata';
+import metadataConfig from 'constants/metadata';
 import Component from './local-priority-card-component';
 
-export default Component;
+const LocalPriorityCardContainer = props => {
+  const handleInfoClick = slug => {
+    const { setModalMetadata } = props;
+    const md = metadataConfig[slug];
+    setModalMetadata({
+      slug: md.slug,
+      title: md.title,
+      isOpen: true
+    });
+  }
+
+  return (
+  <Component
+    handleInfoClick={handleInfoClick}
+    {...props}
+  />
+  )
+}
+
+export default connect(null, metadataActions)(LocalPriorityCardContainer);

--- a/src/components/modal-metadata/modal-metadata-component.jsx
+++ b/src/components/modal-metadata/modal-metadata-component.jsx
@@ -67,7 +67,7 @@ const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata }) => {
                 )
             }
             {
-              metadata && metadata.molLogo === "true" && (
+              metadata && metadata.molLogo === "TRUE" && (
               <div className={styles.logoContainer}>
                 <a href="https://mol.org/" target="_blank" rel="noopener noreferrer">
                   <img

--- a/src/components/modal-metadata/modal-metadata-styles.module.scss
+++ b/src/components/modal-metadata/modal-metadata-styles.module.scss
@@ -22,6 +22,11 @@
   
 }
 
+.closeBtn {
+  background-color: transparent;
+  border: none;
+}
+
 .metadataDescription {
   margin: $site-gutter 0;
 }

--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -1,5 +1,5 @@
 // Protected areas layers. Based on WDPA and RAISIG data.
-export const MERGED_WDPA_VECTOR_TILE_LAYER = 'merged_WDPA_vector_tile_layer';
+export const MERGED_WDPA_VECTOR_TILE_LAYER = 'merged-protected';
 export const PROTECTED_AREAS_FEATURE_LAYER = 'protected_areas_feature_layer';
 export const PROTECTED_AREAS_VECTOR_TILE_LAYER = 'protected_areas_vector_tile_layer';
 export const COMMUNITY_AREAS_FEATURE_LAYER = 'community_areas_feature_layer';

--- a/src/constants/metadata.js
+++ b/src/constants/metadata.js
@@ -1,0 +1,200 @@
+import {
+  MERGED_WDPA_VECTOR_TILE_LAYER,
+  SA_AMPHIB_RARITY,
+  SA_AMPHIB_RICHNESS,
+  SA_DRAGONFLIES_RARITY,
+  SA_DRAGONFLIES_RICHNESS,
+  SA_MAMMALS_RARITY,
+  SA_MAMMALS_RICHNESS,
+  SA_BIRDS_RARITY,
+  SA_BIRDS_RICHNESS,
+  SA_RESTIO_RARITY,
+  SA_RESTIO_RICHNESS,
+  SA_PROTEA_RARITY,
+  SA_PROTEA_RICHNESS,
+  SA_REPTILES_RARITY,
+  SA_REPTILES_RICHNESS,
+  HUMMINGBIRDS_RICHNESS,
+  HUMMINGBIRDS_RARITY,
+  MAMMALS_RARITY,
+  MAMMALS_RICHNESS,
+  FISHES_RARITY,
+  FISHES_RICHNESS,
+  CONIFERS_RARITY,
+  CONIFERS_RICHNESS,
+  CACTI_RARITY,
+  CACTI_RICHNESS,
+  AMPHIB_RARITY,
+  AMPHIB_RICHNESS,
+  REPTILES_RICHNESS,
+  REPTILES_RARITY,
+  BIRDS_RARITY,
+  BIRDS_RICHNESS,
+  ALL_TAXA_RARITY,
+  ALL_TAXA_RICHNESS,
+  COUNTRY_PRIORITY_LAYER,
+  COMMUNITY_AREAS_VECTOR_TILE_LAYER,
+  PROTECTED_AREAS_VECTOR_TILE_LAYER,
+  MERGED_LAND_HUMAN_PRESSURES
+ } from 'constants/layers-slugs';
+
+ export const SPECIES_PROTECTION_INDEX = 'spi-def';
+ export const MERGED_PROTECTION = MERGED_WDPA_VECTOR_TILE_LAYER;
+ export const COUNTRY_PRIORITY = COUNTRY_PRIORITY_LAYER;
+
+export default {
+  [MERGED_PROTECTION]: {
+    slug: MERGED_PROTECTION,
+    title: 'Protected Areas'
+  },
+  [SPECIES_PROTECTION_INDEX]: {
+    slug: SPECIES_PROTECTION_INDEX,
+    title: 'Species Protection Index'
+  },
+  [SA_AMPHIB_RARITY]: {
+    slug: SA_AMPHIB_RARITY,
+    title: "Amphibian regional rarity"
+  },
+  [SA_AMPHIB_RICHNESS]: {
+    slug: SA_AMPHIB_RICHNESS,
+    title: "Amphibian regional richness"
+  },
+  [SA_DRAGONFLIES_RARITY]: {
+    slug: SA_DRAGONFLIES_RARITY,
+    title: "Dragonflies rarity"
+  },
+  [SA_DRAGONFLIES_RICHNESS]: {
+    slug: SA_DRAGONFLIES_RICHNESS,
+    title: "Dragonflies richness"
+  },
+  [SA_MAMMALS_RARITY]: {
+    slug: SA_MAMMALS_RARITY,
+    title: "Mammals regional rarity"
+  },
+  [SA_MAMMALS_RICHNESS]: {
+    slug: SA_MAMMALS_RICHNESS,
+    title: "Mammals regional richness"
+  },
+  [SA_BIRDS_RARITY]: {
+    slug: SA_BIRDS_RARITY,
+    title: "Birds regional rarity"
+  },
+  [SA_BIRDS_RICHNESS]: {
+    slug: SA_BIRDS_RICHNESS,
+    title: "Birds regional richness"
+  },
+  [SA_RESTIO_RARITY]: {
+    slug: SA_RESTIO_RARITY,
+    title: "Restio regional rarity"
+  },
+  [SA_RESTIO_RICHNESS]: {
+    slug: SA_RESTIO_RICHNESS,
+    title: "Restio regional richness"
+  },
+  [SA_PROTEA_RARITY]: {
+    slug: SA_PROTEA_RARITY,
+    title: "Protea regional rarity"
+  },
+  [SA_PROTEA_RICHNESS]: {
+    slug: SA_PROTEA_RICHNESS,
+    title: "Protea regional richness"
+  },
+  [SA_REPTILES_RARITY]: {
+    slug: SA_REPTILES_RARITY,
+    title: "Reptiles regional rarity"
+  },
+  [SA_REPTILES_RICHNESS]: {
+    slug: SA_REPTILES_RICHNESS,
+    title: "Reptiles regional richness"
+  },
+  // Hummingbirds
+  [HUMMINGBIRDS_RICHNESS]: {
+    slug: HUMMINGBIRDS_RICHNESS,
+    title: "Hummingbirds richness"
+  },
+  [HUMMINGBIRDS_RARITY]: {
+    slug: HUMMINGBIRDS_RARITY,
+    title: "Hummingbirds rarity"
+  },
+  // Global data
+  [MAMMALS_RARITY]: {
+    slug: MAMMALS_RARITY,
+    title: "Mammals rarity"
+  },
+  [MAMMALS_RICHNESS]: {
+    slug: MAMMALS_RICHNESS,
+    title: "Mammals richness"
+  },
+  [FISHES_RARITY]: {
+    slug: FISHES_RARITY,
+    title: "Fishes rarity"
+  },
+  [FISHES_RICHNESS]: {
+    slug: FISHES_RICHNESS,
+    title: "Fishes richness"
+  },
+  [CONIFERS_RARITY]: {
+    slug: CONIFERS_RARITY,
+    title: "Conifers rarity"
+  },
+  [CONIFERS_RICHNESS]: {
+    slug: CONIFERS_RICHNESS,
+    title: "Conifers richness"
+  },
+  [CACTI_RARITY]: {
+    slug: CACTI_RARITY,
+    title: "Cacti rarity"
+  },
+  [CACTI_RICHNESS]: {
+    slug: CACTI_RICHNESS,
+    title: "Cacti richness"
+  },
+  [AMPHIB_RARITY]: {
+    slug: AMPHIB_RARITY,
+    title: "Amphibian rarity"
+  },
+  [AMPHIB_RICHNESS]: {
+    slug: AMPHIB_RICHNESS,
+    title: "Amphibian richness"
+  },
+  [REPTILES_RICHNESS]: {
+    slug: REPTILES_RICHNESS,
+    title: "Reptile richness"
+  },
+  [REPTILES_RARITY]: {
+    slug: REPTILES_RARITY,
+    title: "Reptile rarity"
+  },
+  [BIRDS_RARITY]: {
+    slug: BIRDS_RARITY,
+    title: "Birds rarity"
+  },
+  [BIRDS_RICHNESS]: {
+    slug: BIRDS_RICHNESS,
+    title: "Birds richness"
+  },
+  [ALL_TAXA_RARITY]: {
+    slug: ALL_TAXA_RARITY,
+    title: "All groups rarity"
+  },
+  [ALL_TAXA_RICHNESS]: {
+    slug: ALL_TAXA_RICHNESS,
+    title: "All groups richness"
+  },
+  [COUNTRY_PRIORITY_LAYER]: {
+    slug: COUNTRY_PRIORITY_LAYER,
+    title: "Protection needed"
+  },
+  [COMMUNITY_AREAS_VECTOR_TILE_LAYER]: {
+    slug: COMMUNITY_AREAS_VECTOR_TILE_LAYER,
+    title: "Community-based protected areas"
+  },
+  [PROTECTED_AREAS_VECTOR_TILE_LAYER]: {
+    slug: PROTECTED_AREAS_VECTOR_TILE_LAYER,
+    title: "Protected areas"
+  },
+  [MERGED_LAND_HUMAN_PRESSURES]: {
+    slug: MERGED_LAND_HUMAN_PRESSURES,
+    title: "Land use pressures"
+  }
+}


### PR DESCRIPTION
## Metadata for the NRCs

### Description
This PR addresses some (not all) metadata needs for the National Report Cards. 
Functionality wise this PR allows the display of the metadata modals for the new items on the National Report Cards, that is the Species Protection Index information, the Protection needed (A.K.A Countries Priority) and the Protected Areas (the merged WDPA, RAISG and OCM).
We have left out of this PR the modals for the Challenges chart and the SPI ranking since those are gonna be handled on separated PRs
On the implementation side some updates on the way the metadata is handled have been made. We have now a `metadata` constants file where we gather the configuration for the metadata in order to decouple it from the legend config and to be able to add non layer related metadata items (as the Species Protection Index)

### Designs
This PR does not significantly changes any of the previous metadata look and feel (but feel free to check the designs on [the inVision prototype](https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/426389118/preview?scrollOffset=4509))

### Testing instructions
Since some changes have been made on the way the metadata is consumed from the legens would be great to test the legend info buttons (also in the data/global mode) and the metadata triggers on the National Report Cards (SPI question mark, Protection needed and protected areas sources).
Please @gretacv , @tamaramegan validate the texts on the metadata modal titles.

### Feature relevant tickets
[Priority metadata](https://half-earth-map.atlassian.net/browse/HE-49)
[Sources metadata](https://half-earth-map.atlassian.net/browse/HE-53)
[SPI metadata](https://half-earth-map.atlassian.net/browse/HE-23)