### PR TITLE
Fix/safari misplaced chart labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/_site

--- a/src/components/charts/scatter-plot/scatter-plot-component.jsx
+++ b/src/components/charts/scatter-plot/scatter-plot-component.jsx
@@ -129,8 +129,6 @@ const ScatterPlot = ({
                       fill={bubble.color}
                       />
                   }
-                  </AnimatePresence>
-                  <AnimatePresence>
                     <motion.circle
                       key={bubble.iso}
                       transition={animationTransitionConfig}
@@ -143,46 +141,41 @@ const ScatterPlot = ({
                       stroke="#040E14"
                     />
                   </AnimatePresence>
-                  <AnimatePresence>
-                    <motion.foreignObject
-                      width={bubble.size * 2}
-                      height={bubble.size * 2}
-                      key={bubble.iso}
-                      transition={animationTransitionConfig}
-                      initial={{x: chartScale.xScale(bubble.xAxisValues[countryChallengesSelectedKey]) - bubble.size}}
-                      animate={{ x: chartScale.xScale(bubble.xAxisValues[countryChallengesSelectedKey]) - bubble.size }}
-                      exit={{ x: 0 }}
-                      y={chartScale.yScale(bubble.yAxisValue) - bubble.size}
-                      requiredExtensions="http://www.w3.org/1999/xhtml"
-                      onMouseEnter={(e) => {
-                        setTooltipState({
-                          x:getX(e, chartSurfaceRef),
-                          y:getY(e, chartSurfaceRef),
-                          name: bubble.name,
-                          continent: bubble.continent,
-                          color: bubble.color
-                        })
-                        setTickLine(bubble.iso);
-                        setXAxisValue(bubble.xAxisValues[countryChallengesSelectedKey]);
-                        setYAxisValue(bubble.yAxisValue);
-                      }
-                      }
-                      onMouseLeave={() => {
-                        setTooltipState(null);
-                        setTickLine(null);
-                        setXAxisValue(null);
-                        setYAxisValue(null);
-                      }}
-                    >
-                      <div className={styles.bubbleTextContainer}>
-                        <span
-                          className={styles.bubbleText}
-                        >
-                          {bubble.iso}
-                        </span>
-                      </div>
-                    </motion.foreignObject>
-                  </AnimatePresence>
+                  <foreignObject
+                    width={bubble.size * 2}
+                    height={bubble.size * 2}
+                    key={bubble.iso}
+                    y={chartScale.yScale(bubble.yAxisValue) - bubble.size}
+                    x={chartScale.xScale(bubble.xAxisValues[countryChallengesSelectedKey]) - bubble.size}
+                    requiredExtensions="http://www.w3.org/1999/xhtml"
+                    onMouseEnter={(e) => {
+                      setTooltipState({
+                        x:getX(e, chartSurfaceRef),
+                        y:getY(e, chartSurfaceRef),
+                        name: bubble.name,
+                        continent: bubble.continent,
+                        color: bubble.color
+                      })
+                      setTickLine(bubble.iso);
+                      setXAxisValue(bubble.xAxisValues[countryChallengesSelectedKey]);
+                      setYAxisValue(bubble.yAxisValue);
+                    }
+                    }
+                    onMouseLeave={() => {
+                      setTooltipState(null);
+                      setTickLine(null);
+                      setXAxisValue(null);
+                      setYAxisValue(null);
+                    }}
+                  >
+                    <div className={styles.bubbleTextContainer}>
+                      <span
+                        className={styles.bubbleText}
+                      >
+                        {bubble.iso}
+                      </span>
+                    </div>
+                  </foreignObject>
                 </g>
               ))}
           </svg>

--- a/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
+++ b/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
@@ -31,7 +31,7 @@ $chart-margin: 14px;
 
 .bubbleText {
   @extend %title;
-  color: $dark-text;
+  color: #040E14;
 }
 .bubbleValue {
   @extend %title;

--- a/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
+++ b/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
@@ -31,7 +31,7 @@ $chart-margin: 14px;
 
 .bubbleText {
   @extend %title;
-  color: #040E14;
+  color: $challenges-view-background;
 }
 .bubbleValue {
   @extend %title;

--- a/src/scenes/country-scene/country-scene-styles.module.scss
+++ b/src/scenes/country-scene/country-scene-styles.module.scss
@@ -11,7 +11,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  background-color: #040E14;
+  background-color: $challenges-view-background;
   opacity: 0;
   width: 100vw;
   height: 100vh;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -68,6 +68,7 @@ $human-pressure-high: #F3E0F7;
 $human-pressure-mid: #9F82CE;
 $human-pressure-low: #282052;
 $human-pressures-gradient: linear-gradient(270deg, $human-pressure-high 0%, $human-pressure-mid 50%, $human-pressure-low 100%);
+$challenges-view-background: #040E14;
 // country ranking
 $endemic-species: #F8D300;
 $non-endemic-species: #F87200;


### PR DESCRIPTION
## Fix misplaced scatterplot chart labels on Safari
### Description
Safari has a known bug related with `foreignObject` element translations on webkit based browsers. It is avoiding the labels inside the bubbles on the chart to be positioned properly (they are being animated as expected on other browsers). 
We have been forced to remove animation on the labels (placed inside a `foreignObject` inside the `svg` circles). I've tried to place the labels outside the `foreignObject` and position them as HTML elements but we where loosing the `z-index` reference of the `svg` objects and hence not being able to hide those that had overlapping bubbles.
This 'fix' just removes the animation of the labels (and updates its color to be the same as the background of the chart).
### Testing instructions
Visit the app with Safari browser. Inside a National Report Card go to the challenges view and play with the chart. Country iso labels should be properly placed inside the bubbles. 
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-30