### PR TITLE
Fix/back to global crash

### DIFF
--- a/src/components/scene/scene-component.jsx
+++ b/src/components/scene/scene-component.jsx
@@ -1,68 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import cx from 'classnames';
-import { loadModules } from 'esri-loader';
 import Spinner from 'components/spinner';
 import styles from 'styles/themes/scene-theme.module.scss';
 
-const SceneComponent = ({ 
-  style,
+const SceneComponent = ({
+  map,
+  view,
+  loadState,
   sceneId,
   children,
   sceneName,
   className,
-  loaderOptions,
-  sceneSettings,
   spinner = true,
-  onMapLoad = null,
-  onViewLoad = null,
   interactionsDisabled = false,
 }) => {
-
-  const [map, setMap] = useState(null);
-  const [view, setView] = useState(null);
-  const [loadState, setLoadState] = useState('loading');
-
-  useEffect(() => {
-    loadModules(["esri/WebScene"], loaderOptions)
-      .then(([WebScene]) => {
-        const _map = new WebScene({
-          portalItem: {
-            id: sceneId
-          }
-        });
-        _map.load().then(map => { 
-          setMap(map);
-          onMapLoad && onMapLoad(map);
-        })
-      })
-      .catch(err => {
-        console.error(err);
-      });
-  }, [])
-
-  useEffect(() => {
-    if (map) {
-      loadModules(["esri/views/SceneView"], loaderOptions)
-        .then(([SceneView]) => {
-          const _view = new SceneView({
-            map: map,
-            container: `scene-container-${sceneName || sceneId}`,
-            ...sceneSettings
-          });
-          setView(_view);
-        })
-        .catch(err => {
-          console.error(err);
-        });
-    }
-  },[map])
-
-  useEffect(() => {
-    if (map && view) {
-      setLoadState('loaded');
-      onViewLoad && onViewLoad(map, view);
-    }
-  }, [map, view]);
 
   if (loadState === 'loading') {
     return (

--- a/src/components/scene/scene.js
+++ b/src/components/scene/scene.js
@@ -1,3 +1,94 @@
+import React, {useEffect, useState} from 'react';
+import { connect } from 'react-redux';
 import Component from './scene-component';
+import { loadModules } from 'esri-loader';
+import * as urlActions from 'actions/url-actions';
+const actions = { ...urlActions };
 
-export default Component;
+const SceneContainer = (props) => {
+  const {
+    sceneId,
+    sceneName,
+    loaderOptions,
+    sceneSettings,
+    changeGlobe,
+    onMapLoad,
+    onViewLoad,
+  } = props;
+
+  const [map, setMap] = useState(null);
+  const [view, setView] = useState(null);
+  const [loadState, setLoadState] = useState('loading');
+  // const watchUtils = useWatchUtils();
+  const handleLocationChange = (center) => changeGlobe({ center });
+
+  useEffect(() => {
+    loadModules(["esri/WebScene"], loaderOptions)
+      .then(([WebScene]) => {
+        const _map = new WebScene({
+          portalItem: {
+            id: sceneId
+          }
+        });
+        _map.load().then(map => { 
+          setMap(map);
+          onMapLoad && onMapLoad(map);
+        })
+      })
+      .catch(err => {
+        console.error(err);
+      });
+  }, [])
+
+  useEffect(() => {
+    if (map) {
+      loadModules(["esri/views/SceneView"], loaderOptions)
+        .then(([SceneView]) => {
+          const _view = new SceneView({
+            map: map,
+            container: `scene-container-${sceneName || sceneId}`,
+            ...sceneSettings
+          });
+          setView(_view);
+        })
+        .catch(err => {
+          console.error(err);
+        });
+    }
+  },[map])
+
+  useEffect(() => {
+    if (map && view) {
+      setLoadState('loaded');
+      onViewLoad && onViewLoad(map, view);
+    }
+  }, [map, view]);
+
+  // Update location in URL
+  useEffect(() => {
+    let watchHandle;
+    if (view && view.center) {
+      loadModules(["esri/core/watchUtils"]).then(([watchUtils]) => {
+        watchUtils.whenTrue(view, "stationary", function() {
+          const { longitude, latitude } = view.center;
+          handleLocationChange([longitude, latitude]);
+        });
+      })
+    }
+
+    return function cleanUp() {
+      watchHandle && watchHandle.remove()
+    }
+  }, [view]);
+
+  return (
+    <Component
+      loadState={loadState}
+      map={map}
+      view={view}
+      {...props}
+    />
+  )
+}
+
+export default connect(null, actions)(SceneContainer);

--- a/src/components/scene/scene.js
+++ b/src/components/scene/scene.js
@@ -14,13 +14,12 @@ const SceneContainer = (props) => {
     changeGlobe,
     onMapLoad,
     onViewLoad,
+    urlParamsUpdateDisabled
   } = props;
 
   const [map, setMap] = useState(null);
   const [view, setView] = useState(null);
   const [loadState, setLoadState] = useState('loading');
-  // const watchUtils = useWatchUtils();
-  const handleLocationChange = (center) => changeGlobe({ center });
 
   useEffect(() => {
     loadModules(["esri/WebScene"], loaderOptions)
@@ -67,11 +66,11 @@ const SceneContainer = (props) => {
   // Update location in URL
   useEffect(() => {
     let watchHandle;
-    if (view && view.center) {
+    if (view && view.center && !urlParamsUpdateDisabled) {
       loadModules(["esri/core/watchUtils"]).then(([watchUtils]) => {
         watchUtils.whenTrue(view, "stationary", function() {
           const { longitude, latitude } = view.center;
-          handleLocationChange([longitude, latitude]);
+          changeGlobe({ center: [longitude, latitude], zoom: view.zoom });
         });
       })
     }

--- a/src/components/widgets/location-widget/location-widget.js
+++ b/src/components/widgets/location-widget/location-widget.js
@@ -1,10 +1,7 @@
-// Docs for Locate ui widget
-// https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Locate.html
 import { loadModules } from 'esri-loader';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { useWatchUtils } from 'hooks/esri';
 
 import LocationWidgetComponent from './location-widget-component';
 import * as urlActions from 'actions/url-actions';
@@ -13,10 +10,8 @@ import { clickFindMyPositionAnalyticsEvent } from 'actions/google-analytics-acti
 const actions = { ...urlActions, clickFindMyPositionAnalyticsEvent };
 
 const LocationWidget = props => {
-  const { view, changeGlobe, clickFindMyPositionAnalyticsEvent, hidden } = props;
+  const { view, clickFindMyPositionAnalyticsEvent, hidden } = props;
   const [locationWidget, setLocationWidget] = useState(null);
-  const watchUtils = useWatchUtils();
-  const handleLocationChange = (center) => changeGlobe({ center });
 
   useEffect(() => {
     const node = document.createElement("div");
@@ -38,20 +33,6 @@ const LocationWidget = props => {
       ReactDOM.render(null, node);
     };
   }, [view, hidden])
-
-  // Update location in URL
-  useEffect(() => {
-    let watchHandle;
-    if (view) {
-      watchHandle = watchUtils && locationWidget && watchUtils.whenTrue(view, "stationary", function() {
-        const { longitude, latitude } = view.center;
-        handleLocationChange([longitude, latitude]);
-      });
-    }
-    return function cleanUp() {
-      watchHandle && watchHandle.remove()
-    }
-  }, [view, watchUtils, locationWidget]);
 
   return null;
 }

--- a/src/components/widgets/widgets-component.jsx
+++ b/src/components/widgets/widgets-component.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 // WIDGETS
-import LocationWidget from 'components/widgets/location-widget';
 import ZoomWidget from 'components/widgets/zoom-widget';
 import SettingsWidget from 'components/widgets/settings-widget';
 import ToggleUiWidget from 'components/widgets/toggle-ui-widget';
@@ -16,7 +15,6 @@ const WidgetsComponent = ({
   hideSettings = false,
   hideZoom = false,
   hideMiniMap = false,
-  hideLocator = false,
   isFullscreenActive,
   openedModal = null,
   isNotMapsList = true,
@@ -58,14 +56,6 @@ const WidgetsComponent = ({
           view={view}
           hidden={hiddenWidget}
           openedModal={openedModal}
-        />
-      )}
-      {!hideLocator && (
-        <LocationWidget
-          map={map}
-          view={view}
-          isNotMapsList={isNotMapsList}
-          hidden={hiddenWidget}
         />
       )}
     </>

--- a/src/components/widgets/zoom-widget/zoom-widget.js
+++ b/src/components/widgets/zoom-widget/zoom-widget.js
@@ -1,18 +1,13 @@
-// Docs for Zoom ui widget
-// https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Zoom.html
 import { loadModules } from 'esri-loader';
 import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import { useWatchUtils } from 'hooks/esri';
 import ZoomWidgetComponent from './zoom-widget-component';
 import * as actions from 'actions/url-actions';
 
 const ZoomWidget = props => {
-  const { view, changeGlobe, hidden, disableStateUpdate } = props;
+  const { view, hidden } = props;
   const [zoomWidget, setZoomWidget] = useState(null);
-  const watchUtils = useWatchUtils();
-  const handleZoomChange = (zoom) => changeGlobe({ zoom });
 
   // Load custom zoom widget
   useEffect(() => {
@@ -33,15 +28,6 @@ const ZoomWidget = props => {
     };
   }, [view, hidden])
 
-  // Update zoom in URL
-  useEffect(() => {
-    const watchHandle = watchUtils && zoomWidget && !disableStateUpdate && watchUtils.whenTrue(zoomWidget.view, "stationary", function() {
-      handleZoomChange(zoomWidget.view.zoom);
-    });
-    return function cleanUp() {
-      watchHandle && watchHandle.remove()
-    }
-  }, [watchUtils, zoomWidget]);
 
   return null;
 }

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -115,8 +115,6 @@ const DataGlobeComponent = ({
           hidden={esriWidgetsHidden}
           openedModal={openedModal}
           disableSettings
-          hideSearch
-          hideLocator
         />
         {selectedFeaturedMap && (
           <SelectedFeaturedMapCard

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -79,6 +79,7 @@ const DataGlobeComponent = ({
         interactionsDisabled={
           (isMapsList || isFeaturedPlaceCard) && !isOnMobile
         }
+        urlParamsUpdateDisabled
       >
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>

--- a/src/scenes/country-scene/country-scene-component.jsx
+++ b/src/scenes/country-scene/country-scene-component.jsx
@@ -84,8 +84,6 @@ const CountrySceneComponent = ({
           />
         )}
         <Widgets
-          hideSearch
-          hideLocator
           activeLayers={activeLayers}
           openedModal={openedModal}
           isFullscreenActive={isFullscreenActive}


### PR DESCRIPTION
## App crashes after `back to global`
### Description
A bug has been reported on the production site (these are the steps followed to reproduce it):
1- open the page;
2- select a country (Portugal);
3- click the "Rankings" tab at the bottom;
4- click a different country on the ranking list; (selection changes)
5- click the "Back to global" link on the top left
6- BAM WHITE SCREEN

This was caused by the removal of the `location` widget from the `country scene` after the find places card update (that is now the place where user can locate her self on the globe). The location widget was responsible of the update of the `center` url param where the `lat, long` of the view is set.

The fix for this issue has been moving the logic for params update from the location widget and handle it on the `scene` component. The `zoom` update logic (also stored on the url `globe` params) has also been moved to the scene container (it was previously handled on the zoom widget).

### Designs
_no designs_
### Testing instructions
Follow the steps on the description in order to test if the bug is still present
### Feature relevant tickets
This bug was predicted :facepalm: , there was already a `development chore` ticket for this on the sprint, but the release rush left it drain on the priority :(
https://half-earth-map.atlassian.net/browse/HE-72