### PR TITLE
Update country on country click

### DIFF
--- a/src/containers/scenes/data-scene/data-scene-component.jsx
+++ b/src/containers/scenes/data-scene/data-scene-component.jsx
@@ -93,7 +93,6 @@ const CountrySceneComponent = ({
         />
         {selectedAnalysisLayer && (
           <FeatureHighlightLayer
-            isLandscapeMode={isLandscapeMode}
             featureLayerSlug={selectedAnalysisLayer.slug}
             onFeatureClick={handleHighlightLayerFeatureClick}
           />

--- a/src/containers/scenes/nrc-scene/nrc-scene-component.jsx
+++ b/src/containers/scenes/nrc-scene/nrc-scene-component.jsx
@@ -7,6 +7,8 @@ import CountryMaskLayer from 'containers/layers/country-mask-layer';
 import ArcgisLayerManager from 'containers/managers/arcgis-layer-manager';
 import CountryEntryTooltip from 'components/country-entry-tooltip';
 import CountriesBordersLayer from 'containers/layers/countries-borders-layer';
+import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER as bordersLayerTitle } from 'constants/layers-slugs';
+import FeatureHighlightLayer from "containers/layers/feature-highlight-layer";
 import LocalSceneViewManager from 'containers/managers/local-scene-view-manager';
 import CountryLabelsLayer from 'containers/layers/country-labels-layer';
 import TerrainExaggerationLayer from 'containers/layers/terrain-exaggeration-layer';
@@ -27,6 +29,7 @@ const CountrySceneComponent = ({
   countryBorder,
   sceneSettings,
   isFullscreenActive,
+  handleCountryClick,
   countryTooltipDisplayFor,
 }) => (
   <Scene
@@ -44,9 +47,9 @@ const CountrySceneComponent = ({
       countryISO={countryISO}
       spatialReference={LOCAL_SPATIAL_REFERENCE}
     />
-    <CountriesBordersLayer
-      countryISO={countryISO}
-      spatialReference={LOCAL_SPATIAL_REFERENCE}
+    <FeatureHighlightLayer
+      featureLayerSlug={bordersLayerTitle}
+      onFeatureClick={handleCountryClick}
     />
     <CountryEntryTooltip
       countryTooltipDisplayFor={countryTooltipDisplayFor}
@@ -56,6 +59,7 @@ const CountrySceneComponent = ({
       activeLayers={activeLayers}
       countryISO={countryISO}
     />
+
     <TerrainExaggerationLayer />
     <LabelsLayer activeLayers={activeLayers} countryISO={countryISO} />
     {isVisible && 

--- a/src/containers/scenes/nrc-scene/nrc-scene-component.jsx
+++ b/src/containers/scenes/nrc-scene/nrc-scene-component.jsx
@@ -6,7 +6,6 @@ import LabelsLayer from 'containers/layers/labels-layer';
 import CountryMaskLayer from 'containers/layers/country-mask-layer';
 import ArcgisLayerManager from 'containers/managers/arcgis-layer-manager';
 import CountryEntryTooltip from 'components/country-entry-tooltip';
-import CountriesBordersLayer from 'containers/layers/countries-borders-layer';
 import { COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER as bordersLayerTitle } from 'constants/layers-slugs';
 import FeatureHighlightLayer from "containers/layers/feature-highlight-layer";
 import LocalSceneViewManager from 'containers/managers/local-scene-view-manager';

--- a/src/containers/scenes/nrc-scene/nrc-scene.js
+++ b/src/containers/scenes/nrc-scene/nrc-scene.js
@@ -5,11 +5,12 @@ import Component from './nrc-scene-component';
 import EsriFeatureService from 'services/esri-feature-service';
 // Constants
 import { COUNTRIES_GEOMETRIES_SERVICE_URL } from 'constants/layers-urls';
+import { LOCAL_SCENE_TABS_SLUGS } from "constants/ui-params";
 // Actions
 import countriesGeometriesActions from 'redux_modules/countries-geometries';
 import * as urlActions from 'actions/url-actions';
 import { visitCountryReportCardAnalyticsEvent } from 'actions/google-analytics-actions';
-import { DATA } from 'router'
+import { DATA, NATIONAL_REPORT_CARD } from 'router'
 
 import mapStateToProps from './nrc-scene-selectors';
 const actions = {...countriesGeometriesActions, ...urlActions, visitCountryReportCardAnalyticsEvent }
@@ -41,8 +42,15 @@ const NrcSceneContainer = (props) => {
     visitCountryReportCardAnalyticsEvent(countryISO);
   }, [countryISO])
 
+  const handleCountryClick = (results) => {
+    const { graphic } = results[0];
+    const { browsePage } = props;
+    browsePage({type: NATIONAL_REPORT_CARD, payload: { iso: graphic.attributes.GID_0, view:  LOCAL_SCENE_TABS_SLUGS.OVERVIEW }});
+  };
+
   return (
     <Component
+      handleCountryClick={handleCountryClick}
       {...props}
     />
   )


### PR DESCRIPTION
## Select country on feature click
### Description
This PR uses the `FeatureHighlighLayer` component on the NRC scene to update the country selection on click.
### Testing instructions
Go to a countries NRC and click on a different country on the globe. The sidebar should update with the new country data and the globe update it's position and the mask layer 
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-181