### PR TITLE
Filter indicators, filters and data by available data

### DIFF
--- a/src/components/charts/scatter-plot/scatter-plot-component.jsx
+++ b/src/components/charts/scatter-plot/scatter-plot-component.jsx
@@ -140,19 +140,6 @@ const ScatterPlot = ({
     }, [chartScale])
 
     useEffect(() => {
-      if (bubblesArray.length) {
-        const newXScale = d3.scaleLinear()
-        .domain([minXValue(data, countryChallengesSelectedKey), maxXValue(data, countryChallengesSelectedKey)])
-        .range([padding, chartSurfaceRef.current.offsetWidth - padding])
-        bubblesArray.forEach((bubble, index) => {
-          const { children } = bubble;
-          const country = children[0];
-          ease.add(bubble, {x: newXScale(country.attributes.xAxisValues[countryChallengesSelectedKey])}, {duration: 1500, ease: 'easeInOutExpo', wait: index * 2 });
-        })
-      }
-    }, [countryChallengesSelectedKey])
-
-    useEffect(() => {
       if (bubblesArray.length && countryISO && chartScale) {
         bubblesArray.forEach((bubble) => {
           const { children } = bubble;
@@ -219,8 +206,8 @@ const ScatterPlot = ({
           </div>
           <div className={styles.xAxisTicksContainer}>
             {xAxisTicks &&
-              xAxisTicks.map((tick) => (
-                <span className={styles.tick} key={`x-${tick}`}>
+              xAxisTicks.map((tick, index) => (
+                <span className={styles.tick} key={`x-${tick}-${index}`}>
                   {tick}
                 </span>
               ))}

--- a/src/components/country-challenges-chart/country-challenges-chart-component.jsx
+++ b/src/components/country-challenges-chart/country-challenges-chart-component.jsx
@@ -7,7 +7,7 @@ import { ReactComponent as ArrowButton } from 'icons/arrow_right.svg';
 import { ReactComponent as SwitchArrow } from 'icons/switch.svg';
 import { ReactComponent as QuestionIcon } from 'icons/borderedQuestion.svg';
 
-import { INDICATOR_LABELS, CHALLENGES_RELATED_FILTERS_OPTIONS, FILTERS_DICTIONARY } from 'constants/country-mode-constants';
+import { INDICATOR_LABELS, FILTERS_DICTIONARY } from 'constants/country-mode-constants';
 import { countryChallengesChartFormats } from 'utils/data-formatting-utils';
 import styles from './country-challenges-chart-styles.module.scss';
 
@@ -27,11 +27,11 @@ const CountryChallengesChartComponent = ({
   handleSelectNextIndicator,
   countryChallengesSelectedKey,
   handleSelectPreviousIndicator,
-  setInfoModalAdditionalContent
+  setInfoModalAdditionalContent,
+  challengesFilterOptions
 }) => {
-
   useEffect(() => {
-      setInfoModalAdditionalContent(<CountryChallengesModalAdditional />);
+    setInfoModalAdditionalContent(<CountryChallengesModalAdditional />);
   }, []);
 
   return (
@@ -59,7 +59,7 @@ const CountryChallengesChartComponent = ({
             <li className={cx(styles.filterOption, styles.optionsLabel)}>
               Filter countries with similar:
             </li>
-            {CHALLENGES_RELATED_FILTERS_OPTIONS.map((filter) => (
+            {challengesFilterOptions.map((filter) => (
               <li
                 className={cx(styles.filterOption, {
                   [styles.selectedFilter]: filter.slug === selectedFilter

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -66,11 +66,12 @@ const getFilteredData = createSelector(
     if (!plotRawData) return null;
     if (!selectedFilter || selectedFilter === 'all') return plotRawData;
     const relatedCountries = selectedCountryRelations[selectedFilter];
+    const hasNotNullXValue = (country, selectedKey) => (
+      country.xAxisValues[selectedKey] ||
+      country.xAxisValues[selectedKey] === 0
+    );
     return plotRawData.filter(
-      (country) =>
-        (relatedCountries.includes(country.iso) &&
-          country.xAxisValues[selectedKey]) ||
-        country.xAxisValues[selectedKey] === 0
+      (country) => relatedCountries.includes(country.iso) && hasNotNullXValue(country)
     );
   }
 );

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -3,6 +3,10 @@ import { CONTINENT_COLORS } from 'constants/country-mode-constants';
 import { getCountryChallengesSelectedFilter, getCountryISO } from 'pages/data-globe/data-globe-selectors';
 import { countryChallengesChartFormats } from 'utils/data-formatting-utils';
 import * as d3 from 'd3';
+import {
+  INDICATOR_LABELS,
+  CHALLENGES_RELATED_FILTERS_OPTIONS,
+} from 'constants/country-mode-constants';
 
 const selectCountriesData = ({ countryData }) => (countryData && countryData.data) || null;
 
@@ -32,6 +36,17 @@ const getScatterplotRawData = createSelector(
   }
 )
 
+const getXAxisKeys = createSelector(
+  [getCountryISO, getScatterplotRawData],
+  (countryIso, rawData) => {
+  const AllXAxisKeys = Object.keys(INDICATOR_LABELS);
+  if (!rawData) return AllXAxisKeys;
+  const countryData = rawData.find(country => country.iso === countryIso);
+  return AllXAxisKeys.filter(
+    (key) => countryData.xAxisValues[key] || countryData.xAxisValues[key] === 0
+  );
+});
+
 const getSelectedCountryRelations = createSelector(
   [selectCountriesData, getCountryISO],
   (countriesData, selectedCountryIso) => {
@@ -48,7 +63,36 @@ const getFilteredData = createSelector(
     const relatedCountries = selectedCountryRelations[selectedFilter];
     return plotRawData.filter(country => relatedCountries.includes(country.iso));
   }
-)
+);
+
+const getFilteredAvailableData = createSelector(
+  [getFilteredData, getCountryChallengesSelectedKey],
+  (data, selectedKey) => {
+    if (!data || !selectedKey) return null;
+    return data.filter(
+      (d) => d.xAxisValues[selectedKey] || d.xAxisValues[selectedKey] === 0
+    );
+  }
+);
+
+const getChallengesFilterOptions = createSelector(
+  [getXAxisKeys],
+  (keys) => {
+    if (!keys) return [];
+    const indicatorDependantOptions = [
+      'filter_Population2016',
+      'filter_prop_hm_very_high',
+      'filter_GNI_PPP',
+      'filter_total_endemic',
+      'filter_N_SPECIES'
+    ];
+
+    return CHALLENGES_RELATED_FILTERS_OPTIONS.filter((option) => {
+      if (!indicatorDependantOptions.includes(option.slug)) return true;
+      return keys.some(key => option.slug.endsWith(key));
+    });
+  }
+);
 
 const getXAxisTicks = createSelector(
   [getFilteredData, getCountryChallengesSelectedKey],
@@ -74,10 +118,12 @@ const getYAxisTicks = createSelector(
 
 
 const mapStateToProps = createStructuredSelector({
-  data: getFilteredData,
+  data: getFilteredAvailableData,
+  xAxisKeys: getXAxisKeys,
   xAxisTicks: getXAxisTicks,
   yAxisTicks: getYAxisTicks,
-  selectedFilter: getCountryChallengesSelectedFilter
-})
+  selectedFilter: getCountryChallengesSelectedFilter,
+  challengesFilterOptions: getChallengesFilterOptions
+});
 
 export default mapStateToProps;

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -66,7 +66,7 @@ const getFilteredData = createSelector(
     if (!plotRawData) return null;
     if (!selectedFilter || selectedFilter === 'all') return plotRawData;
     const relatedCountries = selectedCountryRelations[selectedFilter];
-    const hasNotNullXValue = (country, selectedKey) => (
+    const hasNotNullXValue = (country) => (
       country.xAxisValues[selectedKey] ||
       country.xAxisValues[selectedKey] === 0
     );

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -56,21 +56,21 @@ const getSelectedCountryRelations = createSelector(
 )
 
 const getFilteredData = createSelector(
-  [getScatterplotRawData, getCountryChallengesSelectedFilter, getSelectedCountryRelations],
-  (plotRawData, selectedFilter, selectedCountryRelations) => {
+  [
+    getScatterplotRawData,
+    getCountryChallengesSelectedFilter,
+    getSelectedCountryRelations,
+    getCountryChallengesSelectedKey
+  ],
+  (plotRawData, selectedFilter, selectedCountryRelations, selectedKey) => {
     if (!plotRawData) return null;
     if (!selectedFilter || selectedFilter === 'all') return plotRawData;
     const relatedCountries = selectedCountryRelations[selectedFilter];
-    return plotRawData.filter(country => relatedCountries.includes(country.iso));
-  }
-);
-
-const getFilteredAvailableData = createSelector(
-  [getFilteredData, getCountryChallengesSelectedKey],
-  (data, selectedKey) => {
-    if (!data || !selectedKey) return null;
-    return data.filter(
-      (d) => d.xAxisValues[selectedKey] || d.xAxisValues[selectedKey] === 0
+    return plotRawData.filter(
+      (country) =>
+        (relatedCountries.includes(country.iso) &&
+          country.xAxisValues[selectedKey]) ||
+        country.xAxisValues[selectedKey] === 0
     );
   }
 );
@@ -118,7 +118,7 @@ const getYAxisTicks = createSelector(
 
 
 const mapStateToProps = createStructuredSelector({
-  data: getFilteredAvailableData,
+  data: getFilteredData,
   xAxisKeys: getXAxisKeys,
   xAxisTicks: getXAxisTicks,
   yAxisTicks: getYAxisTicks,

--- a/src/components/country-challenges-chart/country-challenges-chart.js
+++ b/src/components/country-challenges-chart/country-challenges-chart.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import Component from './country-challenges-chart-component';
 import metadataConfig from 'constants/metadata';
 import { CHALLENGES_CHART } from 'constants/metadata';
-import { INDICATOR_LABELS } from 'constants/country-mode-constants';
 
 import mapStateToProps from './country-challenges-chart-selectors';
 
@@ -14,16 +13,13 @@ const actions = {...metadataActions, ...urlActions };
 
 
 const CountryChallengesChartContainer = (props) => {
-  const xAxisKeys = Object.keys(INDICATOR_LABELS);
-
-
   const [filtersOpen, setFiltersToggle] = useState(false);
 
   const handleSelectNextIndicator = () => {
     setFiltersToggle(false);
-    const { changeUI, countryChallengesSelectedKey } = props;
+    const { changeUI, countryChallengesSelectedKey, xAxisKeys } = props;
     const currentIndex = xAxisKeys.indexOf(countryChallengesSelectedKey);
-    if (currentIndex !== xAxisKeys.length - 1) { 
+    if (currentIndex !== xAxisKeys.length - 1) {
       changeUI({ countryChallengesSelectedKey: xAxisKeys[currentIndex + 1] });
     } else {
       changeUI({ countryChallengesSelectedKey: xAxisKeys[0] });
@@ -32,7 +28,7 @@ const CountryChallengesChartContainer = (props) => {
 
   const handleSelectPreviousIndicator = () => {
     setFiltersToggle(false);
-    const { changeUI, countryChallengesSelectedKey } = props;
+    const { changeUI, countryChallengesSelectedKey, xAxisKeys } = props;
     const currentIndex = xAxisKeys.indexOf(countryChallengesSelectedKey);
     if (currentIndex > 0) {
       changeUI({ countryChallengesSelectedKey: xAxisKeys[currentIndex - 1] });
@@ -71,7 +67,7 @@ const CountryChallengesChartContainer = (props) => {
   const handleFiltersToggle = () => {
     setFiltersToggle(!filtersOpen);
   }
-  
+
   const handleOutsideFiltersClick = () => {
     setFiltersToggle(false);
   }

--- a/src/constants/country-mode-constants.js
+++ b/src/constants/country-mode-constants.js
@@ -39,8 +39,9 @@ export const FILTERS_DICTIONARY = {
   filter_N_SPECIES: 'Number of vertebrate species',
   filter_SPI: 'Species Protection Index',
   filter_neigh: 'Neighbouring countries',
-  filter_steward: 'Species stewardship'
-}
+  filter_steward: 'Species stewardship',
+  filter_continent: 'Same continent countries'
+};
 
 export const CHALLENGES_RELATED_FILTERS_OPTIONS = [
   {slug: 'all', name: FILTERS_DICTIONARY.all},
@@ -55,4 +56,5 @@ export const CHALLENGES_RELATED_FILTERS_OPTIONS = [
   {slug: 'filter_SPI', name: FILTERS_DICTIONARY.filter_SPI},
   {slug: 'filter_neigh', name: FILTERS_DICTIONARY.filter_neigh},
   {slug: 'filter_steward', name: FILTERS_DICTIONARY.filter_steward},
+  {slug: 'filter_continent', name: FILTERS_DICTIONARY.filter_continent}
 ]


### PR DESCRIPTION
## Fix challenges missing data
### Description
This PR fixes the problems with missing data for indicators on the challenges chart
- Indicators without data of a country are not shown (low part of the chart)
- If a country is selected within an indicator, other countries bubbles' are not shown if that indicator data is not available
- On the filter menu if an indicator data is not available for a country the option related to that indicator won't be displayed

Missing: The animation is repeating so a bit annoying right now. I'm not sure if this is a priority right now. Let me know.

![image](https://user-images.githubusercontent.com/9701591/95478964-823b6700-098a-11eb-80b4-7d179e2bf1e3.png)

### Testing instructions
Go to the national reports.
- Select Antartica: Only 3 indicators should show
- If you select other country and you select GNI indicator - ATA (Anctartica) should never show.
- With Anctratica selected you shouldn't see GNI related filter on the dropdown
Try also with similar cases
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-188