### PR TITLE
Always center on country extent when entering

### DIFF
--- a/src/components/local-scene-view-manager/local-scene-view-manager.js
+++ b/src/components/local-scene-view-manager/local-scene-view-manager.js
@@ -2,21 +2,14 @@ import { useEffect } from 'react';
 
 const LocalSceneViewManager = ({
   view,
-  localGeometry,
-  sceneSettings
+  localGeometry
 }) => {
-  const { zoom, center } = sceneSettings;
-  
   useEffect(() => {
     if (view && localGeometry) {
       const { extent } = localGeometry;
       view.extent = extent;
       view.clippingArea = extent;
-      if (!zoom && !center) {
-        view.goTo({ target: extent, tilt: 40 });
-      } else {
-        view.goTo({ target: center, zoom, tilt: 40 })
-      }
+      view.goTo({ target: extent, tilt: 40 });
     }
   }, [localGeometry]);
 

--- a/src/scenes/country-scene/country-scene-component.jsx
+++ b/src/scenes/country-scene/country-scene-component.jsx
@@ -60,10 +60,7 @@ const CountrySceneComponent = ({
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
         onMapLoad={onMapLoad}
       >
-        <LocalSceneViewManager
-          localGeometry={countryBorder}
-          sceneSettings={sceneSettings}
-        />
+        <LocalSceneViewManager localGeometry={countryBorder} />
         <ArcgisLayerManager
           activeLayers={activeLayers}
           userConfig={userConfig}


### PR DESCRIPTION
## Always center on country extent when entering National Cards
### Description
Delete the code that was relying on the zoom and center to set the map position when we enter the National cards. Now we just center the country extent.

This was happening also due to lags in the country center
### Testing instructions
- Select a country boundary
- Before clicking into the modal pan the globe a lot
- Click on the modal to get to the National Report
- You should see the country centered
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-180