### PR TITLE
Fix Custom AOIs protected table country name

### DIFF
--- a/src/components/protected-areas-table/component.jsx
+++ b/src/components/protected-areas-table/component.jsx
@@ -15,8 +15,16 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>NAME</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'NAME', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'NAME', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'NAME', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'NAME', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
@@ -24,8 +32,16 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>GOVERNANCE</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'GOV_TYP', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'GOV_TYP', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'GOV_TYP', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'GOV_TYP', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
@@ -33,8 +49,16 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>DESIGNATION</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'DESIG', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'DESIG', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'DESIG', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'DESIG', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
@@ -42,8 +66,16 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>DESIGNATION TYPE</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'DESIG_T', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'DESIG_T', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'DESIG_T', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'DESIG_T', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
@@ -51,8 +83,16 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>IUCN CATEGORY</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'IUCN_CA', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'IUCN_CA', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'IUCN_CA', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'IUCN_CA', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
@@ -60,48 +100,56 @@ const ProtectedAreasTable = ({ data, handleSortChange }) => (
           <div className={styles.headerColumnContainer}>
             <span>COUNTRY</span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'NAME_0', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'NAME_0', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'NAME_0', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'NAME_0', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
         <th className={styles.lastColumn}>
           <div className={styles.headerColumnContainer}>
-            <span>AREA (KM<sup>2</sup>)</span>
+            <span>
+              AREA (KM<sup>2</sup>)
+            </span>
             <div className={styles.arrowsContainer}>
-              <ArrowUp onClick={() => handleSortChange({ value: 'AREA_KM', ascending: true })} />
-              <ArrowDown onClick={() => handleSortChange({ value: 'AREA_KM', ascending: false })} />
+              <ArrowUp
+                onClick={() =>
+                  handleSortChange({ value: 'AREA_KM', ascending: true })
+                }
+              />
+              <ArrowDown
+                onClick={() =>
+                  handleSortChange({ value: 'AREA_KM', ascending: false })
+                }
+              />
             </div>
           </div>
         </th>
       </tr>
     </thead>
     <tbody>
-      {data && data.map((row, index) => (
-        <tr key={`wdpa-row-${row.NAME}-${index}`}>
-          <td className={styles.firstColumn}>
-            {row.NAME}
-          </td>
-          <td>
-            {row.GOV_TYP}
-          </td>
-          <td>
-            {row.DESIG}
-          </td>
-          <td>
-            {row.DESIG_T}
-          </td>
-          <td>
-            {row.IUCN_CA}
-          </td>
-          <td>
-            {row.NAME_0}
-          </td>
-          <td className={styles.lastColumn}>
-            {`${Math.round(row.AREA_KM)}km`}<sup>2</sup>
-          </td>
-        </tr>
-      ))}
+      {data &&
+        data.map((row, index) => (
+          <tr key={`wdpa-row-${row.NAME}-${index}`}>
+            <td className={styles.firstColumn}>{row.NAME}</td>
+            <td>{row.GOV_TYP}</td>
+            <td>{row.DESIG}</td>
+            <td>{row.DESIG_T}</td>
+            <td>{row.IUCN_CA}</td>
+            <td>{row.NAME_0}</td>
+            <td className={styles.lastColumn}>
+              {`${Math.round(row.AREA_KM)}km`}
+              <sup>2</sup>
+            </td>
+          </tr>
+        ))}
     </tbody>
   </table>
 );

--- a/src/containers/modals/protected-areas-modal/index.js
+++ b/src/containers/modals/protected-areas-modal/index.js
@@ -77,6 +77,7 @@ const Container = (props) => {
 
   useEffect(() => {
     let urlValue;
+
     switch (areaTypeSelected) {
       case NATIONAL_BOUNDARIES_TYPE:
         urlValue = LAYERS_URLS[GADM_0_ADMIN_AREAS_WITH_WDPAS_FEATURE_LAYER];
@@ -97,14 +98,14 @@ const Container = (props) => {
       }
     }
     else if (areaTypeSelected === PROTECTED_AREAS_TYPE) {
-    // --------------- PROTECTED AREA SPECIAL CASE --------------
-     const areaValue = {
-       DESIG: contextualData.DESIG_E,
-       DESIG_T: contextualData.DESIG_T,
-       AREA_KM: contextualData.AREA_KM,
-       IUCN_CA: contextualData.IUCN_CA,
-       NAME: contextualData.NAME,
-       NAME_0: contextualData.ISO3,
+      // --------------- PROTECTED AREA SPECIAL CASE --------------
+      const areaValue = {
+        DESIG: contextualData.DESIG_E,
+        DESIG_T: contextualData.DESIG_T,
+        AREA_KM: contextualData.AREA_KM,
+        IUCN_CA: contextualData.IUCN_CA,
+        NAME: contextualData.NAME,
+        NAME_0: contextualData.ISO3,
        GOV_TYP: contextualData.GOV_TYP,
      }
      setData([areaValue]);

--- a/src/utils/geo-processing-services.js
+++ b/src/utils/geo-processing-services.js
@@ -71,7 +71,7 @@ const getAreaPopulation = (data) => data[CONTEXTUAL_DATA_TABLES[POPULATION]].val
 const getProtectedAreasList = (data) => (
   data[CONTEXTUAL_DATA_TABLES[WDPA_LIST]].value.features.map(f => ({
     NAME: f.attributes.ORIG_NA,
-    NAME_0: f.attributes.ISO3,
+    NAME_0: f.attributes.NAME_0,
     AREA_KM: f.attributes.AREA_KM,
     GOV_TYP: f.attributes.GOV_TYP,
     DESIG: f.attributes.DESIG_E,


### PR DESCRIPTION
## Fix Custom AOIs protected table country name
### Description
On custom AOIs the protected table was showing ISO instead of name
### Testing instructions
Create a new custom AOI (I don't think will work on the saved ones) And go to the protected areas table:
![image](https://user-images.githubusercontent.com/9701591/151780950-a59554c2-368e-4a7d-a563-39705df8b023.png)
On the country name field of the table you should see the country name instead of ISO code
![image](https://user-images.githubusercontent.com/9701591/151781037-44a3ad69-cc4c-4b06-a8d9-414054bbca2e.png)

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-266?atlOrigin=eyJpIjoiZjk2YmFlYmIyYTI4NDZhMThhZTA2YTgxNDhkMTAxZGQiLCJwIjoiaiJ9