### PR TITLE
updated table with gps and agol links

### DIFF
--- a/_docs/scientists/aois-and-crfs.md
+++ b/_docs/scientists/aois-and-crfs.md
@@ -4,8 +4,8 @@ title: AOIs and CRFs
 parent: Scientists 🧑‍🔬
 permalink: /_docs/science/aois-crfs
 ---
-
-# Existing documents
+# Areas of Interest driven by Cloud Raster Format in the ESRI portal
+## Existing documents
 - [Basecamp thread](https://basecamp.com/1756858/projects/13899003/messages/93850769){:target="_blank"} with videos.
 - [Rapid summaries report](https://docs.google.com/document/d/1ndUZfxKBKqpFgUymfge8JKyEcJu3r1IbsVCUQnjnWec/edit){:target="_blank"}: you will find some tricks to build the models of model builder, also a test of performance.
 - [CRF creation and storage](https://docs.google.com/document/d/1H6VaYnBHhPD3mDfCVnfwh6t22tPFffmjyej1OAjgddk/edit){:target="_blank"}: the process to build a crf is in this document.
@@ -116,79 +116,14 @@ def getPresentSpecies(table):
 If you forget to set a high limit for the records returned, the front end might inform of this limit. In the object `w` returned, check `value.exceededTransferLimit`. 
 
 # Current geoprocessing services in use `WIP`
-- [Get percentage presence of species](https://hepportal.arcgis.com/server/rest/services/sampleUniqueSelectCalculate/GPServer/sampleUniqueSelectCalculate){:target="_blank"} It needs to be joined with a table in arcgis online. For each taxa there will be a datacube
-- [Get percentage of protection](https://hepportal.arcgis.com/server/rest/services/paPercentage/GPServer/paPercentage){:target="_blank"}. The crf will be updated once the WDPA version is established, currently it is `clean_wdpa_april.crf` 
-- [Get most prevalent climate regime and land cover](https://hepportal.arcgis.com/server/rest/services/Simple_Zonal_Stats_boolean/GPServer/ZonalStats){:target="_blank"}. It needs to be joined with a table in [arcgis online.](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ecosytem_categories_lookup/FeatureServer){:target="_blank"} The name of the crf is `ELU.crf`. 
-- [Get percentage of land human encroachment](https://hepportal.arcgis.com/server/rest/services/LandEncroachmentPercentage/GPServer/LandEncroachmentPercentage){:target="_blank"} the crf name is `land_encroachment.crf`. The lookup table is in [arcgis online](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/land_encroachment_lookup/FeatureServer){:target="_blank"} .
-- [Get population in area](https://hepportal.arcgis.com/server/rest/services/Simple_Zonal_Stats_boolean/GPServer/ZonalStats){:target="_blank"}. Field with information: `SUM`
-
-
-
-
-| **Front end element** | **Crf name** | **Gp service** | **Field to use from response** | **AGOL table to use** | **AGOL field to use** |
+@Todo: change the protected area crf to use the one provided by MOL (`WDPA_OECM_prop.crf`), it should be a Zonal Stats getting the mean.
+| **Front end element** | **Crf name** |**Crf variable**| **Gp service** | **Field to use from response** | **AGOL table to use** | **AGOL field to use** |
 |--|--|--|--|--|--|
-| population | population2020.crf | [GP ZsatSum](https://hepportal.arcgis.com/server/rest/services/ZsatSum/GPServer/ZsatSum)|`SUM` | _none_   | _none_ |
-| climate_regime | ELU.crf| [GP ZsatMajority](https://hepportal.arcgis.com/server/rest/services/ZsatMajority/GPServer/ZsatMajority)| `MAJORITY` | [item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ecosytem_categories_lookup/FeatureServer) |  |
-| land_cover | ELU.crf | [GP ZsatMajority](https://hepportal.arcgis.com/server/rest/services/ZsatMajority/GPServer/ZsatMajority)| `MAJORITY`  | [item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ecosytem_categories_lookup/FeatureServer) |  |
-| Protection_percentage | clean_wdpa_april.crf |   [GP paPercentage](https://hepportal.arcgis.com/server/rest/services/paPercentage/GPServer/paPercentage) | `Percentage_protected` |_none_  |_none_ |
-| biodiversity_data | mammals_for_greta.crf | [GP sampleUniqueSelectCalculate](https://hepportal.arcgis.com/server/rest/services/sampleUniqueSelectCalculateParallel/GPServer/sampleUniqueSelectCalculate) | Get length of the array. `SliceNumber` has the code of the species. `Percentage_presence` has the value of percent. |TBD  | `SliceNumber`, `species_name`, `species_target`, `species_global_range`, `global_percent_protected` |
-|Human_encroachment|land_encroachment.crf|[GP LandEncroachmentPercentage](https://hepportal.arcgis.com/server/rest/services/LandEncroachmentPercentage/GPServer/LandEncroachmentPercentage)|`SliceNumber` has the code of the type of human activity. `percentage_land_encroachment`|[item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/land_encroachment_lookup/FeatureServer)|`SliceNumber` to join and then `Name`|
-
-
-
-#### geoprocessing services as javascript
-```JavaScript
-export const SUM_VALUE_SERVICE_CONFIG = {
-  url: 'https://hepportal.arcgis.com/server/rest/services/ZsatSum/GPServer/ZsatSum',
-  inputRasterKey: 'crf_name',
-  inputGeometryKey: 'geometry',
-  inputFeatureServiceNameKey: 'esri_out_feature_service_name',
-  outputParamKey: 'output_table',
-  basePath: '/cloudStores/HECloudstore_ds_fuwwtcoj9blciafm/'
-}
-
-export const MAJORITY_VALUE_SERVICE_CONFIG = {
-  url: 'https://hepportal.arcgis.com/server/rest/services/ZsatMajority/GPServer/ZsatMajority',
-  inputRasterKey: 'crf_name',
-  inputGeometryKey: 'geometry',
-  inputFeatureServiceNameKey: 'esri_out_feature_service_name',
-  outputParamKey: 'output_table',
-  basePath: '/cloudStores/HECloudstore_ds_fuwwtcoj9blciafm/'
-}
-
-export const PROTECTED_PERCENTAGE_CONFIG = {
-  url: 'https://hepportal.arcgis.com/server/rest/services/paPercentage/GPServer/paPercentage',
-  inputRasterKey: 'crf_name',
-  inputGeometryKey: 'geometry',
-  inputFeatureServiceNameKey: 'esri_out_feature_service_name',
-  outputParamKey: 'output_table',
-  basePath: '/cloudStores/HECloudstore_ds_fuwwtcoj9blciafm/'
-}
-
-export const LAND_ENCROACHMENT_PERCENTAGE_CONFIG = {
-  url: 'https://hepportal.arcgis.com/server/rest/services/LandEncroachmentPercentage/GPServer/LandEncroachmentPercentage',
-  inputRasterKey: 'crf_name',
-  inputGeometryKey: 'geometry',
-  inputFeatureServiceNameKey: 'esri_out_feature_service_name',
-  outputParamKey: 'output_table',
-  basePath: '/cloudStores/HECloudstore_ds_fuwwtcoj9blciafm/'
-}
-
-export const BIODIVERSITY_SAMPLE_CONFIG = {
-  url: 'https://hepportal.arcgis.com/server/rest/services/sampleUniqueSelectCalculateParallel/GPServer/sampleUniqueSelectCalculate',
-  inputRasterKey: 'crf_name',
-  inputGeometryKey: 'geometry',
-  inputFeatureServiceNameKey: 'esri_out_feature_service_name',
-  uniqueFieldID: 'unique_id_field',
-  outputParamKey: 'output_table',
-  basePath: '/cloudStores/HECloudstore_ds_fuwwtcoj9blciafm/'
-} 
-
-export const CRF_NAMES = {
-  HUMMINGBIRDS: 'hummingbirds_binary', // Should use BIODIVERSITY_SAMPLE_CONFIG
-  MAMMALS: 'mammals_for_greta', // Should use BIODIVERSITY_SAMPLE_CONFIG
-  ECOLOGICAL_LAND_UNITS: 'ELU', // Should use MAJORITY_VALUE_SERVICE_CONFIG
-  POPULATION: 'population2020', // SUM_VALUE_SERVICE_CONFIG
-  PROTECTED_AREAS: 'clean_wdpa_april' // PROTECTED_PERCENTAGE_CONFIG
-}
-```
+| population | population2020.crf |_none_| [GP ZsatSum](https://hepportal.arcgis.com/server/rest/services/ZsatSum/GPServer/ZsatSum)|`SUM` | _none_   | _none_ |
+| climate_regime | ELU.crf|_none_| [GP ZsatMajority](https://hepportal.arcgis.com/server/rest/services/ZsatMajority/GPServer/ZsatMajority)| `MAJORITY` | [item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ecosytem_categories_lookup/FeatureServer) | `cr_type` contains the name of the type of climate regime |
+| land_cover | ELU.crf |_none_| [GP ZsatMajority](https://hepportal.arcgis.com/server/rest/services/ZsatMajority/GPServer/ZsatMajority)| `MAJORITY`  | [item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/ecosytem_categories_lookup/FeatureServer) | `lc_type` contains the name of the type of land cover |
+| Protection_percentage | clean_wdpa_april.crf | _none_|  [GP paPercentage](https://hepportal.arcgis.com/server/rest/services/paPercentage/GPServer/paPercentage) | `Percentage_protected` |_none_  |_none_ |
+| mammal_data | mammals_for_greta.crf | `presence` |[GP sampleUniqueSelectCalculate](https://hepportal.arcgis.com/server/rest/services/sampleUniqueSelectCalculateParallel/GPServer/sampleUniqueSelectCalculate) | Get length of the array. `SliceNumber` has the code of the species. `Percentage_presence` has the value of percent. |[agol link](https://utility.arcgis.com/usrsvcs/servers/826fc7ca52b2418c9feb0269ec0b185e/rest/services/mammals_lookup/FeatureServer)| `SliceNumber`, `Name`, `global_target`, `global_range_km2`, `global_percent_protected` |
+| amphibian_data | amphibians.crf |`amphibians`| [GP sampleUniqueSelectCalculate](https://hepportal.arcgis.com/server/rest/services/SampleAmph/GPServer/SampleAmph) | Get length of the array. `SliceNumber` has the code of the species. `Percentage_presence` has the value of percent. |[agol link](https://utility.arcgis.com/usrsvcs/servers/d723a804327b401395728c66ad5a1e08/rest/services/amphibians_lookup/FeatureServer)| `SliceNumber`, `Name`, `global_target`, `global_range_km2`, `global_percent_protected` |
+| bird_data | birds.crf | `birds`|[GP sampleUniqueSelectCalculate](https://hepportal.arcgis.com/server/rest/services/SampleBirds/GPServer/SampleBirds) | Get length of the array. `SliceNumber` has the code of the species. `Percentage_presence` has the value of percent. |[agol link](https://utility.arcgis.com/usrsvcs/servers/8e6944b5c940408ab4f16d812435ba34/rest/services/birds_lookup/FeatureServer)| `SliceNumber`, `Name`, `global_target`, `global_range_km2`, `global_percent_protected` |
+|Human_encroachment|land_encroachment.crf|_none_|[GP LandEncroachmentPercentage](https://hepportal.arcgis.com/server/rest/services/LandEncroachmentPercentage/GPServer/LandEncroachmentPercentage)|`SliceNumber` has the code of the type of human activity. `percentage_land_encroachment`|[item](https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/land_encroachment_lookup/FeatureServer)|`SliceNumber` to join and then `Name`|


### PR DESCRIPTION
## Update table with webtool links and items in Arcgis online to query
the table now contains the name of the variable within the crf that refers to the presence. The items in AGOL that contain the global data have been linked. Added webtools for amphibians and birds.