### PR TITLE
Feature/about text update

### DIFF
--- a/src/components/about/about-component.jsx
+++ b/src/components/about/about-component.jsx
@@ -32,8 +32,8 @@ const AboutPage = ({ handleCloseAboutPage, tabsData, switchAboutPageTabAnalytics
   }
 
   const renderTabComponent = () => {
-    const { Component, textData } = tabsData[activeTab];
-    return <Component textData={textData} />
+    const { Component } = tabsData[activeTab];
+    return <Component />
   }
 
   return (
@@ -64,7 +64,7 @@ const AboutPage = ({ handleCloseAboutPage, tabsData, switchAboutPageTabAnalytics
   );
 }
 
-const AboutComponent = ({ className, buttonTitle, setPageTexts, textData, VIEW , openAboutPageAnalyticsEvent, switchAboutPageTabAnalyticsEvent }) => {
+const AboutComponent = ({ className, buttonTitle, setPageTexts, VIEW , openAboutPageAnalyticsEvent, switchAboutPageTabAnalyticsEvent }) => {
   const [isAboutPageOpened, setAboutPageOpened] = useState(false);
 
   const handleOpenAboutPage = () => {
@@ -78,8 +78,7 @@ const AboutComponent = ({ className, buttonTitle, setPageTexts, textData, VIEW ,
     [ABOUT_TABS.PARTNERS]: {
       slug: ABOUT_TABS.PARTNERS,
       text: 'PARTNERS',
-      Component: PartnersComponent,
-      textData: textData
+      Component: PartnersComponent
     },
     [ABOUT_TABS.INSTRUCTIONS]: {
       slug: ABOUT_TABS.INSTRUCTIONS,

--- a/src/components/about/about-component.jsx
+++ b/src/components/about/about-component.jsx
@@ -100,7 +100,7 @@ const AboutComponent = ({ className, buttonTitle, setPageTexts, textData, VIEW ,
         ReactDOM.createPortal(
           <AboutPage
             handleCloseAboutPage={handleCloseAboutPage}
-            tabsData={tabsData} 
+            tabsData={tabsData}
             switchAboutPageTabAnalyticsEvent={switchAboutPageTabAnalyticsEvent}
           />,
           document.getElementById('root')

--- a/src/components/about/partners/partners-component.jsx
+++ b/src/components/about/partners/partners-component.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactMarkdown from 'react-markdown/with-html';
 import cx from 'classnames';
 
 import styles from './partners-styles.module.scss';
@@ -25,7 +26,13 @@ const PartnersComponent = ({ sections }) => (
         <div className={styles.logosWrapper} key={`${title}-content`}>
           {content && content.map(logo => <Logo key={logo.href} {...logo} />)}
         </div>
-        <p className={styles.description} key={description}>{description}</p>
+        {description && description.map(paragraph => (
+          <ReactMarkdown
+            className={styles.description}
+            source={paragraph}
+            escapeHtml={false}
+          />
+        ))}
       </div>
     ))}
   </div>

--- a/src/components/about/partners/partners-data.js
+++ b/src/components/about/partners/partners-data.js
@@ -27,7 +27,7 @@ export const texts = {
     title: 'Half-Earth Project Map - Core Team',
     content: [
       'The Half-Earth Project is an initiative of the E.O. Wilson Biodiversity Foundation. Map of Life utilizes geospatial species distribution data and analytics to guide where we have the best opportunity to conserve the most species. Vizzuality brings this information to life.',
-      `Click here to know more about the core team of Half-Earth:
+      `<p style="margin-bottom: 0px;">Click here to know more about the core team of Half-Earth:</p>
       <a target="_blank" href="https://www.half-earthproject.org/half-earth-project-team-members/">www.half-earthproject.org/half-earth-project-team-members</a>`
     ]
   },

--- a/src/components/about/partners/partners-data.js
+++ b/src/components/about/partners/partners-data.js
@@ -22,6 +22,29 @@ import fieldMuseumLogo from 'logos/field-museum-logo_2018.png';
 import gorongosaLogo from 'logos/gorongosa_np_logo.png';
 import inaturalistLogo from 'logos/inaturalist.png';
 
+export const texts = {
+  partners: {
+    title: 'Half-Earth Project Map - Core Team',
+    content: [
+      'The Half-Earth Project is an initiative of the E.O. Wilson Biodiversity Foundation. Map of Life utilizes geospatial species distribution data and analytics to guide where we have the best opportunity to conserve the most species. Vizzuality brings this information to life.',
+      `Click here to know more about the core team of Half-Earth:
+      <a target="_blank" href="https://www.half-earthproject.org/half-earth-project-team-members/">www.half-earthproject.org/half-earth-project-team-members</a>`
+    ]
+  },
+  platformPartners: {
+    title: 'Platform partner'
+  },
+  sponsors: {
+    title: 'Funding support'
+  },
+  dataPartners: {
+    title: 'Data partners'
+  },
+  researchPartners: {
+    title: 'Research partners'
+  },
+}
+
 export const partners = [
   { href: 'https://mol.org/', image: { src: molLogo, alt: 'Map of Life' } },
   {

--- a/src/components/about/partners/partners-styles.module.scss
+++ b/src/components/about/partners/partners-styles.module.scss
@@ -75,6 +75,11 @@
   text-align: center;
   padding: 20px;
 
+  a {
+    color: $brand-color-main;
+    text-decoration: none;
+  }
+
   @media #{$tablet-portrait} {
     padding: 0;
   }

--- a/src/components/about/partners/partners.js
+++ b/src/components/about/partners/partners.js
@@ -1,27 +1,27 @@
 import React from 'react';
 import PartnersComponent from './partners-component';
-import { partners, platformPartners, dataPartners, researchPartners, sponsors } from './partners-data';
+import { texts, partners, platformPartners, dataPartners, researchPartners, sponsors } from './partners-data';
 import styles from './partners-styles.module.scss';
 
-const PartnersContainer = ({ textData }) => {
-  const sections = textData && [
+const PartnersContainer = () => {
+  const sections = [
     {
-      title: textData.title,
-      description: textData.content,
+      title: texts.partners.title,
+      description: texts.partners.content,
       content: partners,
       theme: styles.partners
     },
     {
-      title: textData.platformPartners,
+      title: texts.platformPartners.title,
       content: platformPartners,
       theme: styles.platformPartners
 
     },
-    { title: textData.title2,
+    { title: texts.sponsors.title,
       content: sponsors
     },
-    { title: textData.title3, content: dataPartners },
-    { title: textData.title4, content: researchPartners }
+    { title: texts.dataPartners.title, content: dataPartners },
+    { title: texts.researchPartners.title, content: researchPartners }
   ];
 
   return <PartnersComponent sections={sections}/>

--- a/src/components/mobile-only/menu-settings/menu-settings.js
+++ b/src/components/mobile-only/menu-settings/menu-settings.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { SETTINGS_OPTIONS } from 'constants/mobile-only';
 import { MODALS } from 'constants/ui-params';
 
-import pageTextsActions from 'redux_modules/page-texts/page-texts';
 import * as urlActions from 'actions/url-actions';
 
 import Partners from 'components/about/partners';
@@ -12,15 +11,10 @@ import MapInstructions from 'components/about/map-instructions/map-instructions-
 import HalfEarthModal from 'components/half-earth-modal';
 import Component from './menu-settings-component';
 
-const actions = { ...pageTextsActions, ...urlActions };
-const PARTNERS_TEXT_SLUG = 'partners';
-
-const mapStateToProps = ({ pageTexts }) => ({
-  textData: pageTexts.data[PARTNERS_TEXT_SLUG]
-});
+const actions = { ...urlActions };
 
 const MenuSettingsContainer = props => {
-  const { setPageTexts, textData, openedModal, changeUI } = props;
+  const { openedModal, changeUI } = props;
   const [activeModal, setActiveModal] = useState(null);
 
   // take opened half earth modal from the url state
@@ -50,7 +44,6 @@ const MenuSettingsContainer = props => {
       name: 'Partners',
       Component: Partners,
       onClickHandler: () => {
-        setPageTexts(PARTNERS_TEXT_SLUG)
         setActiveModal(ABOUT_PARTNERS);
       }
     },
@@ -66,9 +59,8 @@ const MenuSettingsContainer = props => {
   return <Component
     options={options}
     activeModal={activeModal}
-    textData={textData}
     closeModal={closeModal}
     {...props} />;
 }
 
-export default connect(mapStateToProps, actions)(MenuSettingsContainer);
+export default connect(null, actions)(MenuSettingsContainer);


### PR DESCRIPTION
## About page text updates
### Description
The About page component has been detached from Contentful. Since stakeholders are not longer updating the contents from Contentful this dependency can be gradually removed. Now the contents of the partners modal will be stored on the code base and updated as needed.
A new paragraph linking to half-earth map team page on half-earthproject.org hass been added under the core team section.
### Designs
https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/365695334/preview?scrollOffset=2558
### Testing instructions
Click the `about the half earth map` button on the bottom right corner in order to access the modal and check the new content.
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-67