### PR TITLE
Feature/country highlighted species

### DIFF
--- a/src/components/country-challenges-chart/country-challenges-chart-component.jsx
+++ b/src/components/country-challenges-chart/country-challenges-chart-component.jsx
@@ -37,7 +37,7 @@ const CountryChallengesChartComponent = ({
   return (
     <div className={className}>
       <div>
-        <span className={styles.chartTitle}>Countries challenges</span>
+        <span className={styles.chartTitle}>Country challenges</span>
         <QuestionIcon className={styles.question} onClick={handleInfoClick} />
       </div>
       <div className={styles.filterSelectContainer}>

--- a/src/components/country-entry-tooltip/country-entry-tooltip.js
+++ b/src/components/country-entry-tooltip/country-entry-tooltip.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER as layerSlug } from 'constants/layers-slugs';
-import { useFeatureLayer } from 'hooks/esri';
+// Services
+import EsriFeatureService from 'services/esri-feature-service';
+// Constants
+import { COUNTRIES_DATA_SERVICE_URL } from 'constants/layers-urls';
 import { LOCAL_SCENE, DATA_SCENE } from 'constants/scenes-constants';
 import countrySceneConfig from 'scenes/country-scene/country-scene-config';
 import * as urlActions from 'actions/url-actions';
@@ -10,27 +12,20 @@ import Component from './country-entry-tooltip-component';
 const CountryEntryTooltipContainer = props => {
   const { countryISO } = props;
   const [tooltipPosition, setTooltipPosition] = useState(null);
-  const countryCentroidsLayer = useFeatureLayer({ layerSlug, outFields: ["NAME_0"] });
 
-  const queryCountryCentroid = ({ countryCentroidsLayer, countryISO }) => {
-    const query = countryCentroidsLayer.createQuery();
-    query.where = `GID_0 = '${countryISO}'`;
-    query.returnGeometry = true;
-    countryCentroidsLayer.queryFeatures(query)
-      .then((results) => {
-        const { features } = results;
-        const { geometry } = features[0];
-        setTooltipPosition(geometry.centroid);
-      })
-  };
-
-
+  // Set country tooltip position
   useEffect(() => {
-    if (countryCentroidsLayer && countryISO) {
-      queryCountryCentroid({countryCentroidsLayer, countryISO});
+    if (countryISO) {
+      EsriFeatureService.getFeatures({
+        url: COUNTRIES_DATA_SERVICE_URL,
+        whereClause: `GID_0 = '${countryISO}'`,
+        returnGeometry: true
+      }).then((features) => {
+        const { geometry } = features[0];
+        setTooltipPosition(geometry);
+      })
     }
-  }, [countryCentroidsLayer, countryISO])
-
+  }, [countryISO])
 
   const handleTooltipClose = () => {
     const { changeGlobe } = props;

--- a/src/components/highlighted-species-list/highlighted-species-list-component.jsx
+++ b/src/components/highlighted-species-list/highlighted-species-list-component.jsx
@@ -8,7 +8,7 @@ const HighlightedSpeciesListComponent = ({
 }) => (
   <div className={styles.container}>
     {highlightedSpecies && highlightedSpecies.map(species => (
-      <div className={styles.species}>
+      <div className={styles.species} key={species.scientificName}>
         <img className={styles.image} src={species.imageUrl || speciesPlaceholder} alt={`${species.name}`}/>
         <section className={styles.dataSection}>
           <p className={styles.name}>{species.name}</p>

--- a/src/components/highlighted-species-list/highlighted-species-list-component.jsx
+++ b/src/components/highlighted-species-list/highlighted-species-list-component.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
+import speciesPlaceholder from 'images/speciesPlaceholder.svg';
+
+import styles from './highlighted-species-list-styles.module.scss';
 
 const HighlightedSpeciesListComponent = ({
   highlightedSpecies
 }) => (
-  <div>
+  <div className={styles.container}>
     {highlightedSpecies && highlightedSpecies.map(species => (
-      <div>
-        <section>image</section>
-        <section>
-          <span>Name</span>
-          <span>{species.attributes.species}</span>
-          <span>Global range protected</span>
-          <span>{species.attributes.percentprotectedglobal}</span>
+      <div className={styles.species}>
+        <img className={styles.image} src={species.imageUrl || speciesPlaceholder} alt={`${species.name}`}/>
+        <section className={styles.dataSection}>
+          <p className={styles.name}>{species.name}</p>
+          <p className={styles.scientificName}>{species.scientificName}</p>
+          <p className={styles.rangeSentence}>Global range protected:</p>
+          <p className={styles.range}>{species.rangeProtected}</p>
         </section>
       </div>
     ))}

--- a/src/components/highlighted-species-list/highlighted-species-list-component.jsx
+++ b/src/components/highlighted-species-list/highlighted-species-list-component.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const HighlightedSpeciesListComponent = ({
+  highlightedSpecies
+}) => (
+  <div>
+    {highlightedSpecies && highlightedSpecies.map(species => (
+      <div>
+        <section>image</section>
+        <section>
+          <span>Name</span>
+          <span>{species.attributes.species}</span>
+          <span>Global range protected</span>
+          <span>{species.attributes.percentprotectedglobal}</span>
+        </section>
+      </div>
+    ))}
+  </div>
+)
+
+export default HighlightedSpeciesListComponent;

--- a/src/components/highlighted-species-list/highlighted-species-list-styles.module.scss
+++ b/src/components/highlighted-species-list/highlighted-species-list-styles.module.scss
@@ -5,12 +5,18 @@
   display: flex;
   flex-direction: column;
   margin-bottom: $sidebar-margin;
+  @media print {
+    margin: 0;
+  }
 }
 
 .species {
   display: flex;
   flex-direction: row;
   margin-top: $sidebar-margin;
+  @media print {
+    margin: 0 0 15pt 0;
+  }
 }
 
 .image {
@@ -18,6 +24,10 @@
   width: 100px;
   height: 100px;
   border-radius: 50%;
+  @media print {
+    width: 40pt;
+    height: 40pt;
+  }
 }
 
 .dataSection {
@@ -39,6 +49,10 @@
   .rangeSentence,
   .range {
     @extend %bodyText;
+    @media print {
+      display: inline;
+      padding-right: 2pt;;
+    }
   }
 
 }

--- a/src/components/highlighted-species-list/highlighted-species-list-styles.module.scss
+++ b/src/components/highlighted-species-list/highlighted-species-list-styles.module.scss
@@ -1,0 +1,44 @@
+@import 'styles/settings';
+@import 'styles/typography-extends';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: $sidebar-margin;
+}
+
+.species {
+  display: flex;
+  flex-direction: row;
+  margin-top: $sidebar-margin;
+}
+
+.image {
+  object-fit: cover;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+}
+
+.dataSection {
+  padding-left: $sidebar-paddings;
+
+  p {
+    margin: 0;
+  }
+
+  .name {
+    @extend %title;
+  }
+  
+  .scientificName {
+    @extend %annotation;
+    font-style: italic;
+  }
+
+  .rangeSentence,
+  .range {
+    @extend %bodyText;
+  }
+
+}

--- a/src/components/highlighted-species-list/highlighted-species-list.js
+++ b/src/components/highlighted-species-list/highlighted-species-list.js
@@ -1,28 +1,28 @@
-import React, {useEffect, useState, useReducer} from 'react';
-import { random } from 'lodash';
+import React, {useEffect, useState} from 'react';
  import Component from './highlighted-species-list-component';
 import EsriFeatureService from 'services/esri-feature-service';
 import MolService from 'services/mol';
 import { HIGHLIGHTED_COUNTRY_SPECIES_URL } from 'constants/layers-urls';
 
 const HighlightedSpeciesContainer = (props) => {
-  const {countryISO, maxHighlightedSpecies } = props;
+  const {countryISO, highlightedSpeciesRandomNumber } = props;
   const [highlightedSpeciesInitial, setHiglightedSpeciesInitial] = useState(null);
   const [highlightedSpecies, setHiglightedSpecies] = useState(null);
 
   useEffect(() => {
-    const randomizeSpecies = random(1, maxHighlightedSpecies);
-    EsriFeatureService.getFeatures({
-      url: HIGHLIGHTED_COUNTRY_SPECIES_URL,
-      whereClause: `GID_0 = '${countryISO}' AND random = ${randomizeSpecies}`
-    }).then((features) => {
-      const _highlightedSpeciesInitial = features.map((species) => ({
-            rangeProtected: species.attributes.percentprotectedglobal,
-            scientificName: species.attributes.species_scientific_name,
-          }))
-          setHiglightedSpeciesInitial(_highlightedSpeciesInitial)
-    })
-  }, [countryISO])
+    if (countryISO && highlightedSpeciesRandomNumber) {
+      EsriFeatureService.getFeatures({
+        url: HIGHLIGHTED_COUNTRY_SPECIES_URL,
+        whereClause: `GID_0 = '${countryISO}' AND random = ${highlightedSpeciesRandomNumber}`
+      }).then((features) => {
+        const _highlightedSpeciesInitial = features.map((species) => ({
+              rangeProtected: species.attributes.percentprotectedglobal,
+              scientificName: species.attributes.species_scientific_name,
+            }))
+            setHiglightedSpeciesInitial(_highlightedSpeciesInitial)
+      })
+    }
+  }, [countryISO, highlightedSpeciesRandomNumber])
 
   useEffect(() => {
     if (highlightedSpeciesInitial) {

--- a/src/components/highlighted-species-list/highlighted-species-list.js
+++ b/src/components/highlighted-species-list/highlighted-species-list.js
@@ -1,22 +1,45 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useReducer} from 'react';
 import { random } from 'lodash';
  import Component from './highlighted-species-list-component';
 import EsriFeatureService from 'services/esri-feature-service';
+import MolService from 'services/mol';
 import { HIGHLIGHTED_COUNTRY_SPECIES_URL } from 'constants/layers-urls';
 
 const HighlightedSpeciesContainer = (props) => {
   const {countryISO, maxHighlightedSpecies } = props;
+  const [highlightedSpeciesInitial, setHiglightedSpeciesInitial] = useState(null);
   const [highlightedSpecies, setHiglightedSpecies] = useState(null);
 
   useEffect(() => {
     const randomizeSpecies = random(1, maxHighlightedSpecies);
     EsriFeatureService.getFeatures({
       url: HIGHLIGHTED_COUNTRY_SPECIES_URL,
-      whereClause: `iso3 = '${countryISO}' AND random = ${randomizeSpecies}`
+      whereClause: `GID_0 = '${countryISO}' AND random = ${randomizeSpecies}`
     }).then((features) => {
-      setHiglightedSpecies(features)
+      const _highlightedSpeciesInitial = features.map((species) => ({
+            rangeProtected: species.attributes.percentprotectedglobal,
+            scientificName: species.attributes.species_scientific_name,
+          }))
+          setHiglightedSpeciesInitial(_highlightedSpeciesInitial)
     })
   }, [countryISO])
+
+  useEffect(() => {
+    if (highlightedSpeciesInitial) {
+      const speciesNames = highlightedSpeciesInitial.map(species => species.scientificName);
+      MolService.getSpecies(speciesNames).then((results) => {
+        const _highlightedSpecies = results.map((species, index) => (
+          {
+            ...highlightedSpeciesInitial[index],
+            name: species.commonname,
+            imageUrl: species.image && species.image.url
+          }
+        ))
+        setHiglightedSpecies(_highlightedSpecies)
+      }
+      )
+    }
+  }, [highlightedSpeciesInitial])
 
   return (
     <Component

--- a/src/components/highlighted-species-list/highlighted-species-list.js
+++ b/src/components/highlighted-species-list/highlighted-species-list.js
@@ -1,0 +1,30 @@
+import React, {useEffect, useState} from 'react';
+import { random } from 'lodash';
+ import Component from './highlighted-species-list-component';
+import EsriFeatureService from 'services/esri-feature-service';
+import { HIGHLIGHTED_COUNTRY_SPECIES_URL } from 'constants/layers-urls';
+
+const HighlightedSpeciesContainer = (props) => {
+  const {countryISO, maxHighlightedSpecies } = props;
+  const [highlightedSpecies, setHiglightedSpecies] = useState(null);
+
+  useEffect(() => {
+    const randomizeSpecies = random(1, maxHighlightedSpecies);
+    EsriFeatureService.getFeatures({
+      url: HIGHLIGHTED_COUNTRY_SPECIES_URL,
+      whereClause: `iso3 = '${countryISO}' AND random = ${randomizeSpecies}`
+    }).then((features) => {
+      setHiglightedSpecies(features)
+    })
+  }, [countryISO])
+
+  return (
+    <Component
+      highlightedSpecies={highlightedSpecies}
+      {...props}
+    />
+  )
+}
+
+export default HighlightedSpeciesContainer;
+

--- a/src/components/local-scene-sidebar/local-priority-card/local-priority-card-component.jsx
+++ b/src/components/local-scene-sidebar/local-priority-card/local-priority-card-component.jsx
@@ -37,12 +37,11 @@ const LocalPriorityCardComponent = ({
           <div className={styles.priorityIcon}/>
           <div className={styles.datasetMetadata}>
             <p className={styles.datasetExplanation}>{
-              `The brightly colored map layer indicates the minimum amount of 
-              additional conservation area needed for ${countryName} to achieve 
-              a National SPI of 100, and presents one possible pathway toward the 
-              Half-Earth goal of comprehensive terrestrial biodiversity conservation. 
-              Higher values indicate locations within the country that contribute 
-              more to the conservation of species habitat.`
+              `The brightly colored map layer presents one possible configuration
+               of the additional areas needed to achieve the Half-Earth goal of 
+               comprehensive terrestrial biodiversity conservation. Higher values 
+               indicate locations within ${countryName} that contribute more to the 
+               conservation of species habitat.`
             }
             </p>
             <p className={styles.datasetSource} onClick={() => handleInfoClick(COUNTRY_PRIORITY)}>

--- a/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
@@ -41,6 +41,7 @@ const LocalSceneSidebarComponent = ({
   countryDescription,
   countryDataLoading,
   handleSceneModeChange,
+  maxHighlightedSpecies,
   endemicVertebratesCount,
   endemicVertebratesSentence
 }) => {
@@ -90,25 +91,27 @@ const LocalSceneSidebarComponent = ({
         countryDescription={countryDescription}
         countryDataLoading={countryDataLoading}
         endemicVertebratesCount={endemicVertebratesCount}
-      />
+        />
       <LocalPriorityCard
         countryName={countryName}
         protectionNeeded={protectionNeeded}
         currentProtection={currentProtection}
-      />
+        />
       <LocalSpeciesCard
         birds={birds}
         mammals={mammals}
         reptiles={reptiles}
-        chartData={speciesChartData}
         amphibians={amphibians}
+        countryISO={countryISO}
         countryName={countryName}
         openedModal={openedModal}
         birdsEndemic={birdsEndemic}
+        chartData={speciesChartData}
         mammalsEndemic={mammalsEndemic}
         reptilesEndemic={reptilesEndemic}
         vertebratesCount={vertebratesCount}
         amphibiansEndemic={amphibiansEndemic}
+        maxHighlightedSpecies={maxHighlightedSpecies}
         endemicVertebratesCount={endemicVertebratesCount}
         endemicVertebratesSentence={endemicVertebratesSentence}
       />

--- a/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
@@ -41,9 +41,9 @@ const LocalSceneSidebarComponent = ({
   countryDescription,
   countryDataLoading,
   handleSceneModeChange,
-  maxHighlightedSpecies,
   endemicVertebratesCount,
-  endemicVertebratesSentence
+  endemicVertebratesSentence,
+  highlightedSpeciesRandomNumber,
 }) => {
 
   const sidebarHidden = isFullscreenActive;
@@ -111,9 +111,9 @@ const LocalSceneSidebarComponent = ({
         reptilesEndemic={reptilesEndemic}
         vertebratesCount={vertebratesCount}
         amphibiansEndemic={amphibiansEndemic}
-        maxHighlightedSpecies={maxHighlightedSpecies}
         endemicVertebratesCount={endemicVertebratesCount}
         endemicVertebratesSentence={endemicVertebratesSentence}
+        highlightedSpeciesRandomNumber={highlightedSpeciesRandomNumber}
       />
       <div className={styles.actionGroup}>
         <DownloadIcon />

--- a/src/components/local-scene-sidebar/local-scene-sidebar-selectors.js
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-selectors.js
@@ -1,4 +1,4 @@
-import { createSelector } from 'reselect';
+import { createSelector, createStructuredSelector } from 'reselect';
 
 const SPECIES_COLOR = {
   birds: '#34BD92',
@@ -45,6 +45,11 @@ const getNumberOfVertebrates = createSelector(selectCountryData, countryData => 
 const getNumberOfEndemicVertebrates = createSelector(selectCountryData, countryData => {
   if (!countryData) return null;
   return countryData.total_endemic.toLocaleString('en');
+})
+
+const getMaxHighlightedSpecies = createSelector(selectCountryData, countryData => {
+  if (!countryData) return null;
+  return countryData.max_highlited_sp;
 })
 
 const getIndexStatement = createSelector(
@@ -97,26 +102,27 @@ const chartData = [
   return chartData
 })
 
-const mapStateToProps = (state, props) => ({
-    SPI: getSpeciesProtectionIndex(state, props),
-    birds: getTaxa('birds')(state, props),
-    mammals: getTaxa('mammals')(state, props),
-    reptiles: getTaxa('reptiles')(state, props),
-    amphibians: getTaxa('amphibians')(state, props),
-    countryData: selectCountryData(state, props),
-    birdsEndemic: getEndemicSpecies('birds')(state, props),
-    mammalsEndemic: getEndemicSpecies('mammals')(state, props),
-    indexStatement: getIndexStatement(state, props),
-    reptilesEndemic: getEndemicSpecies('reptiles')(state, props),
-    vertebratesCount: getNumberOfVertebrates(state, props),
-    protectionNeeded: getProtectionNeeded(state, props),
-    speciesChartData: getSpeciesChartData(state, props),
-    amphibiansEndemic: getEndemicSpecies('amphibians')(state, props),
-    currentProtection: getCurrentProtection(state, props),
-    countryDescription: getDescription(state, props),
-    countryDataLoading: selectCountryDataLoading(state, props),
-    endemicVertebratesCount: getNumberOfEndemicVertebrates(state, props),
-    endemicVertebratesSentence: getEndemicSpeciesSentence(state, props),
-  }
-)
+const mapStateToProps = createStructuredSelector({
+  SPI: getSpeciesProtectionIndex,
+  birds: getTaxa('birds'),
+  mammals: getTaxa('mammals'),
+  reptiles: getTaxa('reptiles'),
+  amphibians: getTaxa('amphibians'),
+  countryData: selectCountryData,
+  birdsEndemic: getEndemicSpecies('birds'),
+  mammalsEndemic: getEndemicSpecies('mammals'),
+  indexStatement: getIndexStatement,
+  reptilesEndemic: getEndemicSpecies('reptiles'),
+  vertebratesCount: getNumberOfVertebrates,
+  protectionNeeded: getProtectionNeeded,
+  speciesChartData: getSpeciesChartData,
+  amphibiansEndemic: getEndemicSpecies('amphibians'),
+  currentProtection: getCurrentProtection,
+  countryDescription: getDescription,
+  countryDataLoading: selectCountryDataLoading,
+  endemicVertebratesCount: getNumberOfEndemicVertebrates,
+  endemicVertebratesSentence: getEndemicSpeciesSentence,
+  maxHighlightedSpecies: getMaxHighlightedSpecies
+})
+
 export default mapStateToProps;

--- a/src/components/local-scene-sidebar/local-scene-sidebar-selectors.js
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-selectors.js
@@ -1,4 +1,5 @@
 import { createSelector, createStructuredSelector } from 'reselect';
+import { random } from 'lodash';
 
 const SPECIES_COLOR = {
   birds: '#34BD92',
@@ -47,9 +48,11 @@ const getNumberOfEndemicVertebrates = createSelector(selectCountryData, countryD
   return countryData.total_endemic.toLocaleString('en');
 })
 
-const getMaxHighlightedSpecies = createSelector(selectCountryData, countryData => {
+const getHighlightedSpeciesRandomNumber = createSelector(selectCountryData, countryData => {
   if (!countryData) return null;
-  return countryData.max_highlited_sp;
+  const max = countryData.max_highlited_sp;
+  const highlightedSpeciesRandomNumber = random(1, max);
+  return highlightedSpeciesRandomNumber;
 })
 
 const getIndexStatement = createSelector(
@@ -122,7 +125,7 @@ const mapStateToProps = createStructuredSelector({
   countryDataLoading: selectCountryDataLoading,
   endemicVertebratesCount: getNumberOfEndemicVertebrates,
   endemicVertebratesSentence: getEndemicSpeciesSentence,
-  maxHighlightedSpecies: getMaxHighlightedSpecies
+  highlightedSpeciesRandomNumber: getHighlightedSpeciesRandomNumber
 })
 
 export default mapStateToProps;

--- a/src/components/local-scene-sidebar/local-scene-sidebar.js
+++ b/src/components/local-scene-sidebar/local-scene-sidebar.js
@@ -36,7 +36,7 @@ const LocalSceneSidebarContainer = (props) => {
     view.goTo({ target: extent, tilt: 0, heading: 0 })
         .then(() => {
           const today = new Date();
-          const date =  Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric'}).format(today);
+          const date = Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric'}).format(today);
           const tempTitle = document.title;
           document.title = `Half-Earth National Report Card ${date} - ${countryName}`;
           window.print();

--- a/src/components/local-scene-sidebar/local-scene-sidebar.js
+++ b/src/components/local-scene-sidebar/local-scene-sidebar.js
@@ -17,6 +17,7 @@ const LocalSceneSidebarContainer = (props) => {
     changeUI,
     sceneMode,
     changeGlobe,
+    countryName,
     localGeometry
   } = props;
 
@@ -33,7 +34,14 @@ const LocalSceneSidebarContainer = (props) => {
   const handlePrintReport = () => {
     const { extent } = localGeometry;
     view.goTo({ target: extent, tilt: 0, heading: 0 })
-        .then(() => window.print())
+        .then(() => {
+          const today = new Date();
+          const date =  Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric'}).format(today);
+          const tempTitle = document.title;
+          document.title = `Half-Earth National Report Card ${date} - ${countryName}`;
+          window.print();
+          document.title = tempTitle;
+        })
         .catch(() => window.print())
   }
 

--- a/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
+++ b/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import LocalSceneCard from 'components/local-scene-card';
 import SpeciesModal from 'components/species-modal';
 import PieChart from 'components/charts/pie-chart';
+import HighLightedSpeciesList from 'components/highlighted-species-list';
 import { MODALS } from 'constants/ui-params';
 import { ReactComponent as MammalsIcon } from 'icons/taxa_mammals.svg';
 import { ReactComponent as BirdsIcon } from 'icons/taxa_birds.svg';
@@ -17,7 +18,9 @@ const LocalSpeciesCardComponent = ({
   birds,
   mammals,
   reptiles,
+  changeUI,
   chartData,
+  countryISO,
   amphibians,
   countryName,
   openedModal,
@@ -26,8 +29,8 @@ const LocalSpeciesCardComponent = ({
   reptilesEndemic,
   vertebratesCount,
   amphibiansEndemic,
+  maxHighlightedSpecies,
   endemicVertebratesSentence,
-  changeUI
 }) => {
   const setModal = (opened) => {
     changeUI({ openedModal: opened ? MODALS.SPECIES : null });
@@ -90,6 +93,10 @@ const LocalSpeciesCardComponent = ({
         <p
           className={styles.speciesSentence}
         >{`These are the four species in ${countryName} with the smallest global range (one per taxonomic group).`}</p>
+        <HighLightedSpeciesList
+          countryISO={countryISO}
+          maxHighlightedSpecies={maxHighlightedSpecies}
+        />
         <Button theme={buttonTheme} onClick={() => setModal(true)}>
           See all species
         </Button>

--- a/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
+++ b/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
@@ -92,13 +92,13 @@ const LocalSpeciesCardComponent = ({
       <section>
         <p
           className={styles.speciesSentence}
-        >{`These are the four species in ${countryName} with the smallest global range (one per taxonomic group).`}</p>
+        >{`These are the four vertebrates in ${countryName} with the smallest global range (one per taxonomic group).`}</p>
         <HighLightedSpeciesList
           countryISO={countryISO}
           maxHighlightedSpecies={maxHighlightedSpecies}
         />
         <Button theme={buttonTheme} onClick={() => setModal(true)}>
-          See all species
+          See all vertebrates
         </Button>
         <SpeciesModal open={openedModal === MODALS.SPECIES} handleModalClose={() => setModal(false)} />
       </section>

--- a/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
+++ b/src/components/local-scene-sidebar/local-species-card/local-species-card-component.jsx
@@ -29,8 +29,8 @@ const LocalSpeciesCardComponent = ({
   reptilesEndemic,
   vertebratesCount,
   amphibiansEndemic,
-  maxHighlightedSpecies,
   endemicVertebratesSentence,
+  highlightedSpeciesRandomNumber,
 }) => {
   const setModal = (opened) => {
     changeUI({ openedModal: opened ? MODALS.SPECIES : null });
@@ -95,7 +95,7 @@ const LocalSpeciesCardComponent = ({
         >{`These are the four vertebrates in ${countryName} with the smallest global range (one per taxonomic group).`}</p>
         <HighLightedSpeciesList
           countryISO={countryISO}
-          maxHighlightedSpecies={maxHighlightedSpecies}
+          highlightedSpeciesRandomNumber={highlightedSpeciesRandomNumber}
         />
         <Button theme={buttonTheme} onClick={() => setModal(true)}>
           See all vertebrates

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './national-report-pdf.module.scss';
+import HighLightedSpeciesList from 'components/highlighted-species-list';
 import { ReactComponent as MammalsIcon } from 'icons/taxa_mammals.svg';
 import { ReactComponent as BirdsIcon } from 'icons/taxa_birds.svg';
 import { ReactComponent as ReptilesIcon } from 'icons/taxa_reptiles.svg';
@@ -22,7 +23,8 @@ const NationalReportPdf = ({
   protectionNeeded,
   amphibiansEndemic,
   currentProtection,
-  endemicVertebratesCount
+  endemicVertebratesCount,
+  highlightedSpeciesRandomNumber,
 }) => {
 
   return (
@@ -108,7 +110,10 @@ const NationalReportPdf = ({
         <p className={styles.legendTag}>lower priority</p>
       </section>
       <section className={styles.species}>
-        <span>coming soon</span>
+        <HighLightedSpeciesList
+          countryISO={countryISO}
+          highlightedSpeciesRandomNumber={highlightedSpeciesRandomNumber}
+        />
       </section>
       <section className={styles.mapWrapper}/>
       <section className={styles.urlWrapper} >

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
@@ -33,6 +33,11 @@ const NationalReportPdf = ({
         <img className={styles.flag} src={`${process.env.PUBLIC_URL}/flags/${countryISO}.svg`} alt="" />
         <span className={styles.countryName}>{countryName}</span>
       </section>
+      <section className={styles.date}>
+        <span>
+          {Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric'}).format(new Date())}
+        </span>
+      </section>
       <section className={styles.indexWrapper}>
         <p className={styles.overviewText}>{`The national species protection index is: ${SPI}`}</p>
         <p className={styles.indexStatement}>{indexStatement}</p>

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
@@ -122,7 +122,7 @@ const NationalReportPdf = ({
       </section>
       <section className={styles.mapWrapper}/>
       <section className={styles.urlWrapper} >
-        <a href={shortLink}>Half Earth Map: {shortLink}</a>
+        <a href={shortLink}>{shortLink}</a>
       </section>
     </div>
   )

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
@@ -127,12 +127,6 @@ $gap: 20pt;
 
     .species {
       grid-area: sp;
-      background-color: $grey-text;
-      opacity: .25;
-      border-radius: 6px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
     }
 
     .indexWrapper,

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
@@ -76,7 +76,7 @@ $gap: 20pt;
     height:595pt;
     background-color: $white;
     display: grid;
-    column-gap: $gap;
+    column-gap: 23pt;
     row-gap: $gap;
     grid-template-columns: repeat(10, 63pt);
     grid-template-rows: 30pt 78pt 13pt 100pt 73pt 168pt 15pt;
@@ -87,7 +87,7 @@ $gap: 20pt;
     "exp exp exp exp cmp cmp cmp sp sp sp"
     ". . . . prot prot prot prot prot prot"
     ". . . . prior prior prior prior prior prior"
-    ". . . . url url url url url url";
+    ". . . . . . . url url url";
 
     .nameWrapper {
       grid-area: hd;
@@ -129,6 +129,7 @@ $gap: 20pt;
     .urlWrapper {
       grid-area: url;
       overflow: hidden;
+      text-align: right;
     }
 
     .species {

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf.module.scss
@@ -18,6 +18,7 @@ $gap: 20pt;
   margin: 0;
 }
 
+.date,
 .numberText,
 .speciesCount,
 .speciesSentence,
@@ -80,7 +81,7 @@ $gap: 20pt;
     grid-template-columns: repeat(10, 63pt);
     grid-template-rows: 30pt 78pt 13pt 100pt 73pt 168pt 15pt;
     grid-template-areas:
-    "hd hd hd hd hd hd hd hd hd hd"
+    "hd hd hd hd hd hd hd hd hd date"
     "index index index index rg rg rg sp sp sp"
     "intro intro intro intro cmp cmp cmp sp sp sp"
     "exp exp exp exp cmp cmp cmp sp sp sp"
@@ -95,6 +96,11 @@ $gap: 20pt;
       .countryName {
         margin-left: $gap;
       }
+    }
+
+    .date {
+      grid-area: date;
+      text-align: right;
     }
 
     .indexWrapper {

--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -145,7 +145,11 @@ const RankingChart = ({
                 <div className={styles.row} key={d.name}>
                   {categories.map((category) => renderBar(category, d))}
                   <div className={styles.spiCountry}>
-                    <span className={cx(styles.titleText, styles.spiIndex)}>
+                    <span className={cx(
+                      styles.titleText,
+                      styles.spiIndex,
+                      {[styles.selectedCountry]: countryISO === d.iso}
+                    )}>
                       {d.index}.
                     </span>
                     <button

--- a/src/components/ranking-chart/ranking-chart-styles.module.scss
+++ b/src/components/ranking-chart/ranking-chart-styles.module.scss
@@ -71,7 +71,7 @@
 }
 
 .selectedCountry {
-  color: $white;
+  color: $brand-color-main;
   font-weight: bold;
 }
 

--- a/src/components/species-modal/species-modal-component.jsx
+++ b/src/components/species-modal/species-modal-component.jsx
@@ -97,7 +97,6 @@ const SpeciesModalComponent = ({
   const tableHeight = height - PX_TO_TOP;
   const speciesNumber = () => {
     if (!speciesList) return countryData.speciesNumber;
-    console.log(speciesList.length, countryData.speciesNumber);
     return speciesList.length < countryData.speciesNumber
       ? `${speciesList.length} of ${countryData.speciesNumber}`
       : speciesList.length;

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -63,7 +63,7 @@ import {
 export const GRID_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_grid_55k_dis/FeatureServer";
 export const PLEDGES_LAYER_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer";
 export const METADATA_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Metadata2/FeatureServer/0';
-export const HIGHLIGHTED_COUNTRY_SPECIES_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/dupl_highlited_sp/FeatureServer/0';
+export const HIGHLIGHTED_COUNTRY_SPECIES_URL = 'https://utility.arcgis.com/usrsvcs/servers/aa62e9946df34e4ba176827c8ebc1b4d/rest/services/dupl_highlited_sp/FeatureServer/0';
 export const COUNTRIES_DATA_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_centroid/FeatureServer/0';
 export const COUNTRIES_GEOMETRIES_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_generalised/FeatureServer/0';
 

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -63,6 +63,9 @@ import {
 export const GRID_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_grid_55k_dis/FeatureServer";
 export const PLEDGES_LAYER_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer";
 export const METADATA_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Metadata2/FeatureServer/0';
+export const HIGHLIGHTED_COUNTRY_SPECIES_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/dupl_highlited_sp/FeatureServer/0';
+export const COUNTRIES_DATA_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_centroid/FeatureServer/0';
+export const COUNTRIES_GEOMETRIES_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_generalised/FeatureServer/0';
 
 export const LAYERS_URLS = {
   [COUNTRY_PRIORITY_LAYER]:

--- a/src/scenes/country-scene/country-scene-component.jsx
+++ b/src/scenes/country-scene/country-scene-component.jsx
@@ -132,7 +132,6 @@ const CountrySceneComponent = ({
       <PdfNationalReport
         countryISO={countryISO}
         countryName={countryName}
-        countryBorder={countryBorder}
         onMapLoad={onMapLoad}
         shortLink={shortLink}
       />

--- a/src/services/esri-feature-service.js
+++ b/src/services/esri-feature-service.js
@@ -1,6 +1,7 @@
 import { loadModules } from 'esri-loader';
+import { LOCAL_SPATIAL_REFERENCE } from 'constants/scenes-constants';
 
-function getFeatures({ url, whereClause = "", outFields = ["*"], returnGeometry = false, outSpatialReference = 102100 }) {
+function getFeatures({ url, whereClause = "", outFields = ["*"], returnGeometry = false, outSpatialReference = LOCAL_SPATIAL_REFERENCE }) {
   return new Promise((resolve, reject) => {
     loadModules(["esri/tasks/QueryTask", "esri/tasks/support/Query"]).then(([QueryTask, Query]) => {
       var queryTask = new QueryTask({

--- a/src/services/esri-feature-service.js
+++ b/src/services/esri-feature-service.js
@@ -1,0 +1,26 @@
+import { loadModules } from 'esri-loader';
+
+function getFeatures({ url, whereClause = "", outFields = ["*"], returnGeometry = false, outSpatialReference = 102100 }) {
+  return new Promise((resolve, reject) => {
+    loadModules(["esri/tasks/QueryTask", "esri/tasks/support/Query"]).then(([QueryTask, Query]) => {
+      var queryTask = new QueryTask({
+        url
+      });
+      var query = new Query();
+      query.outFields = outFields;
+      query.where = whereClause;
+      query.returnGeometry = returnGeometry;
+      query.outSpatialReference = outSpatialReference;
+      queryTask.execute(query).then(function(results){
+          if (results && results.features && results.features.length > 0) {
+            resolve(results.features);
+          }
+          resolve(null);
+      });
+    }).catch(error => reject(error));
+  })
+}
+
+export default {
+  getFeatures
+}

--- a/src/services/mol.js
+++ b/src/services/mol.js
@@ -1,0 +1,14 @@
+const config = { url: 'https://api.mol.org/1.x/species/info', query: '?scientificname=' };
+
+async function getSpecies(species) {
+  const speciesArray = Array.isArray(species) ? species : [ species ];
+  const promises = speciesArray.map(
+    specie => fetch(`${config.url}${config.query}${specie}`).then(d => d.json())
+  );
+  const data = await Promise.all(promises);
+  return data && data
+      .filter(d => !!d.length)
+      .map(d => ({ ...d[0] }));
+}
+
+export default { getSpecies };


### PR DESCRIPTION
## Add four highlighted species to NRC sidebar and PDF
### Description
The `highlighted-species-list` component has been created. It gets a set of endemic and rare species for each country. A `random` [from the service](https://eowilson.maps.arcgis.com/home/item.html?id=aa62e9946df34e4ba176827c8ebc1b4d) attribute is used in order to display a different subset each time the user visits a country.
Two new services have been created `mol` (to get data from [MoL API](https://api.mol.org/1.x/docs/?m=uploader_ext)) and `esri-feature-service` (to abstract the way we get data from arcgis online services that are not meant to be displayed on the map but fetched to get data). 
`esri-feature-service` has been made to substitute the flow of creating and querying a `featureLayer` by a more common service pattern, hiding Esri logic inside the service. 

**Known issues**: Some species do not have an associated image on MoL API data and some others are not returning data at all. The later means that sometimes the widget does not display four species. A SQL `whereClause` can be passed as a prop to filter the set of features returned by the service.

### Designs
https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/421888088/preview?scrollOffset=4509

### Testing instructions
Visit a national report card and scroll down to the species section on the sidebar

### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-26
https://half-earth-map.atlassian.net/browse/HE-167