### PR TITLE
Fix breaking sort into new line

### DIFF
--- a/src/components/header-item/header-item-component.jsx
+++ b/src/components/header-item/header-item-component.jsx
@@ -9,7 +9,7 @@ const HeaderItem = ({
   isSortSelected,
   sortDirection,
   handleSortClick,
-  className
+  theme
 }) => {
   const highlightAsc = isSortSelected && sortDirection === SORT.ASC;
   const highlightDesc = isSortSelected && sortDirection === SORT.DESC;
@@ -20,22 +20,30 @@ const HeaderItem = ({
         {
           [styles.highlightCategory]: isSortSelected
         },
-        className
+        theme.headerItem
       )}
       key={title}
       onClick={() => handleSortClick(title)}
     >
-      {title}
+      <span>{title}</span>
       <span className={styles.sortArrows}>
         <span
-          className={cx(styles.arrowUp, {
-            [styles.highlightedSort]: highlightAsc
-          })}
+          className={cx(
+            styles.arrowUp,
+            {
+              [styles.highlightedSort]: highlightAsc
+            },
+            theme.arrowUp
+          )}
         />
         <span
-          className={cx(styles.arrowDown, {
-            [styles.highlightedSort]: highlightDesc
-          })}
+          className={cx(
+            styles.arrowDown,
+            {
+              [styles.highlightedSort]: highlightDesc
+            },
+            theme.arrowDown
+          )}
         />
       </span>
     </button>
@@ -47,7 +55,12 @@ HeaderItem.propTypes = {
   className: PropTypes.string,
   isSortSelected: PropTypes.bool,
   sortDirection: PropTypes.string,
-  handleSortClick: PropTypes.func.isRequired
+  handleSortClick: PropTypes.func.isRequired,
+  theme: PropTypes.object
+};
+
+HeaderItem.defaultProps = {
+  theme: {}
 };
 
 export default HeaderItem;

--- a/src/components/header-item/header-item.module.scss
+++ b/src/components/header-item/header-item.module.scss
@@ -1,6 +1,13 @@
 @import 'styles/settings';
 @import 'styles/mixins';
 
+.headerItem {
+  display: flex;
+  padding-right: 20px;
+  align-items: flex-end;
+  align-self: flex-end;
+}
+
 .sortArrows {
   display: inline-block;
   position: relative;
@@ -34,7 +41,6 @@
   .arrowUp {
     @include caret($_temporary-light-text, 'up');
     position: absolute;
-    top: -1px;
     &.highlightedSort::after {
       border-top-color: $white;
     }

--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -119,7 +119,7 @@ const RankingChart = ({
           <HeaderItem
             title={category.toUpperCase()}
             key={category}
-            className={cx(styles.headerItem, styles.titleText)}
+            theme={{ headerItem: cx(styles.headerItem, styles.titleText) }}
             isSortSelected={
               sortRankingCategory &&
               sortRankingCategory.split('-')[0] &&

--- a/src/components/ranking-chart/ranking-chart-styles.module.scss
+++ b/src/components/ranking-chart/ranking-chart-styles.module.scss
@@ -26,6 +26,7 @@ $scroll-bar-width: 7px;
 .header {
   width: calc(#{$chart-width-without-legend} * 0.8);
   padding-right: $scroll-bar-width;
+  display: flex;
 
   .headerItem {
     width: 18%;
@@ -33,6 +34,7 @@ $scroll-bar-width: 7px;
     margin-bottom: 10px;
     text-align: left;
     padding: 0;
+    align-items: baseline;
 
     &:last-child {
       padding-left: 1rem;

--- a/src/components/species-modal/species-modal-component.jsx
+++ b/src/components/species-modal/species-modal-component.jsx
@@ -127,7 +127,7 @@ const SpeciesModalComponent = ({
               {headers.map((title) => (
                 <HeaderItem
                   title={title}
-                  className={styles.tableHeaderItem}
+                  theme={{ headerItem: styles.tableHeaderItem, arrowUp: styles.arrowUp }}
                   key={title}
                   isSortSelected={
                     sortCategory &&

--- a/src/components/species-modal/species-modal-styles.module.scss
+++ b/src/components/species-modal/species-modal-styles.module.scss
@@ -55,7 +55,7 @@
   }
 
   .tableHeaderContainer {
-    height: 60px;
+    min-height: 60px;
     padding: 15px 74px 15px 40px;
     background-color: $white;
     padding-top: 30px;
@@ -72,12 +72,14 @@
     @extend %subtitle;
     text-align: left;
     width: 20%;
+    padding-right: 60px;
 
-    // sort arrows
-    > span {
-      margin-bottom: -3px;
-    }
   }
+
+  .arrowUp {
+    top: -3px;
+  }
+
 
   .tableRowContainer {
     display: flex;


### PR DESCRIPTION
## Fix breaking sort into new line
### Description
The text of the sorted headers was making the sort icons move into the next line. Now its always side by side

![image](https://user-images.githubusercontent.com/9701591/96016725-5ff18f80-0e49-11eb-9f82-fc9f3786b562.png)
![image](https://user-images.githubusercontent.com/9701591/96016718-5d8f3580-0e49-11eb-82b2-8d11813555e6.png)
![image](https://user-images.githubusercontent.com/9701591/96016711-5bc57200-0e49-11eb-8175-b6013801968b.png)
![image](https://user-images.githubusercontent.com/9701591/96016703-58ca8180-0e49-11eb-82bd-7efff0cc8083.png)

### Designs
https://projects.invisionapp.com/d/main?origin=v7#/console/17484384/423981226/preview?scrollOffset=4811
### Testing instructions
Go to national reports rankings and species lists and try different screen sizes

### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-202