### PR TITLE
Use renderer to open link in new tab

### DIFF
--- a/src/components/modal-metadata/modal-metadata-component.jsx
+++ b/src/components/modal-metadata/modal-metadata-component.jsx
@@ -6,8 +6,7 @@ import MolLogo from 'logos/mol.png';
 import ReactMarkdown from 'react-markdown';
 import styles from './modal-metadata-styles.module.scss';
 
-const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata, additionalContent }) => {
-  return (
+const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata, additionalContent }) => (
     <Modal
       onRequestClose={handleClose}
       isOpen={isOpen}
@@ -56,18 +55,13 @@ const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata, addition
               )}
             {
               metadata && metadata.source && (
-              <p className={styles.metadataSource}>
-                <ReactMarkdown source={`Source: ${metadata.source}`} escapeHtml={false}/>
-                {' '}
-                {
-                      metadata.sourceUrl && (
-                      <a href={metadata.sourceUrl} target="_blank" rel="noopener noreferrer">
-                        {metadata.sourceUrl}
-                      </a>
-                        )
-                    }
-              </p>
-                )
+              <div className={styles.metadataSource}>
+                <ReactMarkdown
+                  renderers={{link: ({href, children}) => <a href={href} target="_blank" rel="noopener noreferrer">{children[0].props.children}</a>}}
+                  children={`Source: ${metadata.source}`}
+                />
+              </div>
+              )
             }
             {
               metadata && metadata.molLogo === "TRUE" && (
@@ -83,11 +77,10 @@ const ModalMetadata = ({ isOpen, handleClose, loading, title, metadata, addition
                 )
             }
           </>
-)
+       )
       }
     </Modal>
-  )
-}
+)
 
 ModalMetadata.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
## Avoid crash when clicking on source link 
### Description
On the production site when trying to follow the source link on the metadata modal the app tries to open the link inside the iframe. 
This would cause undesiderable scenarios. In some cases `(1)` the resource is open inside the iframe and on worst scenarios `(2)` the iframe crashes. 

`(1)`
<img src="https://user-images.githubusercontent.com/6906348/99521189-65844d00-2994-11eb-92e7-19766d499386.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/6906348/99521433-b3995080-2994-11eb-8f47-ba6d0a4108ef.png" width=30% height=30% >

`(2)`
<img src="https://user-images.githubusercontent.com/6906348/99526589-be0b1880-299b-11eb-9b92-713260b30237.png" width=30% height=30%>
<img src="https://user-images.githubusercontent.com/6906348/99526983-5d301000-299c-11eb-88db-bffa1956f91b.png" width=30% height=30%>

This is the anchor for the source
![image](https://user-images.githubusercontent.com/6906348/99516162-27842a80-298e-11eb-898e-152a491c6636.png)

### Designs
_No designs_
### Testing instructions
To test the iframe open [this codepen](https://codepen.io/weberjavi/pen/gOMyeEQ) on an incognito window. The iframe is pointing to the demo site that has this branch deployed.
Alternatively you can also inspect the source link on the dev console and check that it has the `target="_blank"` attribute.
### Feature relevant tickets
https://half-earth-map.atlassian.net/browse/HE-226