### PR TITLE
Fix/no common name

### DIFF
--- a/src/containers/sidebars/aoi-sidebar/species-card/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/species-card/component.jsx
@@ -142,7 +142,8 @@ const Component = ({
                     className={styles.commonName}
                     href={individualSpeciesData.molLink}
                   >
-                    {individualSpeciesData.commonname}
+                    {individualSpeciesData.commonname ||
+                      individualSpeciesData.name}
                   </a>
                   <span className={styles.scientificName}>
                     {individualSpeciesData.name}{' '}

--- a/src/containers/sidebars/aoi-sidebar/species-card/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/species-card/styles.module.scss
@@ -163,18 +163,23 @@
     align-items: center;
     justify-content: start;
     width: 70%;
+
     .commonName {
       @extend %title;
       color: $dark-text;
+      text-align: center;
+
       &:hover {
         color: $dark-text-hover;
       }
     }
+
     .scientificName {
       @extend %annotation;
       font-style: italic;
     }
   }
+
   .arrow_icon_container {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Fix missing common name and text align
### Description
 - Repeat the scientific name in case the common name is missing
 - Always center the common name
### Testing instructions
- Go to Guinea AOI. If you click the previous image button at some point you should find the [PHRYNOBATRACHUS PINTOI](https://mol.org/species/Phrynobatrachus%20pintoi). This one had a missing common name
- If you press the next button a couple times too, you should find the [WESTERN GOLDEN-BACKED WEAVER](https://mol.org/species/Ploceus%20preussi)
 
![image](https://user-images.githubusercontent.com/9701591/153028947-b9d258a0-2348-4bfe-978d-b15cdc884ac5.png)

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/HE-282?atlOrigin=eyJpIjoiZDM2NzY5NTMxZThjNGFlNGFiODE0MTBlMWYzNDI5NGEiLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/HE-278?atlOrigin=eyJpIjoiMDdhM2EyZTgxZTRjNDI5ZWJiY2Y5YzY2MzVkZDYxZmEiLCJwIjoiaiJ9