### PR TITLE
Dont show PA item in production

### DIFF
--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -35,14 +35,14 @@ export const { NATIONAL_BOUNDARIES, SUBNATIONAL_BOUNDARIES, PROTECTED_AREAS } = 
 
 export const DEFAULT_SOURCE = NATIONAL_BOUNDARIES;
 
-const { REACT_APP_VERCEL_ENV } = process.env;
+const { REACT_APP_FEATURE_PA_AOI } = process.env;
 
-console.log('testing REACT_APP_VERCEL_ENV',process.env, REACT_APP_VERCEL_ENV);
+console.log('testing REACT_APP_VERCEL_ENV',process.env, REACT_APP_FEATURE_PA_AOI, typeof REACT_APP_FEATURE_PA_AOI);
 
 export const PRECALCULATED_AOI_OPTIONS = [
   { title: NATIONAL_BOUNDARIES, slug: NATIONAL_BOUNDARIES, label: 'National boundaries' },
   { title: SUBNATIONAL_BOUNDARIES, slug: SUBNATIONAL_BOUNDARIES, label: 'Subnational boundaries' },
-  ...(REACT_APP_VERCEL_ENV !== 'production') ? [{ title: PROTECTED_AREAS, slug: PROTECTED_AREAS, label: 'Protected areas' }] : []
+  ...(REACT_APP_FEATURE_PA_AOI === 'true') ? [{ title: PROTECTED_AREAS, slug: PROTECTED_AREAS, label: 'Protected areas' }] : []
 ]
 
 export const AOIS_HISTORIC = process.env.NODE_ENV === "development" ? AOIS_HISTORIC_DEVELOPMENT : AOIS_HISTORIC_PRODUCTION;

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -37,7 +37,7 @@ export const DEFAULT_SOURCE = NATIONAL_BOUNDARIES;
 
 const { REACT_APP_VERCEL_ENV } = process.env;
 
-console.log('testing REACT_APP_VERCEL_ENV', REACT_APP_VERCEL_ENV);
+console.log('testing REACT_APP_VERCEL_ENV',process.env, REACT_APP_VERCEL_ENV);
 
 export const PRECALCULATED_AOI_OPTIONS = [
   { title: NATIONAL_BOUNDARIES, slug: NATIONAL_BOUNDARIES, label: 'National boundaries' },

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -37,8 +37,6 @@ export const DEFAULT_SOURCE = NATIONAL_BOUNDARIES;
 
 const { REACT_APP_FEATURE_PA_AOI } = process.env;
 
-console.log('testing REACT_APP_VERCEL_ENV',process.env, REACT_APP_FEATURE_PA_AOI, typeof REACT_APP_FEATURE_PA_AOI);
-
 export const PRECALCULATED_AOI_OPTIONS = [
   { title: NATIONAL_BOUNDARIES, slug: NATIONAL_BOUNDARIES, label: 'National boundaries' },
   { title: SUBNATIONAL_BOUNDARIES, slug: SUBNATIONAL_BOUNDARIES, label: 'Subnational boundaries' },

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -35,10 +35,14 @@ export const { NATIONAL_BOUNDARIES, SUBNATIONAL_BOUNDARIES, PROTECTED_AREAS } = 
 
 export const DEFAULT_SOURCE = NATIONAL_BOUNDARIES;
 
+const { REACT_APP_VERCEL_ENV } = process.env;
+
+console.log('testing REACT_APP_VERCEL_ENV', REACT_APP_VERCEL_ENV);
+
 export const PRECALCULATED_AOI_OPTIONS = [
   { title: NATIONAL_BOUNDARIES, slug: NATIONAL_BOUNDARIES, label: 'National boundaries' },
   { title: SUBNATIONAL_BOUNDARIES, slug: SUBNATIONAL_BOUNDARIES, label: 'Subnational boundaries' },
-  { title: PROTECTED_AREAS, slug: PROTECTED_AREAS, label: 'Protected areas' }
+  ...(REACT_APP_VERCEL_ENV !== 'production') ? [{ title: PROTECTED_AREAS, slug: PROTECTED_AREAS, label: 'Protected areas' }] : []
 ]
 
 export const AOIS_HISTORIC = process.env.NODE_ENV === "development" ? AOIS_HISTORIC_DEVELOPMENT : AOIS_HISTORIC_PRODUCTION;


### PR DESCRIPTION
## Don't show Protected Areas dropdown item in production AOI
### Description
We are going to use the `REACT_APP_FEATURE_PA_AOI` env variable. It will be false on production and this branch (for testing) and true on the rest. This is configured on the Vercel config online
### Testing instructions
The items should be hidden on production and this testing branch but not on the rest of environments
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-274?atlOrigin=eyJpIjoiNTljMWE2MzMyYWYxNGEwZGI2NzQyYzU0MGNkYmI1NDQiLCJwIjoiaiJ9