### PR TITLE
Update layer URL

### DIFF
--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -106,7 +106,7 @@ export const LAYERS_URLS = {
   [FEATURED_PLACES_LAYER]:
     'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Bioplaces/FeatureServer',
   [MERGED_WDPA_VECTOR_TILE_LAYER]:
-    'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/merged_protection_wdpa_oecm_and_raisg/VectorTileServer',
+  'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/NRC_WDPA_OECM_Jan2020_cleaned_MOL/VectorTileServer',
   [PROTECTED_AREAS_FEATURE_LAYER]:
     'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Protected_areas_FL/FeatureServer',
   [PROTECTED_AREAS_VECTOR_TILE_LAYER]:


### PR DESCRIPTION
## updated vector tile service for NRC protected areas
### Description
This PR only modifies one line of code to retrieve the Protected Area data from a new service that does not contain the RAISG  polygons
### Designs
Fill colour: `#008604`
Outline colour: `#72B642`
Outline width: 0.25 px
### Testing instructions
Open a NRC in the Amazon basin. Check the Protected Area layer and the priority layer do not overlap (use opacity). There should "cookie cut" each other. 
### Feature relevant tickets
[HE-28: The vector tile layer of NRCs shows RAISG](https://vizzuality.atlassian.net/browse/HE-28?atlOrigin=eyJpIjoiNjM3N2NiMzk2NzFiNDE4OWE5YWE2YzQ3NjZiNTc3MjciLCJwIjoiaiJ9)