### PR TITLE
Small NRCs improvements

### DIFF
--- a/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-component.jsx
@@ -55,7 +55,10 @@ const LocalSceneSidebarComponent = ({
       />
       <DummyBlurWorkaround />
       <div className={styles.nameWrapper}>
-        <img className={styles.flag} src={`${process.env.PUBLIC_URL}/flags/${countryISO}.svg`} alt="" />
+        <div className={styles.flagWrapper}>
+          <img className={styles.flag} src={`${process.env.PUBLIC_URL}/flags/${countryISO}.svg`} alt="" />
+          <span className={styles.nrcTitle}>National report card of</span>
+        </div>
         {countryName && <p className={styles.countryName}>{countryName}</p>}
       </div>
       <Tabs

--- a/src/components/local-scene-sidebar/local-scene-sidebar-styles.module.scss
+++ b/src/components/local-scene-sidebar/local-scene-sidebar-styles.module.scss
@@ -34,7 +34,7 @@
 
 .loadingText {
   @extend %bodyText;
-  margin-bottom: 20px;
+  margin-bottom: $site-gutter;
   color: $white;
 }
 
@@ -44,10 +44,23 @@
   align-items: baseline;
 }
 
+.flagWrapper {
+  display: flex;
+  align-items: center;
+  margin-top: $site-gutter;
+}
+
 .flag {
   width: 30px;
   margin-left: $site-gutter;
   position: relative;
+}
+
+.nrcTitle {
+  @extend %title;
+  color: $white;
+  margin-left: $paragraph-gutter;
+  padding-top: 5px;
 }
 
 .countryName {

--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -129,7 +129,7 @@ const RankingChart = ({
           <div className={styles.table}>
             {data.map((d, i) => (
               <div className={cx(styles.row, {
-                [styles.found]: scrollIndex === i,
+                [styles.selectedCountry]: countryISO === d.iso,
               }
               )} key={d.name}>
                 <button
@@ -138,6 +138,7 @@ const RankingChart = ({
                 >
                   <span
                     className={cx(styles.spiCountryIndex, {
+                      [styles.found]: scrollIndex === i,
                       [styles.selectedCountry]: countryISO === d.iso,
                     })}
                   >
@@ -145,6 +146,7 @@ const RankingChart = ({
                   </span>
                   <span
                     className={cx(styles.spiCountryName, {
+                      [styles.found]: scrollIndex === i,
                       [styles.selectedCountry]: countryISO === d.iso,
                     })}
                   >

--- a/src/components/ranking-chart/ranking-chart-styles.module.scss
+++ b/src/components/ranking-chart/ranking-chart-styles.module.scss
@@ -96,11 +96,6 @@ $scroll-bar-width: 7px;
   }
 }
 
-.selectedCountry {
-  color: $brand-color-main;
-  font-weight: bold;
-}
-
 .spiCountryIndex {
   width: 2.5rem;
   display: inline-block;
@@ -148,12 +143,15 @@ $scroll-bar-width: 7px;
 .row {
   display: flex;
   align-items: flex-end;
+}
 
-  &.found {
-    .spiCountryText, .spiCountryIndex, .spiCountryName {
-      color: $white;
-    }
-  }
+.found {
+  color: $white;
+}
+
+.selectedCountry {
+  color: $brand-color-main;
+  font-weight: bold;
 }
 
 .tooltip {

--- a/src/components/ranking-chart/ranking-chart.js
+++ b/src/components/ranking-chart/ranking-chart.js
@@ -16,6 +16,12 @@ const RankingChartContainer = (props) => {
   const debouncedSearchTerm = useDebounce(searchTerm, 30);
 
   useEffect(() => {
+    const { countryISO, data } = props;
+    const newIndex = data.findIndex(d => d.iso === countryISO);
+    setScrollIndex(newIndex);
+  }, [])
+
+  useEffect(() => {
     if (data && searchTerm) {
       const newIndex = data.findIndex(d => d.name.toLowerCase().startsWith(searchTerm.toLowerCase()));
       setScrollIndex(newIndex);


### PR DESCRIPTION
## Small NRCs improvements
### Description
This PR adds the `National Report Card` title to the NRC sidebar and scrolls the ranking to the selected country on the Ranking tab on the NRCs.
### Designs
![image](https://user-images.githubusercontent.com/6906348/124147847-5b304280-da8f-11eb-9824-70eef0fd50a3.png)

### Testing instructions
Go to NRCs, the `National Report Card for` string is displayed on the side of the country flag.
Go to NRCs and select the Ranking tab. Selected country, coloured in turquoise, should be visible in the ranking.
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-71
https://vizzuality.atlassian.net/browse/HE-72