### PR TITLE
updated service urls and attribute for range

### DIFF
--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -61,7 +61,7 @@ export const SIDEBAR_CARDS_CONFIG = {
   },
   [PROTECTION_SLUG]: {
     title: 'What is already protected in this area?',
-    description: ({ protectionPercentage, percentage }) => `Of the current area, __${(protectionPercentage || percentage) ? roundUpPercentage(percentageFormat(capPercentage(protectionPercentage || (percentage && percentage * 100)))) : '0'}% of land is under formal protection__.`,
+    description: ({ protectionPercentage, percentage }) => `Of the current area, __${(protectionPercentage || percentage) ? roundUpPercentage(percentageFormat(capPercentage(protectionPercentage || percentage))) : '0'}% of land is under formal protection__.`,
     warning: null
   },
   [LAND_HUMAN_PRESSURES_SLUG]: {

--- a/src/constants/geo-processing-services.js
+++ b/src/constants/geo-processing-services.js
@@ -100,5 +100,5 @@ export const GEOPROCESSING_SERVICES_URLS = {
   [REPTILES]: 'https://heportal.esri.com/server/rest/services/SampleReptProd20220131/GPServer/SampleReptProdRange',
   [MAMMALS]: 'https://heportal.esri.com/server/rest/services/SampleMamProd20220131/GPServer/SampleMamProdRange',
   [AMPHIBIANS]: 'https://heportal.esri.com/server/rest/services/SampleAmphProd20220131/GPServer/SampleAmphProdRange',
-  [CONTEXTUAL_DATA]: 'https://heportal.esri.com/server/rest/services/ContextualLayers20220131Prod/GPServer/ContextualLayersProd',
+  [CONTEXTUAL_DATA]: 'https://heportal.esri.com/server/rest/services/ContextualLayersProd20220131/GPServer/ContextualLayersProd',
 }

--- a/src/constants/geo-processing-services.js
+++ b/src/constants/geo-processing-services.js
@@ -96,9 +96,9 @@ export const BIODIVERSITY_CRFS_CONFIG = {
 }
 
 export const GEOPROCESSING_SERVICES_URLS = {
-  [BIRDS]: 'https://heportal.esri.com/server/rest/services/SampleBirdsProd/GPServer/SampleBirds',
-  [REPTILES]: 'https://heportal.esri.com/server/rest/services/SampleReptProd/GPServer/SampleRept',
-  [MAMMALS]: 'https://heportal.esri.com/server/rest/services/SampleMamProd/GPServer/SampleMam',
-  [AMPHIBIANS]: 'https://heportal.esri.com/server/rest/services/SampleAmphProd/GPServer/SampleAmphProd',
-  [CONTEXTUAL_DATA]: 'https://heportal.esri.com/server/rest/services/ContextualLayersProd/GPServer/ContextualLayersProd',
+  [BIRDS]: 'https://heportal.esri.com/server/rest/services/SampleBirdsProd20220131/GPServer/SampleBirdsProdRange',
+  [REPTILES]: 'https://heportal.esri.com/server/rest/services/SampleReptProd20220131/GPServer/SampleReptProdRange',
+  [MAMMALS]: 'https://heportal.esri.com/server/rest/services/SampleMamProd20220131/GPServer/SampleMamProdRange',
+  [AMPHIBIANS]: 'https://heportal.esri.com/server/rest/services/SampleAmphProd20220131/GPServer/SampleAmphProdRange',
+  [CONTEXTUAL_DATA]: 'https://heportal.esri.com/server/rest/services/ContextualLayers20220131Prod/GPServer/ContextualLayersProd',
 }

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -221,10 +221,10 @@ export const LAYERS_URLS = {
   [MAMMALS_LOOKUP]:'https://utility.arcgis.com/usrsvcs/servers/bc206ff519234e4ab1e9dab1c8c1f601/rest/services/Mammal_CRF_species_table_service/FeatureServer/0',
   [REPTILES_LOOKUP]:'https://utility.arcgis.com/usrsvcs/servers/e2587fabd9a74981bd8e0d8cd24ca37a/rest/services/Reptile_CRF_species_table_service/FeatureServer/0',
    // AOIs precalculated layers
-   [GADM_0_ADMIN_AREAS_FEATURE_LAYER]: 'https://utility.arcgis.com/usrsvcs/servers/348e04300dcb4339a25c44b0e54561b1/rest/services/gadm0_precalculated_range/FeatureServer/0',
+   [GADM_0_ADMIN_AREAS_FEATURE_LAYER]: 'https://utility.arcgis.com/usrsvcs/servers/8629db3301254c7ca6d94e91be44acb4/rest/services/gadm0_precalculated_range_area/FeatureServer/0',
    [GADM_0_ADMIN_AREAS_WITH_WDPAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/wdpa_with_gadm0/FeatureServer/0',
    [GADM_1_ADMIN_AREAS_WITH_WDPAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/wdpa_with_gadm1/FeatureServer/0',
-   [GADM_1_ADMIN_AREAS_FEATURE_LAYER]: 'https://utility.arcgis.com/usrsvcs/servers/56f6738878394ccf9ec258af1275bdaa/rest/services/gadm1_precalculated_range/FeatureServer/0',
+   [GADM_1_ADMIN_AREAS_FEATURE_LAYER]: 'https://utility.arcgis.com/usrsvcs/servers/329a41aec90249c2ba5d6330f43f9390/rest/services/gadm1_precalculated_range_area/FeatureServer/0',
   //  [GADM_1_ADMIN_AREAS_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm36_level1_Simplify_precalculated_crfs/FeatureServer/0',
   //  [WDPA_OECM_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/WDPA%20with%20OECMs%20June%202021/FeatureServer',
     [WDPA_OECM_FEATURE_LAYER]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/WDPA_terrestrialmarine2021_simplified_v2/FeatureServer/0',

--- a/src/containers/sidebars/aoi-sidebar/index.js
+++ b/src/containers/sidebars/aoi-sidebar/index.js
@@ -15,7 +15,7 @@ const AoiSidebarContainer = (props) => {
   useEffect(() => {
     if (Object.keys(contextualData).length > 0) {
       // Custom AOIs rely on percentage instead of protectionPercentage
-      const percentage = contextualData.protectionPercentage || (contextualData.percentage * 100);
+      const percentage = contextualData.protectionPercentage || contextualData.percentage;
       setFormattedValues({
         landCover: contextualData.elu && contextualData.elu.landCover,
         area: localeFormatting(contextualData.area),
@@ -23,7 +23,7 @@ const AoiSidebarContainer = (props) => {
         population: contextualData.population && localeFormatting(contextualData.population),
         mainPressure: contextualData.pressures && getMainPressure(contextualData.pressures),
         totalPressures: contextualData.pressures && getTotalPressures(contextualData.pressures),
-        protectionPercentage: (contextualData.protectionPercentage || contextualData.percentage) && percentageFormat(percentage),
+        protectionPercentage: percentage && percentageFormat(percentage),
       })
     }
   }, [contextualData]);

--- a/src/utils/geo-processing-services.js
+++ b/src/utils/geo-processing-services.js
@@ -116,7 +116,7 @@ export function getSpeciesData(crfName, geometry) {
         ...acc,
         [f.attributes.SliceNumber]: {
           sliceNumber: f.attributes.SliceNumber,
-          presencePercentage: f.attributes.percentage_presence
+          presencePercentage: f.attributes.per_global
         }
       }), {});
       const ids = data.value.features.map(f => f.attributes.SliceNumber);
@@ -153,7 +153,7 @@ export const getPrecalculatedSpeciesData = (crfName, jsonSlices) => {
       ...acc,
       [f.SliceNumber]: {
         sliceNumber: f.SliceNumber,
-        presencePercentage: f.percentage_presence
+        presencePercentage: f.per_global
       }
     }), {});
     const ids = data.map(f => f.SliceNumber);


### PR DESCRIPTION
In this PR I updated the geoprocessing services for the AOIs. There is a modification in the field names because we are going to calculate both the percentage of a species relative to it global species range (per_global) and relative to its presence inside the aoi (per_aoi). We have also updated the attribute in the `src/utils/geo-processing-services.js` but check in case there are more places where we need to update this.