### PR TITLE
Chore/api version upgrade 4.17

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     />
     <meta name="theme-color" content="#000000" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <link rel="stylesheet" href="https://js.arcgis.com/4.15/esri/css/main.css">
+    <link rel="stylesheet" href="https://js.arcgis.com/4.17/esri/css/main.css">
     <script src="https://cdn.jsdelivr.net/npm/es6-promise@4/dist/es6-promise.auto.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=EB+Garamond:400,700&display=swap" rel="stylesheet">
     <script>

--- a/src/components/local-scene-view-manager/local-scene-view-manager.js
+++ b/src/components/local-scene-view-manager/local-scene-view-manager.js
@@ -9,7 +9,15 @@ const LocalSceneViewManager = ({
       const { extent } = localGeometry;
       view.extent = extent;
       view.clippingArea = extent;
-      view.goTo({ target: extent, tilt: 40 });
+      
+      view.goTo({ target: extent, tilt: 40 })
+      .catch(error => {
+        const newViewpoint = view.viewpoint.clone();
+        newViewpoint.targetGeometry = extent;
+        view.viewpoint = newViewpoint;
+        view.goTo({tilt: 40})
+      }
+        )
     }
   }, [localGeometry]);
 

--- a/src/components/local-scene-view-manager/local-scene-view-manager.js
+++ b/src/components/local-scene-view-manager/local-scene-view-manager.js
@@ -9,15 +9,10 @@ const LocalSceneViewManager = ({
       const { extent } = localGeometry;
       view.extent = extent;
       view.clippingArea = extent;
-      
       view.goTo({ target: extent, tilt: 40 })
       .catch(error => {
-        const newViewpoint = view.viewpoint.clone();
-        newViewpoint.targetGeometry = extent;
-        view.viewpoint = newViewpoint;
-        view.goTo({tilt: 40})
-      }
-        )
+        view.goTo({ target: extent, tilt: 40 })
+      })
     }
   }, [localGeometry]);
 


### PR DESCRIPTION
## Upgrade API version from 4.15 to 4.17
### Description
This PR bumps API version to 4.17.
On the update process one issue has been found. When entering national report cards from the globe an `AbortError` is triggered by the `view.goTo` function, that was avoiding the view to tilt as expected. I have worked around that triggering a second goTo from inside the `catch` (this error does not triggers when the scene is already mounted and travelling from country to country.)
### Designs
_No designs_
### Testing instructions
Test the full app.
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-179