### PR TITLE
Use centroid for flying after search

### DIFF
--- a/src/components/mobile-only/menu-footer/menu-footer.js
+++ b/src/components/mobile-only/menu-footer/menu-footer.js
@@ -18,7 +18,8 @@ const MenuFooterContainer = props => {
   const { view, isSidebarOpen, isLandscapeMode, activeOption, selectedSidebar, selectedFeaturedMap, featured = false } = props;
   const { handleOpenSearch, handleCloseSearch, searchWidget } = useSearchWidgetLogic(
     view,
-    searchTermsAnalyticsEvent
+    searchTermsAnalyticsEvent,
+    // TODO : Add config to search widget to make i work
   );
 
   const FEATURED_MAPS_LIST_SIDEBAR = 'featuredMapsList';
@@ -27,7 +28,7 @@ const MenuFooterContainer = props => {
   const resetActiveOption = () => props.changeUI({ activeOption: '' });
   const resetFeaturedMap = () => { if (selectedFeaturedMap) props.changeUI({ selectedFeaturedMap: '' }); }
   const setActiveOption = (option) => props.changeUI({ activeOption: option })
-  
+
   const toggleFeaturedMapsList = () => {
     const activeSidebar =  selectedSidebar && activeOption === FOOTER_OPTIONS.ADD_LAYER;
     props.changeUI({ selectedSidebar: activeSidebar ? '' : FEATURED_MAPS_LIST_SIDEBAR});
@@ -44,7 +45,7 @@ const MenuFooterContainer = props => {
   }
 
   useEffect(() => {
-    if (isLandscapeMode) { 
+    if (isLandscapeMode) {
       resetActiveOption();
       handleSidebarClose();
       handleCloseSearch();
@@ -86,7 +87,7 @@ const MenuFooterContainer = props => {
     }
   ]
 
-  return <Component options={options} {...props} />; 
+  return <Component options={options} {...props} />;
 }
 
 export default connect(null, actions)(MenuFooterContainer);

--- a/src/components/search-location/index.js
+++ b/src/components/search-location/index.js
@@ -5,7 +5,7 @@ import MAP_TOOLTIP_CONFIG from 'constants/map-tooltip-constants';
 import { SEARCH_SOURCES_CONFIG } from 'constants/search-location-constants';
 import urlActions from 'actions/url-actions';
 import mapTooltipActions from 'redux_modules/map-tooltip';
-import { setCountryTooltip } from 'utils/globe-events-utils';
+import { setCountryTooltip, flyToCentroid } from 'utils/globe-events-utils';
 
 import { useSearchWidgetLogic } from 'hooks/esri';
 const actions = { ...mapTooltipActions, ...urlActions };
@@ -41,6 +41,8 @@ const SearchLocationContainer = (props) => {
         subtitle: attributes[subtitle] || attributes['NAME_1'],
       }
     });
+
+    flyToCentroid(view, geometry)
 
     // National Report Card search
     if (iso) {

--- a/src/containers/managers/local-scene-view-manager/local-scene-view-manager.js
+++ b/src/containers/managers/local-scene-view-manager/local-scene-view-manager.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { flyToCentroid } from 'utils/globe-events-utils';
 
 const LocalSceneViewManager = ({
   view,
@@ -9,15 +10,7 @@ const LocalSceneViewManager = ({
     if (view && localGeometry) {
       const { extent } = localGeometry;
       view.extent = extent;
-      view.goTo(
-        { target: extent }
-      )
-      .catch(error => {
-        console.error('error', error);
-        view.goTo(
-          { target: extent }
-        )
-      })
+      flyToCentroid(view, localGeometry)
     }
   }, [localGeometry]);
 

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -125,6 +125,7 @@ const AnalyzeAreasContainer = (props) => {
   }
 
   const handleOptionSelection = (option) => {
+    // eslint-disable-next-line default-case
     switch (option.slug) {
       case GADM_1_ADMIN_AREAS_FEATURE_LAYER:
         setAreaTypeSelected(SUBNATIONAL_BOUNDARIES_TYPE);

--- a/src/hooks/esri.js
+++ b/src/hooks/esri.js
@@ -2,6 +2,7 @@ import { loadModules } from 'esri-loader';
 import { useState, useEffect } from 'react';
 import { LAYERS_URLS } from 'constants/layers-urls';
 import { calculateGeometryArea } from 'utils/analyze-areas-utils';
+import { flyToCentroid } from 'utils/globe-events-utils';
 
 // Load watchUtils module to follow esri map changes
 export const useWatchUtils = () => {
@@ -50,7 +51,8 @@ export const useSearchWidgetLogic = (view, searchTermsAnalyticsEvent, searchWidg
         popupEnabled: false, // hide location popup
         resultGraphicEnabled: false, // hide location pin
         sources: searchSources(FeatureLayer, Locator),
-        includeDefaultSources: false
+        includeDefaultSources: false,
+        goToOverride: () => {} // Go to will be done on the callback
       });
       setSearchWidget(sWidget);
     }

--- a/src/utils/globe-events-utils.js
+++ b/src/utils/globe-events-utils.js
@@ -76,6 +76,15 @@ export const flyToGeometry = (view, layerFeatures) => {
   }
 }
 
+export const flyToCentroid = (view, geometry, zoom) => {
+  if (geometry && geometry.centroid) {
+    view.goTo({
+      target: geometry.centroid,
+      zoom
+    })
+  }
+}
+
 export const setCountryTooltip = ({ countryIso, countryName, changeGlobe }) => {
   changeGlobe({countryTooltipDisplayFor: countryIso, countryName });
 };


### PR DESCRIPTION
## Fix US and Russia not centering properly after search
### Description
The countries that cross the antimeridian have the wrong extent center but correct centroids so we had to rearrange the after search behavior to fly to the centroid instead.

- Zoom could be improved as its going only to the centroid
- Mobile search is not working (it wasn't)

### Testing instructions
On the AOI search, look for US or Russia. You should get the map centered. Also inside the AOI country view

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-285