### PR TITLE
Fix/aoi name and country centroids

### DIFF
--- a/src/constants/graphic-styles.js
+++ b/src/constants/graphic-styles.js
@@ -3,7 +3,7 @@ export const MASK_STYLES = {
   fillOpacity: 0.5,
   outlineColor: [147, 255, 95],
   outlineOpacity: 0.9,
-  outlineWidth: 1,
+  outlineWidth: 0,
 }
 
 export const BORDERS_OPACITY = 0.3;

--- a/src/containers/modals/aoi-history-modal/component.jsx
+++ b/src/containers/modals/aoi-history-modal/component.jsx
@@ -36,13 +36,13 @@ const AoiHistoryModalComponent = ({
     }
   }, [editAoiId, activeInputRef])
 
-  const AoiInfoComponent = ({id, name, timestamp}) => (
+  const AoiInfoComponent = ({id, areaName, timestamp}) => (
     <>
       <span
         className={styles.aoiName}
         onClick={() => handleAoiClick(id)}
       >
-        {name}
+        {areaName}
       </span>
       <span className={styles.timestamp}>
         {timestampAoiFormatting(timestamp)}
@@ -50,7 +50,7 @@ const AoiHistoryModalComponent = ({
     </>
   )
 
-  return (
+  return console.log(aoiHistory) || (
     <Modal isOpen={isOpen} onRequestClose={handleModalClose} theme={styles}>
       <div className={styles.modalContainer}>
         <h2 className={styles.title}>Your areas of interest history.</h2>
@@ -67,7 +67,7 @@ const AoiHistoryModalComponent = ({
         <ul className={styles.aoiListContainer}>
           {aoiHistory.map(({
             id,
-            name,
+            areaName,
             timestamp
           }) => (
             <li 
@@ -92,7 +92,7 @@ const AoiHistoryModalComponent = ({
                   className={styles.nameInput}
                   onChange={handleAoiNameChange}
                 /> :
-                  <AoiInfoComponent id={id} name={name} timestamp={timestamp}/>
+                  <AoiInfoComponent id={id} areaName={areaName} timestamp={timestamp}/>
                   }
                 </div>
                 <div

--- a/src/containers/modals/aoi-history-modal/index.js
+++ b/src/containers/modals/aoi-history-modal/index.js
@@ -38,7 +38,7 @@ const Container = (props) => {
 
   const handleAoiDataStore = (id) => {
     writeToForageItem(id, {
-      name: updatedAoiName,
+      areaName: updatedAoiName,
       timestamp: Date.now()
     }).then(() => {
       getAoiHistory().then((aois) => setAoiHistory(aois.sort(sortByDate)));

--- a/src/containers/scenes/aoi-scene/config.js
+++ b/src/containers/scenes/aoi-scene/config.js
@@ -2,7 +2,6 @@ import {
   MASK_LAYER,
   GRAPHIC_LAYER,
   CITIES_LABELS_LAYER,
-  COUNTRIES_LABELS_FEATURE_LAYER,
   LANDSCAPE_FEATURES_LABELS_LAYER,
   PROTECTED_AREAS_VECTOR_TILE_LAYER
 } from 'constants/layers-slugs';
@@ -13,7 +12,6 @@ export default {
     { title: MASK_LAYER },
     { title: GRAPHIC_LAYER },
     { title: CITIES_LABELS_LAYER },
-    { title: COUNTRIES_LABELS_FEATURE_LAYER },
     { title: LANDSCAPE_FEATURES_LABELS_LAYER },
     { title: PROTECTED_AREAS_VECTOR_TILE_LAYER },
   ],

--- a/src/containers/scenes/aoi-scene/index.js
+++ b/src/containers/scenes/aoi-scene/index.js
@@ -45,7 +45,6 @@ const Container = props => {
   const [taxaData, setTaxaData] = useState([])
   const [contextualData, setContextualData] = useState({})
   const [area, setAreaData] = useState(null);
-  const [areaName] = useState({areaName: 'Custom area'});
   const [geometry, setGeometry] = useState(null);
   const [jsonUtils, setJsonUtils] = useState(null);
   const [pressures, setPressuresData] = useState(null);
@@ -83,7 +82,6 @@ const Container = props => {
   useEffect(() => {
     if (geometryEngine &&  jsonUtils && !precalculatedLayerSlug) {
       localforage.getItem(aoiId).then((localStoredAoi) => {
-        console.log(localStoredAoi)
         if (localStoredAoi && localStoredAoi.species && localStoredAoi.jsonGeometry) {
           const { jsonGeometry, species, ...rest } = localStoredAoi;
           setSpeciesData({species});
@@ -92,17 +90,17 @@ const Container = props => {
         } else {
             getAoiFromDataBase(aoiId).then((aoiData) => {
             if (aoiData) {
-              console.log('data from arcgisonline', aoiData)
               const { geometry, species, ...rest } = aoiData;
               setGeometry(geometry);
               setSpeciesData(species);
               setContextualData({ ...rest })
             } else {
-              const area = calculateGeometryArea(aoiStoredGeometry, geometryEngine);
+              const areaName = 'Custom area';
               const jsonGeometry = aoiStoredGeometry.toJSON();
-              setAreaData({area});
+              const area = calculateGeometryArea(aoiStoredGeometry, geometryEngine);
+              setAreaData({area, areaName});
               setGeometry(jsonUtils.fromJSON(jsonGeometry));
-              writeToForageItem(aoiId, {jsonGeometry, area, ...areaName, timestamp: Date.now()});
+              writeToForageItem(aoiId, {jsonGeometry, area, areaName, timestamp: Date.now()});
               fetchDataAndUpdateForageItem(aoiId, getEluData, aoiStoredGeometry).then(data => setEluData(data));
               fetchDataAndUpdateForageItem(aoiId, getPopulationData, aoiStoredGeometry).then(data => setPopulationData(data));
               fetchDataAndUpdateForageItem(aoiId, getLandPressuresData, aoiStoredGeometry).then(data => setPressuresData(data));
@@ -126,13 +124,12 @@ const Container = props => {
     setContextualData({
       ...elu,
       ...area,
-      ...areaName,
       ...pressures,
       ...population,
       ...protectedAreasList,
       ...percentageProtected,
     })
-  },[elu, area, areaName, population, pressures, percentageProtected, protectedAreasList]);
+  },[elu, area, population, pressures, percentageProtected, protectedAreasList]);
 
   useEffect(() => {
     setSpeciesData({

--- a/src/containers/scenes/aoi-scene/index.js
+++ b/src/containers/scenes/aoi-scene/index.js
@@ -45,7 +45,7 @@ const Container = props => {
   const [taxaData, setTaxaData] = useState([])
   const [contextualData, setContextualData] = useState({})
   const [area, setAreaData] = useState(null);
-  const [areaName] = useState({name: 'Custom area'});
+  const [areaName] = useState({areaName: 'Custom area'});
   const [geometry, setGeometry] = useState(null);
   const [jsonUtils, setJsonUtils] = useState(null);
   const [pressures, setPressuresData] = useState(null);

--- a/src/containers/sidebars/aoi-sidebar/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/component.jsx
@@ -24,14 +24,13 @@ import styles from './styles.module.scss';
 const LocalSceneSidebarComponent = ({
   map,
   area,
-  speciesData,
-  contextualData,
   className,
   landCover,
   population,
+  speciesData,
   activeLayers,
   climateRegime,
-  handlePrintReport,
+  contextualData,
   shareAoiAnalytics,
   handleSceneModeChange,
 }) => {
@@ -54,7 +53,7 @@ const LocalSceneSidebarComponent = ({
       <DummyBlurWorkaround />
       <div className={styles.topRow}>
         <div className={styles.nameWrapper}>
-          <p className={styles.areaName}>{contextualData.name}</p>
+          <p className={styles.areaName}>{contextualData.areaName}</p>
           {area && <p className={styles.area}>{`${area} `}<span>km<sup>2</sup></span></p>}
         </div>
         <div className={styles.actionButtons}>
@@ -96,27 +95,27 @@ const LocalSceneSidebarComponent = ({
         />
         <SidebarCard 
           map={map}
-          contextualData={contextualData}
           toggleType='radio'
           activeLayers={activeLayers}
+          contextualData={contextualData}
           cardCategory={BIODIVERSITY_SLUG}
           layers={AOI_BIODIVERSITY_TOGGLES}
           // displayWarning={area < 10000}
         />
         <SidebarCard 
           map={map}
-          contextualData={contextualData}
           layers={WDPALayers}
           toggleType='checkbox'
           activeLayers={activeLayers}
           cardCategory={PROTECTION_SLUG}
+          contextualData={contextualData}
         />
         <SidebarCard 
           map={map}
-          contextualData={contextualData}
           toggleType='checkbox'
           activeLayers={activeLayers}
           layers={humanPressuresLandUse}
+          contextualData={contextualData}
           cardCategory={LAND_HUMAN_PRESSURES_SLUG}
         />
         <section className={styles.completeDatabaseWrapper}>

--- a/src/containers/sidebars/aoi-sidebar/index.js
+++ b/src/containers/sidebars/aoi-sidebar/index.js
@@ -36,7 +36,6 @@ const AoiSidebarContainer = (props) => {
       landCover={values.landCover}
       population={values.population}
       contextualData={contextualData}
-      areaName={contextualData.name}
       climateRegime={values.climateRegime}
       handleSceneModeChange={handleSceneModeChange}
       {...props}

--- a/src/utils/local-forage-utils.js
+++ b/src/utils/local-forage-utils.js
@@ -32,7 +32,7 @@ export function getAoiHistory() {
       localforage.iterate((value, key) => {
         _aoiHistory.push({
           id: key,
-          name: value.name,
+          areaName: value.areaName,
           timestamp: value.timestamp
         })
       }).then(() => {


### PR DESCRIPTION
## Bring back AOI name and remove country centroids.
### Description
This PR brings back the area name name (for the pre-calculated areas) to the sidebar on the AOIs scene.

![Screenshot from 2021-12-09 13-43-00](https://user-images.githubusercontent.com/6906348/145398665-bfdcc63a-80f4-47a7-8c57-b53c1e47114d.png)

It also removes the unwanted country centroids that were being displayed on the AOI scene.

### Testing instructions
Get into a pre-calculated area of interest by clicking on a map feature (national or sub-national)

### Feature relevant tickets
[HE-177](https://vizzuality.atlassian.net/browse/HE-177)
[HE-194](https://vizzuality.atlassian.net/browse/HE-194)