### PR TITLE
Scene initial rotation

### DIFF
--- a/src/containers/scenes/data-scene/data-scene-component.jsx
+++ b/src/containers/scenes/data-scene/data-scene-component.jsx
@@ -60,6 +60,7 @@ const CountrySceneComponent = ({
         sceneName={'data-scene'}
         sceneSettings={updatedSceneSettings}
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
+        initialRotation
       >
         <ArcgisLayerManager
           userConfig={userConfig}

--- a/src/pages/featured-globe/featured-globe-component.jsx
+++ b/src/pages/featured-globe/featured-globe-component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import loadable from '@loadable/component'
+import loadable from '@loadable/component';
 import { ZOOM_LEVEL_TRIGGER } from 'constants/landscape-view-constants';
 
 import Scene from 'components/scene';
@@ -24,9 +24,11 @@ import MenuSettings from 'components/mobile-only/menu-settings';
 import uiStyles from 'styles/ui.module.scss';
 
 const InfoModal = loadable(() => import('components/modal-metadata'));
-const FeaturedPlaceCard = loadable(() => import('containers/sidebars/featured-place-card'));
+const FeaturedPlaceCard = loadable(() =>
+  import('containers/sidebars/featured-place-card')
+);
 
-const { REACT_APP_ARGISJS_API_VERSION:API_VERSION } = process.env
+const { REACT_APP_ARGISJS_API_VERSION: API_VERSION } = process.env;
 
 const DataGlobeComponent = ({
   sceneSettings,
@@ -49,7 +51,7 @@ const DataGlobeComponent = ({
   mouseMoveCallbacksArray,
   activeOption,
   openedModal,
-  userConfig
+  userConfig,
 }) => {
   const isFeaturedPlaceCard = selectedFeaturedPlace && !isLandscapeMode;
   const isOnMobile = useMobile();
@@ -57,9 +59,10 @@ const DataGlobeComponent = ({
 
   return (
     <>
-      <HalfEarthLogo className={uiStyles.halfEarthLogoTopLeft}/>
+      <HalfEarthLogo className={uiStyles.halfEarthLogoTopLeft} />
       <MainMenu />
       <Scene
+        sceneName="featured-scene"
         sceneSettings={sceneSettings}
         loaderOptions={{ url: `https://js.arcgis.com/${API_VERSION}` }}
         onMapLoad={onMapLoad}
@@ -67,6 +70,7 @@ const DataGlobeComponent = ({
           (isMapsList || isFeaturedPlaceCard) && !isOnMobile
         }
         urlParamsUpdateDisabled
+        initialRotation
       >
         {isGlobeUpdating && <Spinner floating />}
         <MobileOnly>
@@ -152,6 +156,6 @@ const DataGlobeComponent = ({
       {hasMetadata && <InfoModal />}
     </>
   );
-}
+};
 
 export default DataGlobeComponent;


### PR DESCRIPTION
## Make the globe rotate once initially on data and feature scenes
### Description
- The globe will rotate once until the user has any interaction
- It rotates only when all the layers are loaded!
- Once it has rotated in a scene it will never do it again on the same session

### Testing instructions
Open the data or feature scenes and wait for the layers to fully load

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-102?atlOrigin=eyJpIjoiMWJmNjg3NGI4ZDQzNDhhMDlmMTc1MzEzY2ZiODM0MjAiLCJwIjoiaiJ9