### PR TITLE
Feature/challenges chart units

### DIFF
--- a/src/components/charts/scatter-plot/scatter-plot-component.jsx
+++ b/src/components/charts/scatter-plot/scatter-plot-component.jsx
@@ -16,6 +16,7 @@ const ScatterPlot = ({
   xAxisLabels,
   onBubbleClick,
   handleContainerClick,
+  tooltipValuesFormats,
   countryChallengesSelectedKey,
 }) => {
   const chartSurfaceRef = useRef(null);
@@ -162,6 +163,7 @@ const ScatterPlot = ({
           country.width = isSelectedCountry ? bigBubble : smallBubble;
           country.height = isSelectedCountry ? bigBubble : smallBubble;
           country.alpha = isSelectedCountry ? 1 : 0.6;
+          
           country.on('pointerover', e => {
             setTooltipState({
               x: e.data.global.x,
@@ -171,7 +173,7 @@ const ScatterPlot = ({
               color: country.attributes.color,
               yValue: Number.parseFloat(country.attributes.yAxisValue).toFixed(2),
               yLabel: 'Species Protection Index',
-              xValue: filter => country.attributes.xAxisValues[filter],
+              xValue: filter => tooltipValuesFormats[filter](country.attributes.xAxisValues[filter]),
               xLabel: filter => xAxisLabels[filter]
             })
             if (!isSelectedCountry) {

--- a/src/components/country-challenges-chart/country-challenges-chart-component.jsx
+++ b/src/components/country-challenges-chart/country-challenges-chart-component.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import ScatterPlot from 'components/charts/scatter-plot';
+import { countryChallengesChartFormats } from 'utils/data-formatting-utils';
 import { INDICATOR_LABELS, CHALLENGES_RELATED_FILTERS_OPTIONS, FILTERS_DICTIONARY } from 'constants/country-mode-constants';
 import styles from './country-challenges-chart-styles.module.scss';
 import { ReactComponent as ArrowButton } from 'icons/arrow_right.svg';
@@ -62,6 +63,7 @@ const CountryChallengesChartComponent = ({
         yAxisTicks={yAxisTicks}
         onBubbleClick={handleBubbleClick}
         handleContainerClick={handleOutsideFiltersClick}
+        tooltipValuesFormats={countryChallengesChartFormats}
         countryChallengesSelectedKey={countryChallengesSelectedKey}
       />
       <div className={styles.xAxisContainer}>

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -1,6 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { CONTINENT_COLORS } from 'constants/country-mode-constants';
 import { getCountryChallengesSelectedFilter, getCountryISO } from 'pages/data-globe/data-globe-selectors';
+import { countryChallengesChartFormats } from 'utils/data-formatting-utils';
 import * as d3 from 'd3';
 
 const selectCountriesData = ({ countryData }) => (countryData && countryData.data) || null;
@@ -53,9 +54,12 @@ const getXAxisTicks = createSelector(
   [getFilteredData, getCountryChallengesSelectedKey],
   (plotData, selectedKey) => {
     if (!plotData || !selectedKey) return null;
+    const highValue = d3.max(plotData, d => d.xAxisValues[selectedKey])
+    const lowValue = d3.min(plotData, d => d.xAxisValues[selectedKey])
+    const formatFunction = countryChallengesChartFormats[selectedKey];
     return [
-      d3.min(plotData, d => d.xAxisValues[selectedKey]),
-      d3.max(plotData, d => d.xAxisValues[selectedKey])
+      formatFunction(lowValue),
+      formatFunction(highValue)
     ]
   }
 )

--- a/src/utils/data-formatting-utils.js
+++ b/src/utils/data-formatting-utils.js
@@ -1,0 +1,12 @@
+import * as d3 from 'd3';
+
+export const currencyFormatting = d3.format("$,.2f");
+export const localeFormatting = d3.format(",.0f");
+
+export const countryChallengesChartFormats = {
+  Population2016: value => localeFormatting(value),
+  GNI_PPP: value => `${currencyFormatting(value)} B`,
+  prop_hm_very_high: value => `${d3.format(".2f")(value)}%`,
+  total_endemic: value => localeFormatting(value),
+  N_SPECIES: value => localeFormatting(value),
+}


### PR DESCRIPTION
## Add units to country challenges chart
### Description
We have added units to chart ticks and tooltips following the specification from [this jira ticket](https://half-earth-map.atlassian.net/browse/HE-82)
### Designs
_not applicable_
### Testing instructions
Go into the country scene (National Report Card) and play with challenges chart indicators and tooltips.
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-82