### PR TITLE
Fix/custom aoi percentages

### DIFF
--- a/src/components/source-annotation/component.jsx
+++ b/src/components/source-annotation/component.jsx
@@ -10,44 +10,46 @@ const Component = ({
   metaDataSources,
   isJSX = false,
 }) => {
-  const lastSource = sources && sources.length -1;
+  const lastSource = sources && sources.length - 1;
   const isMultiSource = sources && sources.length > 1;
   return (
     <section className={className}>
       {metaDataSources && (
-        <cite className={cx(
-          styles.metadataSource,
-          {[styles.light]: theme === 'light'}
-        )}>
+        <cite
+          className={cx(styles.metadataSource, {
+            [styles.light]: theme === 'light',
+          })}
+        >
           {!isJSX && (
             <ReactMarkdown
-              renderers={{link: ({href, children}) => <a href={href} target="_blank" rel="noopener noreferrer">{children[0].props.children}</a>}}
+              renderers={{
+                link: ({ href, children }) => (
+                  <a href={href} target="_blank" rel="noopener noreferrer">
+                    {children[0].props.children}
+                  </a>
+                ),
+              }}
               children={`Source: ${metaDataSources}`}
             />
           )}
           {isJSX && <span>Source: {metaDataSources}</span>}
         </cite>
-        )
-      }
-      {sources && (<span className={styles.sourcesWrapper}>
-        {`Source: `}
-        {sources.map((source, index) => (
-          <>
-          {(isMultiSource && index === lastSource) && <span> and </span> }
-            <cite
-              className={styles.source}
-            >
-              {`${source.label}`}
-            </cite>
-            {index !== lastSource && <span>, </span> }
-            {index === lastSource && <span>.</span> }
-          </>
-        ))
-        }
-      </span>)}
+      )}
+      {sources && (
+        <span className={styles.sourcesWrapper}>
+          {`Source: `}
+          {sources.map((source, index) => (
+            <>
+              {isMultiSource && index === lastSource && <span> and </span>}
+              <cite className={styles.source}>{`${source.label}`}</cite>
+              {index !== lastSource && <span>, </span>}
+              {index === lastSource && <span>.</span>}
+            </>
+          ))}
+        </span>
+      )}
     </section>
-
-  )
-}
+  );
+};
 
 export default Component;

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -43,6 +43,7 @@ export const AOIS_HISTORIC = process.env.NODE_ENV === "development" ? AOIS_HISTO
 
 const capPercentage = (percentage) => percentage > 100 ? 100 : percentage;
 
