### PR TITLE
Remove tilt

### DIFF
--- a/src/containers/managers/local-scene-view-manager/local-scene-view-manager.js
+++ b/src/containers/managers/local-scene-view-manager/local-scene-view-manager.js
@@ -1,21 +1,32 @@
 import { useEffect } from 'react';
+import PropTypes from 'prop-types';
 
 const LocalSceneViewManager = ({
   view,
-  localGeometry
+  localGeometry,
 }) => {
   useEffect(() => {
     if (view && localGeometry) {
       const { extent } = localGeometry;
       view.extent = extent;
-      view.goTo({ target: extent, tilt: 30 })
+      view.goTo(
+        { target: extent }
+      )
       .catch(error => {
-        view.goTo({ target: extent, tilt: 30 })
+        console.error('error', error);
+        view.goTo(
+          { target: extent }
+        )
       })
     }
   }, [localGeometry]);
 
   return null;
 }
+
+LocalSceneViewManager.propTypes = {
+  view: PropTypes.object,
+  localGeometry: PropTypes.object,
+};
 
 export default LocalSceneViewManager;


### PR DESCRIPTION
## Countries on the AOI selection had a weird tilt
### Description
AOI scene view and NRC countries view were starting with a strange tilt that made it difficult to see the whole country sometimes. Now it is removed
### Testing instructions
- Select a precalculated country AOI or go to the NRC view and select a country (Brazil was the example)
- The map should not tilt anymore
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-263?atlOrigin=eyJpIjoiNGY1OTI2MTAxOTYzNDllY2JjMjc1ZjA2M2RmMDdkNDMiLCJwIjoiaiJ9