### PR TITLE
Remove user modal from data and NRC pages

### DIFF
--- a/src/pages/data-globe/data-globe-component.jsx
+++ b/src/pages/data-globe/data-globe-component.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import loadable from '@loadable/component'
 // components
 import DataScene from 'scenes/data-scene';
-import UserDataModal from 'components/user-data-modal';
 import TutorialModal from 'components/tutorial/tutorial-modal';
 import Switcher from 'components/switcher';
 import HalfEarthLogo from 'components/half-earth-logo';
@@ -64,7 +63,6 @@ const DataGlobeComponent = ({
         onMapLoad={(map) => handleMapLoad(map, activeLayers)}
       />
       {!useMobile() && <Switcher />}
-      <UserDataModal />
       <TutorialModal />
       {hasMetadata && <InfoModal />}
       {!useMobile() && <About />}

--- a/src/pages/nrc/nrc-component.jsx
+++ b/src/pages/nrc/nrc-component.jsx
@@ -5,7 +5,6 @@ import loadable from '@loadable/component'
 import Legend from 'components/legend';
 import About from 'components/about';
 import RankingChart from 'components/ranking-chart';
-import UserDataModal from 'components/user-data-modal';
 import NationalReportCardScene from 'scenes/nrc-scene';
 import HalfEarthLogo from 'components/half-earth-logo';
 import LocalSceneSidebar from 'components/local-scene-sidebar';
@@ -87,7 +86,6 @@ const NationalReportCard = ({
       <InfoModal />
     )}
     {!useMobile() && <About className={styles.hideOnPrint} />}
-    <UserDataModal />
   </>
 );
 


### PR DESCRIPTION
## Remove user modal from data and NRC pages
### Description
This PR removes all instances of the user data modal released for the June 2021 user research.
### Testing instructions
Visit the app in incognito window and no modal should be displayed.
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-70