### PR TITLE
changes in layerslug for marine data

### DIFF
--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -79,9 +79,9 @@ export const ALL_TAXA_PRIORITY = 'all-taxa-priority';
 export const ALL_TAXA_RARITY = 'all-taxa-rarity';
 export const ALL_TAXA_RICHNESS = 'all-taxa-richness';
 
-export const ALL_MARINE_VERTEBRATES_PRIORITY = 'all-marine-priority';
-export const ALL_MARINE_VERTEBRATES_RICHNESS = 'all-marine-richness';
-export const ALL_MARINE_VERTEBRATES_RARITY = 'all-marine-rarity';
+export const ALL_MARINE_VERTEBRATES_PRIORITY = 'all-marine-vertebrates-priority';
+export const ALL_MARINE_VERTEBRATES_RICHNESS = 'all-marine-vertebrates-richness';
+export const ALL_MARINE_VERTEBRATES_RARITY = 'all-marine-vertebrates-rarity';
 
 export const FISHES_PRIORITY = 'fishes-priority';
 export const FISHES_RARITY = 'fishes-rarity';


### PR DESCRIPTION
## Changes in layerslug for all marine data
### For all marine vertebrates, the layerslug was wrong (ex. ALL_MARINE_VERTEBRATES_PRIORITY was 'all-marine-priority' and now has been changed to 'all-marine-vertebrates-priority'). Now information on biodiversity tabs for marine vertebrates is showing up