+// Custom AOIs on the PROTECTION_SLUG rely on percentage instead of protectionPercentage
 export const SIDEBAR_CARDS_CONFIG = {
   [SPECIES_SLUG]: {
     title: (speciesCount) => <span>This area is expected<br/>to have {speciesCount}</span>,
@@ -56,7 +57,7 @@ export const SIDEBAR_CARDS_CONFIG = {
   },
   [PROTECTION_SLUG]: {
     title: 'What is already protected in this area?',
-    description: ({protectionPercentage}) => `Of the current area, __${roundUpPercentage(percentageFormat(capPercentage(protectionPercentage)))}% of land is under formal protection__.`,
+    description: ({ protectionPercentage, percentage }) => (protectionPercentage || percentage) ? `Of the current area, __${roundUpPercentage(percentageFormat(capPercentage(protectionPercentage || (percentage && percentage * 100))))}% of land is under formal protection__.` : '',
     warning: null
   },
   [LAND_HUMAN_PRESSURES_SLUG]: {

--- a/src/constants/geo-processing-services.js
+++ b/src/constants/geo-processing-services.js
@@ -18,6 +18,7 @@ export const CRF_NAMES = {
 
 export const CONTEXTUAL_DATA = 'contextual_data';
 export const WDPA_LIST = 'wdpa_list';
+export const WDPA_PERCENTAGE = 'wdpa_percentage';
 
 export const CRF_DATA_CATEGORIES = {
   CONTEXT: 'context',
@@ -28,6 +29,7 @@ export const { BIRDS, AMPHIBIANS, MAMMALS, REPTILES, ECOLOGICAL_LAND_UNITS, POPU
 
 export const CONTEXTUAL_DATA_TABLES = {
   [WDPA_LIST]: 'output_table_wdpa',
+  [WDPA_PERCENTAGE]:'output_table_wdpa_percentage',
   [POPULATION]: 'output_table_population',
   [HUMAN_PRESSURES]: 'output_table_encroachment',
   [ECOLOGICAL_LAND_UNITS]:'output_table_elu_majority',
@@ -58,6 +60,7 @@ export const CONTEXTUAL_DATA_SERVICE_CONFIG = {
   },
   outputTablesKeys: [
     CONTEXTUAL_DATA_TABLES[WDPA_LIST],
+    CONTEXTUAL_DATA_TABLES[WDPA_PERCENTAGE],
     CONTEXTUAL_DATA_TABLES[POPULATION],
     CONTEXTUAL_DATA_TABLES[HUMAN_PRESSURES],
     CONTEXTUAL_DATA_TABLES[ECOLOGICAL_LAND_UNITS],

--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -21,6 +21,7 @@ export const URBAN_HUMAN_PRESSURES_TILE_LAYER = 'urban_human_pressures';
 export const IRRIGATED_HUMAN_PRESSURES_TILE_LAYER = 'irrigated_human_pressures';
 export const RAINFED_HUMAN_PRESSURES_TILE_LAYER = 'rainfed_human_pressures';
 export const RANGELAND_HUMAN_PRESSURES_TILE_LAYER = 'rangeland_human_pressures';
+export const MERGED_LAND_HUMAN_PRESSURES = 'merged_land_human_pressures';
 // Marine human pressures tiled layers.
 export const MARINE_LAND_DRIVERS_HUMAN_PRESSURES_TILE_LAYER = 'marine_land_drivers_human_pressures';
 export const MARINE_OCEAN_DRIVERS_HUMAN_PRESSURES_TILE_LAYER = 'marine_ocean_drivers_human_pressures';

--- a/src/constants/metadata.js
+++ b/src/constants/metadata.js
@@ -35,7 +35,9 @@ import {
   COUNTRY_PRIORITY_LAYER,
   COMMUNITY_AREAS_VECTOR_TILE_LAYER,
   PROTECTED_AREAS_VECTOR_TILE_LAYER,
-  MARINE_AND_LAND_HUMAN_PRESSURES
+  MARINE_AND_LAND_HUMAN_PRESSURES,
+  ALL_TAXA_PRIORITY,
+  MERGED_LAND_HUMAN_PRESSURES
  } from 'constants/layers-slugs';
 
  export const SPECIES_PROTECTION_INDEX = 'spi-def';
@@ -43,8 +45,20 @@ import {
  export const RANKING_CHART = 'spi-ranking';
  export const MERGED_PROTECTION = MERGED_WDPA_VECTOR_TILE_LAYER;
  export const COUNTRY_PRIORITY = COUNTRY_PRIORITY_LAYER;
- 
+ export {
+   ALL_TAXA_PRIORITY,
+   MERGED_LAND_HUMAN_PRESSURES,
+ } from 'constants/layers-slugs';
+
 export default {
+  [ALL_TAXA_PRIORITY]: {
+    slug: ALL_TAXA_PRIORITY,
+    title: 'Biodiversity pattern'
+  },
+  [MERGED_LAND_HUMAN_PRESSURES]: {
+    slug: MERGED_LAND_HUMAN_PRESSURES,
+    title: 'Human modifications'
+  },
   [CHALLENGES_CHART]: {
     slug: CHALLENGES_CHART,
     title: 'What are the challenges for a country?'

--- a/src/containers/scenes/aoi-scene/index.js
+++ b/src/containers/scenes/aoi-scene/index.js
@@ -117,9 +117,13 @@ const Container = props => {
           const { jsonGeometry, species, ...rest } = localStoredAoi;
           const geometry = jsonUtils.fromJSON(jsonGeometry);
           setSpeciesData({ species: orderBy(species, ['has_image', 'conservationConcern'], ['desc', 'desc']) });
-          setContextualData({ ...rest, aoiId, isCustom: true });
+          const contextualData = { ...rest, aoiId, isCustom: true };
+
+          // Set data before fetch just to show name and available info
+          setContextualData(contextualData);
+
           getContextData(geometry).then((data) => {
-            setContextualData(data);
+            setContextualData({ ...contextualData, ...data });
           });
           setGeometry(geometry);
         } else {
@@ -138,11 +142,13 @@ const Container = props => {
               const areaName = 'Custom area';
               const jsonGeometry = aoiStoredGeometry && aoiStoredGeometry.toJSON();
               const area = calculateGeometryArea(aoiStoredGeometry, geometryEngine);
+
               setContextualData({ area, areaName, isCustom: true, aoiId });
               setGeometry(jsonUtils.fromJSON(jsonGeometry));
               writeToForageItem(aoiId, { jsonGeometry, area, areaName, timestamp: Date.now() });
 
               getContextData(aoiStoredGeometry).then((data) => {
+
                 setContextualData({ area, areaName, ...data });
               });
 

--- a/src/containers/sidebars/aoi-sidebar/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/component.jsx
@@ -24,7 +24,11 @@ import {
   BIODIVERSITY_SLUG,
   PROTECTION_SLUG,
 } from 'constants/analyze-areas-constants';
-
+import {
+  MERGED_PROTECTION,
+  MERGED_LAND_HUMAN_PRESSURES,
+  ALL_TAXA_PRIORITY,
+} from 'constants/metadata';
 import styles from './styles.module.scss';
 
 const AOISidebarComponent = ({
@@ -151,6 +155,7 @@ const AOISidebarComponent = ({
           contextualData={contextualData}
           cardCategory={BIODIVERSITY_SLUG}
           layers={AOI_BIODIVERSITY_TOGGLES}
+          metadataSlug={ALL_TAXA_PRIORITY}
           // displayWarning={area < 10000}
         />
         <SidebarCard
@@ -160,6 +165,7 @@ const AOISidebarComponent = ({
           activeLayers={activeLayers}
           cardCategory={PROTECTION_SLUG}
           contextualData={contextualData}
+          metadataSlug={MERGED_PROTECTION}
         />
         <SidebarCard
           map={map}
@@ -168,6 +174,7 @@ const AOISidebarComponent = ({
           layers={humanPressuresLandUse}
           contextualData={contextualData}
           cardCategory={LAND_HUMAN_PRESSURES_SLUG}
+          metadataSlug={MERGED_LAND_HUMAN_PRESSURES}
         />
         <section className={styles.completeDatabaseWrapper}>
           <p>Do you have more information about this particular area?</p>

--- a/src/containers/sidebars/aoi-sidebar/index.js
+++ b/src/containers/sidebars/aoi-sidebar/index.js
@@ -14,6 +14,8 @@ const AoiSidebarContainer = (props) => {
   const [values, setFormattedValues ] = useState({})
   useEffect(() => {
     if (Object.keys(contextualData).length > 0) {
+      // Custom AOIs rely on percentage instead of protectionPercentage
+      const percentage = contextualData.protectionPercentage || (contextualData.percentage * 100);
       setFormattedValues({
         landCover: contextualData.elu && contextualData.elu.landCover,
         area: localeFormatting(contextualData.area),
@@ -21,7 +23,7 @@ const AoiSidebarContainer = (props) => {
         population: contextualData.population && localeFormatting(contextualData.population),
         mainPressure: contextualData.pressures && getMainPressure(contextualData.pressures),
         totalPressures: contextualData.pressures && getTotalPressures(contextualData.pressures),
-        protectionPercentage: contextualData.protectionPercentage && percentageFormat(contextualData.protectionPercentage),
+        protectionPercentage: (contextualData.protectionPercentage || contextualData.percentage) && percentageFormat(percentage),
       })
     }
   }, [contextualData]);

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -38,6 +38,7 @@ const SidebarCard = ({
   isProtectedAreasModalOpen,
   handleProtectedAreasModalToggle,
   contextualData,
+  metadata,
 }) => (
   <SidebarCardWrapper className={styles.cardWrapper}>
     <div>
@@ -67,16 +68,7 @@ const SidebarCard = ({
       )}
       <SourceAnnotation
         theme="dark"
-        isJSX
-        metaDataSources={
-          <a
-            href="http://protectedplanet.net/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            World Database on Protected Areas.
-          </a>
-        }
+        metaDataSources={metadata && metadata.source}
         className={styles.sourceContainer}
       />
     </div>

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/index.js
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/index.js
@@ -5,6 +5,8 @@ import { AOI_LEGEND_CATEGORIES, SIDEBAR_CARDS_CONFIG } from 'constants/analyze-a
 import { layerManagerToggle, batchToggleLayers } from 'utils/layer-manager-utils';
 import * as urlActions from 'actions/url-actions';
 import metadataActions from 'redux_modules/metadata';
+import metadataConfig from 'constants/metadata';
+import metadataService from 'services/metadata-service';
 
 const actions = {...metadataActions, ...urlActions};
 
@@ -15,12 +17,21 @@ const Container = (props) => {
     changeGlobe,
     activeLayers,
     cardCategory,
+    metadataSlug
   } = props;
 
   const [selectedLayer, setSelectedLayer] = useState(null);
   const [cardDescription, setCardDescription] = useState(null);
   const [protectedAreasModalOpen, setProtectedAreasModalOpen] = useState(false);
   const { description, title } = SIDEBAR_CARDS_CONFIG[cardCategory];
+  const [metadata, setMetadata] = useState(null);
+
+  useEffect(() => {
+    const md = metadataConfig[metadataSlug]
+    metadataService.getMetadata(md.slug).then( data => {
+      setMetadata(data);
+    })
+  }, []);
 
   useEffect(() => {
     if (Object.keys(contextualData).length > 0) {
@@ -52,7 +63,6 @@ const Container = (props) => {
   const handleProtectedAreasModalToggle = () => {
     setProtectedAreasModalOpen(!protectedAreasModalOpen);
   }
-
   return (
     <Component
       cardTitle={title}
@@ -62,6 +72,7 @@ const Container = (props) => {
       handleAllProtectedAreasClick={handleAllProtectedAreasClick}
       handleProtectedAreasModalToggle={handleProtectedAreasModalToggle}
       isProtectedAreasModalOpen={protectedAreasModalOpen}
+      metadata={metadata}
       {...props}
     />
   )

--- a/src/containers/sidebars/sidebar-legend/styles.module.scss
+++ b/src/containers/sidebars/sidebar-legend/styles.module.scss
@@ -1,6 +1,10 @@
 @import 'styles/settings';
 @import 'styles/typography-extends';
 
+.container {
+  margin-bottom: 5px;
+}
+
 .gradientWrapper {
   height: 8px;
   border-radius: 5px;

--- a/src/utils/geo-processing-services.js
+++ b/src/utils/geo-processing-services.js
@@ -80,7 +80,7 @@ const getProtectedAreasList = (data) => (
   }))
 )
 
-const getPercentage = (data) => data[CONTEXTUAL_DATA_TABLES[WDPA_PERCENTAGE]].value.features[0].attributes.percentage_protected;
+const getPercentage = (data) => data[CONTEXTUAL_DATA_TABLES[WDPA_PERCENTAGE]].value.features[0] && data[CONTEXTUAL_DATA_TABLES[WDPA_PERCENTAGE]].value.features[0].attributes.percentage_protected;
 
 export function getContextData(geometry) {
   return new Promise((resolve, reject) => {

--- a/src/utils/geo-processing-services.js
+++ b/src/utils/geo-processing-services.js
@@ -9,6 +9,7 @@ import { getCrfData } from 'services/geo-processing-services/biodiversity';
 import { getCrfData as getContextualData } from 'services/geo-processing-services/contextual-data';
 import {
   WDPA_LIST,
+  WDPA_PERCENTAGE,
   POPULATION,
   LOOKUP_TABLES,
   HUMAN_PRESSURES,
@@ -79,6 +80,8 @@ const getProtectedAreasList = (data) => (
   }))
 )
 
+const getPercentage = (data) => data[CONTEXTUAL_DATA_TABLES[WDPA_PERCENTAGE]].value.features[0].attributes.percentage_protected;
+
 export function getContextData(geometry) {
   return new Promise((resolve, reject) => {
     getContextualData(geometry).then(async data => {
@@ -86,11 +89,13 @@ export function getContextData(geometry) {
       const population = getAreaPopulation(data);
       const elu = await getEluData(data);
       const protectedAreasList = getProtectedAreasList(data);
+      const percentage = getPercentage(data);
       resolve({
         elu,
         pressures,
         population,
-        protectedAreasList
+        protectedAreasList,
+        percentage
       });
     }).catch((error) => {
       reject(error)


### PR DESCRIPTION
## Add custom aoi percentage of protection on the sidebar
### Description
We had to fetch this percentage from a different endpoint as is not the same source as the pregenerated

Also, a race condition with the Name not showing and showing NaN as the area is fixed now

### Testing instructions
Create or load a custom AOI. Go to the protected area card on the sidebar. You should be able to see the percentage
### Feature relevant tickets
[_Link to the related task manager tickets_](https://vizzuality.atlassian.net/browse/HE-268?atlOrigin=eyJpIjoiOGNkMmE3MzdmOWVlNDkyNGE0NGY0YzY4ZWFiOWQwMWEiLCJwIjoiaiJ9)