### PR TITLE
Feature/mobile search

### DIFF
--- a/src/components/map-tooltip/component.jsx
+++ b/src/components/map-tooltip/component.jsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { loadModules } from 'esri-loader';
 import { ReactComponent as CloseIcon } from 'icons/close.svg';
 import styles from './styles.module.scss';
+import { useMobile } from 'constants/responsive';
 
 const MapTooltipComponent = ({
   img,
@@ -46,7 +47,10 @@ const MapTooltipComponent = ({
   return (
     <div
       ref={tooltipref}
-      className={cx(styles.tooltipContainer, { [styles.isVisible]: isVisible })}
+      className={cx(styles.tooltipContainer, {
+        [styles.isVisible]: isVisible,
+        [styles.isMobile]: useMobile(),
+      })}
     >
       {content && (
         <>

--- a/src/components/map-tooltip/styles.module.scss
+++ b/src/components/map-tooltip/styles.module.scss
@@ -3,12 +3,17 @@
 
 .tooltipContainer {
   display: none;
+
   &.isVisible {
     display: flex;
     align-items: center;
     flex-direction: column;
     margin: 0;
     transition: all .3s linear;
+  }
+
+  &.isMobile {
+    margin-bottom: 30px;
   }
 }
 
@@ -32,7 +37,7 @@
     @extend %title;
     color: $white;
   }
-  
+
   .subtitle {
     @extend %annotation;
     color: $white;

--- a/src/components/mobile-only/menu-footer/menu-footer-component.jsx
+++ b/src/components/mobile-only/menu-footer/menu-footer-component.jsx
@@ -1,20 +1,47 @@
 import React from 'react';
 import cx from 'classnames';
 import styles from './menu-footer-styles.module';
+import { FOOTER_OPTIONS } from 'constants/mobile-only';
+import MobileSearchInput from './mobile-search-input';
 
-const MenuFooter = ({ options, activeOption }) => {
-  const isActive = (o) => activeOption && o.key === activeOption; 
+const MenuFooter = ({
+  options,
+  activeOption,
+  handleSearchInputChange,
+  isSearchResultVisible,
+  searchResults,
+  onOptionSelection,
+}) => {
+  const isActive = (o) => activeOption && o.key === activeOption;
 
   return (
     <div className={styles.menuContainer}>
-      {options.length && options.map(option => (
-        <div onClick={option.onClickHandler} className={cx(styles.option, { [styles.activeOptionContainer]: isActive(option) })}>
-          <option.icon className={styles.icon}/>
-          <span className={styles.title}>{option.name}</span>
-        </div>
-      ))}
+      {options.length &&
+        options.map((option) =>
+          option.key === FOOTER_OPTIONS.SEARCH &&
+          activeOption === FOOTER_OPTIONS.SEARCH ? (
+            <MobileSearchInput
+              option={option}
+              handleSearchInputChange={handleSearchInputChange}
+              isSearchResultVisible={isSearchResultVisible}
+              searchResults={searchResults}
+              onOptionSelection={onOptionSelection}
+            />
+          ) : (
+            <div
+              key={option.key}
+              onClick={option.onClickHandler}
+              className={cx(styles.option, {
+                [styles.activeOptionContainer]: isActive(option),
+              })}
+            >
+              <option.icon className={styles.icon} />
+              <span className={styles.title}>{option.name}</span>
+            </div>
+          )
+        )}
     </div>
   );
-}
+};
 
 export default MenuFooter;

--- a/src/components/mobile-only/menu-footer/menu-footer-styles.module.scss
+++ b/src/components/mobile-only/menu-footer/menu-footer-styles.module.scss
@@ -48,3 +48,30 @@
     display: block;
   }
 }
+
+.input {
+  @extend %subtitle;
+}
+
+.optionsList {
+  @extend %bodyText;
+  color: $dark-text;
+  cursor: pointer;
+  background-color: $white;
+  list-style: none;
+  margin: 0 0 20px 0;
+  padding: $sidebar-paddings 0;
+  border-radius: 6px;
+
+  &.fullWidth {
+    width: 100%;
+  }
+
+  .option {
+    padding: 5px $sidebar-paddings;
+
+    &:hover {
+      background-color: $dark-opacity;
+    }
+  }
+}

--- a/src/components/mobile-only/menu-footer/mobile-search-input/mobile-search-input-component.jsx
+++ b/src/components/mobile-only/menu-footer/mobile-search-input/mobile-search-input-component.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import cx from 'classnames';
+import styles from '../menu-footer-styles.module';
+import { usePopper } from 'react-popper';
+import { createPortal } from 'react-dom';
+
+const MobileSearchInput = ({
+  option,
+  handleSearchInputChange,
+  isSearchResultVisible,
+  searchResults,
+  onOptionSelection,
+}) => {
+  const PARENT_WIDTH = '280px';
+
+  const [popperElement, setPopperElement] = useState(null);
+  const [referenceElement, setReferenceElement] = useState(null);
+  const { styles: popperStyles, attributes } = usePopper(
+    referenceElement,
+    popperElement
+  );
+
+  const renderSuggestionsPortal = ({
+    popperStyles,
+    attributes,
+    setPopperElement,
+  }) =>
+    createPortal(
+      <div
+        ref={setPopperElement}
+        style={{ ...popperStyles.popper, width: PARENT_WIDTH }}
+        {...attributes.popper}
+      >
+        <ul className={cx(styles.optionsList)}>
+          {searchResults.map((option) => (
+            <li
+              className={styles.option}
+              key={option.key}
+              onClick={() => {
+                onOptionSelection(option);
+              }}
+            >
+              {option.text}
+            </li>
+          ))}
+        </ul>
+      </div>,
+      document.getElementById('root')
+    );
+
+  return (
+    <div
+      key={option.key}
+      className={cx(styles.option, styles.activeOptionContainer)}
+    >
+      <option.icon className={styles.icon} />
+      <input
+        type="text"
+        placeholder={option.name}
+        className={styles.input}
+        ref={setReferenceElement}
+        onChange={handleSearchInputChange}
+      />
+      {isSearchResultVisible &&
+        renderSuggestionsPortal({
+          popperStyles,
+          attributes,
+          setPopperElement,
+        })}
+    </div>
+  );
+};
+
+export default MobileSearchInput;

--- a/src/components/mobile-only/menu-footer/mobile-search-input/mobile-search-input.js
+++ b/src/components/mobile-only/menu-footer/mobile-search-input/mobile-search-input.js
@@ -1,0 +1,1 @@
+export { default } from './mobile-search-input-component';

--- a/src/components/mobile-only/menu-settings/menu-settings-component.jsx
+++ b/src/components/mobile-only/menu-settings/menu-settings-component.jsx
@@ -5,12 +5,18 @@ import { FOOTER_OPTIONS, SETTINGS_OPTIONS } from 'constants/mobile-only';
 import ShareModal from 'components/share-modal';
 import ShareModalButton from 'components/share-button';
 
-
 import styles from './menu-settings-styles.module.scss';
 
-const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal }) => {
+const MenuSettings = ({
+  options,
+  activeOption,
+  textData,
+  activeModal,
+  closeModal,
+}) => {
   const isSettingsOpen = activeOption === FOOTER_OPTIONS.SETTINGS;
-  const isHalfEarthModal = activeModal && activeModal === SETTINGS_OPTIONS.HALF_EARTH_MODAL;
+  const isHalfEarthModal =
+    activeModal && activeModal === SETTINGS_OPTIONS.HALF_EARTH_MODAL;
   const Component = activeModal && options[activeModal].Component;
   const [isShareModalOpen, setShareModalOpen] = useState(false);
   return (
@@ -20,7 +26,11 @@ const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal
       >
         {options &&
           Object.values(options).map((option) => (
-            <div className={styles.box} onClick={option.onClickHandler}>
+            <div
+              key={option.name}
+              className={styles.box}
+              onClick={option.onClickHandler}
+            >
               <span className={styles.title}>{option.name}</span>
               <ArrowExpandIcon />
             </div>
@@ -52,6 +62,6 @@ const MenuSettings = ({ options, activeOption, textData, activeModal, closeModal
       )}
     </>
   );
-}
+};
 
 export default MenuSettings;

--- a/src/containers/scenes/data-scene/data-scene-component.jsx
+++ b/src/containers/scenes/data-scene/data-scene-component.jsx
@@ -1,26 +1,26 @@
 // Dependencies
-import React from "react";
-import cx from "classnames";
-import loadable from "@loadable/component";
+import React, { useMemo } from 'react';
+import cx from 'classnames';
+import loadable from '@loadable/component';
 // Components
-import Scene from "components/scene";
-import Widgets from "containers/widgets";
-import ArcgisLayerManager from "containers/managers/arcgis-layer-manager";
-import CountryLabelsLayer from "containers/layers/country-labels-layer";
-import FeatureHighlightLayer from "containers/layers/feature-highlight-layer";
-import MapTooltip from "components/map-tooltip";
-import MenuFooter from "components/mobile-only/menu-footer";
-import DataGlobalSidebar from "containers/sidebars/data-global-sidebar";
-import MenuSettings from "components/mobile-only/menu-settings";
+import Scene from 'components/scene';
+import Widgets from 'containers/widgets';
+import ArcgisLayerManager from 'containers/managers/arcgis-layer-manager';
+import CountryLabelsLayer from 'containers/layers/country-labels-layer';
+import FeatureHighlightLayer from 'containers/layers/feature-highlight-layer';
+import MapTooltip from 'components/map-tooltip';
+import MenuFooter from 'components/mobile-only/menu-footer';
+import DataGlobalSidebar from 'containers/sidebars/data-global-sidebar';
+import MenuSettings from 'components/mobile-only/menu-settings';
 // Constants
-import { MobileOnly, useMobile } from "constants/responsive";
+import { MobileOnly, useMobile } from 'constants/responsive';
 
-import styles from "./data-scene-styles.module.scss";
-import animationStyles from "styles/common-animations.module.scss";
+import styles from './data-scene-styles.module.scss';
+import animationStyles from 'styles/common-animations.module.scss';
 
 // Dynamic imports
-const Spinner = loadable(() => import("components/spinner"));
-const LabelsLayer = loadable(() => import("containers/layers/labels-layer"));
+const Spinner = loadable(() => import('components/spinner'));
+const LabelsLayer = loadable(() => import('containers/layers/labels-layer'));
 
 const { REACT_APP_ARGISJS_API_VERSION: API_VERSION } = process.env;
 
@@ -47,13 +47,18 @@ const CountrySceneComponent = ({
   handleTooltipActionButtonClick,
   handleHighlightLayerFeatureClick,
 }) => {
-  const sidebarHidden = isLandscapeMode || isFullscreenActive || useMobile();
+  const isMobile = useMobile();
+  const sidebarHidden = isLandscapeMode || isFullscreenActive || isMobile;
+  const updatedSceneSettings = useMemo(
+    () => ({ ...sceneSettings, padding: { left: 0 } }),
+    [isMobile]
+  );
   return (
     <>
       <Scene
         onMapLoad={onMapLoad}
-        sceneName={"data-scene"}
-        sceneSettings={sceneSettings}
+        sceneName={'data-scene'}
+        sceneSettings={updatedSceneSettings}
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
       >
         <ArcgisLayerManager


### PR DESCRIPTION
## Add mobile search functionality
### Description
- Remove add layers and legend icons (not implemented)
- Add search functionality. Only for countries
- Fix the padding and the tooltip position so we can access the country (The position of the tooltip is not exact with the country, maybe that is a different ticket)

<img width="320" alt="image" src="https://user-images.githubusercontent.com/9701591/153199331-d6aa05e1-4327-42a6-ae9e-15ab34326149.png">
<img width="322" alt="image" src="https://user-images.githubusercontent.com/9701591/153199332-adb1bcb0-1557-4281-a50a-79e121158943.png">

### Testing instructions
- Open the app on mobile or browser with mobile resolution
- Click on the search button
- Search for a country
- Click on the country on the suggestions
- The tooltip should appear and be clickable, the map should pan to the country


### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-286?atlOrigin=eyJpIjoiNWNjNGM5NDJhMWIyNDI1MTg4Nzc2ZTc4MTFkZDExOGYiLCJwIjoiaiJ9