### PR TITLE
Persist filter on challenges chart

### DIFF
--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -9,9 +9,8 @@ import {
 } from 'constants/country-mode-constants';
 
 const selectCountriesData = ({ countryData }) => (countryData && countryData.data) || null;
-const selectCountryIso = ({location}) => location.payload.iso.toUpperCase();
+const selectCountryIso = ({ location }) => location.payload.iso.toUpperCase();
 const getCountryChallengesSelectedKey = (state, props) => props && props.countryChallengesSelectedKey;
-
 
 const getScatterplotRawData = createSelector(
   [selectCountriesData],

--- a/src/components/country-challenges-chart/country-challenges-chart.js
+++ b/src/components/country-challenges-chart/country-challenges-chart.js
@@ -12,7 +12,6 @@ import { LOCAL_SCENE_TABS_SLUGS } from 'constants/ui-params';
 
 const actions = {...metadataActions, ...urlActions };
 
-
 const CountryChallengesChartContainer = (props) => {
 
   const handleSelectNextIndicator = () => {
@@ -36,8 +35,8 @@ const CountryChallengesChartContainer = (props) => {
   }
 
   const handleBubbleClick = ({ countryISO }) => {
-    const { browsePage } = props;
-    browsePage({type: NATIONAL_REPORT_CARD, payload: { iso: countryISO, view:  LOCAL_SCENE_TABS_SLUGS.CHALLENGES }});
+    const { browsePage, selectedFilterOption } = props;
+    browsePage({type: NATIONAL_REPORT_CARD, payload: { iso: countryISO, view: LOCAL_SCENE_TABS_SLUGS.CHALLENGES }, query: { ui: { countryChallengesSelectedFilter: selectedFilterOption.slug }}});
   }
 
   const handleFilterSelection = (selectedFilter) => {


### PR DESCRIPTION
## Persist filter on challenges chart
### Description
On NRC challenges chart now when you change the filter and click one bubble, the filter persists with the country change
### Testing instructions
- Go to one country Challenge chart on NRC
- Change the 'Filter Countries' dropdown
- Click on one bubble to go to a different country
- The filter should persist

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-104?atlOrigin=eyJpIjoiZjBhZmQyNjBiMGI0NDk4MGE3MzllY2VjODZlYjI1ZWQiLCJwIjoiaiJ9