### PR TITLE
Add SPI sorting column

### DIFF
--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -23,8 +23,9 @@ const legendText = {
     protectionNotNeeded: 'Protection non-needed'
   }
 };
-const categories = Object.keys(legendText);
 
+const categories = Object.keys(legendText);
+const headers = categories.concat('spi');
 
 const RankingChart = ({
   data,
@@ -123,7 +124,7 @@ const RankingChart = ({
             ref={tableRef}
           >
             <div className={styles.header}>
-              {categories.map((category) => (
+              {headers.map((category) => (
                 <HeaderItem
                   title={category.toUpperCase()}
                   key={category}

--- a/src/components/ranking-chart/ranking-chart-styles.module.scss
+++ b/src/components/ranking-chart/ranking-chart-styles.module.scss
@@ -31,6 +31,10 @@
     text-align: left;
     padding: 0;
 
+    &:last-child {
+      padding-left: 1rem;
+    }
+
     &:hover {
       color: white;
     }


### PR DESCRIPTION
## Add SPI header with sorting on rankings
### Description
This PR adds SPI header with sorting for the countries list on rankings. Now we can go back to the original SPI order

![image](https://user-images.githubusercontent.com/9701591/95608726-d7947880-0a5d-11eb-91a1-79ade9fd8222.png)
### Designs
https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/427356835/preview?scrollOffset=5188
### Testing instructions
Go to rankings. Try sorting by SPI column
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-198