### PR TITLE
Cap human pressures to 100%

### DIFF
--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -64,8 +64,8 @@ export const SIDEBAR_CARDS_CONFIG = {
   },
   [LAND_HUMAN_PRESSURES_SLUG]: {
     title: 'How much do humans affect this area?',
-    description: ({pressures}) => `Of the current area, __${roundUpPercentage(getTotalPressures(capPercentage(pressures)))}% is under human pressure__,
-    the majority of which are pressures from ${getMainPressure(pressures)}.`,
+    description: ({ pressures }) => pressures ? `Of the current area, __${roundUpPercentage(getTotalPressures(pressures))}% is under human pressure__,
+    the majority of which are pressures from ${getMainPressure(pressures)}.` : '',
     warning: null
   },
 }

--- a/src/utils/analyze-areas-utils.js
+++ b/src/utils/analyze-areas-utils.js
@@ -61,9 +61,10 @@ export function featureCollectionFromShape(input, view, onSucces, onError) {
 
 export const getTotalPressures = (pressures) => {
   if (!pressures) return null;
-  const total = Object.keys(pressures).reduce((acc, key) => {
+  let total = Object.keys(pressures).reduce((acc, key) => {
     return pressures[key] ? acc + parseFloat(pressures[key]) : acc;
   }, 0);
+  total = (total > 100) ? 100 : total;
   return percentageFormat(total);
 }
 


### PR DESCRIPTION
## Cap human pressures to 100%
### Description
Human pressures weren't properly capped to 100%. Also now the phrase is not displayed until we have data (we had false data until then)
### Testing instructions
Try drawing an area next to Quinnipiac River, on Connecticut state of the US.

![image](https://user-images.githubusercontent.com/9701591/151334170-84595606-6a00-4d7f-adb3-6d418596863d.png)

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-270?atlOrigin=eyJpIjoiYjZiNWNhYzM1ZGYwNDQxNThjYjk1NzliYzgyZjQ1Y2QiLCJwIjoiaiJ9