### PR TITLE
Hide landscape feature dots

### DIFF
--- a/src/components/labels-layer/labels-layer.js
+++ b/src/components/labels-layer/labels-layer.js
@@ -4,8 +4,8 @@ import { loadModules } from 'esri-loader';
 import { findLayerInMap } from 'utils/layer-manager-utils';
 import * as urlActions from 'actions/url-actions';
 import { LANDSCAPE_LABELS_LAYERS } from 'constants/layers-groups';
+import { LANDSCAPE_FEATURES_LABELS_LAYER } from 'constants/layers-slugs';
 import { stylesConfig } from './labels-layer-styles-config';
-
 const labelsStylesSlugs = [
   'style_1_ter',
   'style_2_ter',
@@ -59,15 +59,25 @@ const LabelsLayer = props => {
           if (countryISO) {
             layer.definitionExpression = `GID_0 = '${countryISO}'`
           }
+          if (layer.title === LANDSCAPE_FEATURES_LABELS_LAYER) {
+            // Hides the dots but keeps the landscape feature layers
+            layer.renderer = {
+              type: 'simple',
+              symbol: {
+                type: 'simple-marker',
+                size: 0
+              }
+            }
+          }
         });
       });
     };
-    
+
     const layers = LANDSCAPE_LABELS_LAYERS.map(layer => findLayerInMap(layer, map)).filter(Boolean);
     if (layers.length) {
       styleLayers(layers);
       setLabelsLayers(layers);
-    } 
+    }
   }, [activeLayers]);
 
   useEffect(() => {

--- a/src/scenes/data-scene/data-scene-component.jsx
+++ b/src/scenes/data-scene/data-scene-component.jsx
@@ -12,6 +12,7 @@ import TutorialModal from 'components/tutorial/tutorial-modal';
 import DataGlobalSidebar from 'components/data-global-sidebar';
 import MenuSettings from 'components/mobile-only/menu-settings';
 import ArcgisLayerManager from 'components/arcgis-layer-manager';
+import { LANDSCAPE_FEATURES_LABELS_LAYER } from 'constants/layers-slugs';
 import CountryLabelsLayer from 'components/country-labels-layer';
 import CountriesBordersLayer from 'components/countries-borders-layer';
 import LandscapeViewManager from 'components/landscape-view-manager';
@@ -56,6 +57,18 @@ const CountrySceneComponent = ({
   userConfig
 }) => {
   const isOnMobile = useMobile();
+  const hideDots = ({ layer }) => {
+    if (layer.title === LANDSCAPE_FEATURES_LABELS_LAYER) {
+      // Hides the dots but keeps the landscape feature layers
+      layer.renderer = {
+        type: 'simple',
+        symbol: {
+          type: 'simple-marker',
+          size: 0
+        }
+      };
+    }
+  };
   return (
     <>
       <Scene
@@ -68,6 +81,7 @@ const CountrySceneComponent = ({
         <ArcgisLayerManager
           activeLayers={activeLayers}
           userConfig={userConfig}
+          customFunctions={[hideDots]}
         />
         {isGlobeUpdating && <Spinner floating />}
         {!isOnMobile && <Switcher />}

--- a/src/scenes/data-scene/data-scene-component.jsx
+++ b/src/scenes/data-scene/data-scene-component.jsx
@@ -12,7 +12,6 @@ import TutorialModal from 'components/tutorial/tutorial-modal';
 import DataGlobalSidebar from 'components/data-global-sidebar';
 import MenuSettings from 'components/mobile-only/menu-settings';
 import ArcgisLayerManager from 'components/arcgis-layer-manager';
-import { LANDSCAPE_FEATURES_LABELS_LAYER } from 'constants/layers-slugs';
 import CountryLabelsLayer from 'components/country-labels-layer';
 import CountriesBordersLayer from 'components/countries-borders-layer';
 import LandscapeViewManager from 'components/landscape-view-manager';
@@ -57,18 +56,6 @@ const CountrySceneComponent = ({
   userConfig
 }) => {
   const isOnMobile = useMobile();
-  const hideDots = ({ layer }) => {
-    if (layer.title === LANDSCAPE_FEATURES_LABELS_LAYER) {
-      // Hides the dots but keeps the landscape feature layers
-      layer.renderer = {
-        type: 'simple',
-        symbol: {
-          type: 'simple-marker',
-          size: 0
-        }
-      };
-    }
-  };
   return (
     <>
       <Scene
@@ -81,7 +68,6 @@ const CountrySceneComponent = ({
         <ArcgisLayerManager
           activeLayers={activeLayers}
           userConfig={userConfig}
-          customFunctions={[hideDots]}
         />
         {isGlobeUpdating && <Spinner floating />}
         {!isOnMobile && <Switcher />}


### PR DESCRIPTION
## Hide landscape feature dots but keep the labels
### Description
These dots weren't able to remove before reaching the frontend so we have to cast a new renderer just to not render them but render the labels.
![image](https://user-images.githubusercontent.com/9701591/96236452-59bff800-0f9c-11eb-87bc-e72a1b8400d0.png)

### Testing instructions
Go to landscape mode. Only the blue label items should be missing the point.

### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-129