### PR TITLE
Fix/tooltip and places

### DIFF
--- a/src/components/aoi-entry-tooltip/aoi-entry-tooltip-component.jsx
+++ b/src/components/aoi-entry-tooltip/aoi-entry-tooltip-component.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { loadModules } from 'esri-loader';
+import { ReactComponent as CloseIcon } from 'icons/close.svg';
 import styles from './aoi-entry-tooltip-styles.module.scss';
 import { format } from 'd3-format';
 import cx from 'classnames';
@@ -70,6 +71,7 @@ const AOIEntryTooltipComponent = ({
         [styles.tooltipVisible]: tooltip && tooltipContent,
       })}
     >
+      <CloseIcon className={styles.tooltipClose} onClick={handleTooltipClose} />
       <section className={styles.tooltipSection}>
         <span className={styles.tooltipName}>Priority area {MOL_ID}</span>
       </section>

--- a/src/components/aoi-entry-tooltip/aoi-entry-tooltip-styles.module.scss
+++ b/src/components/aoi-entry-tooltip/aoi-entry-tooltip-styles.module.scss
@@ -51,6 +51,7 @@
   right: 10px;
   top: 10px;
   cursor: pointer;
+  fill: $white;
 }
 
 .areaSection {

--- a/src/constants/search-location-constants.js
+++ b/src/constants/search-location-constants.js
@@ -41,7 +41,7 @@ export const SEARCH_SOURCES_CONFIG = {
     url: LAYERS_URLS[HALF_EARTH_FUTURE_TILE_LAYER],
     title: HALF_EARTH_FUTURE_TILE_LAYER,
     outFields: ["*"],
-    searchFields: ["NAME_0"],
-    suggestionTemplate: '{NAME_0}'
+    searchFields: ["MOL_ID", "NAME_0"],
+    suggestionTemplate: 'Priority area {MOL_ID}, {NAME_0}'
   },
 }

--- a/src/containers/scenes/nrc-scene/nrc-scene-config.js
+++ b/src/containers/scenes/nrc-scene/nrc-scene-config.js
@@ -23,7 +23,6 @@ export default {
     { title: COUNTRIES_GENERALIZED_BORDERS_FEATURE_LAYER },
     { title: COUNTRY_PRIORITY_LAYER, opacity: DEFAULT_OPACITY },
     { title: PROTECTED_AREAS_VECTOR_TILE_LAYER, opacity: DEFAULT_OPACITY },
-    { title: HALF_EARTH_FUTURE_TILE_LAYER, opacity: DEFAULT_OPACITY },
     { title: MERGED_WDPA_VECTOR_TILE_LAYER, opacity: DEFAULT_OPACITY }
   ],
   zoom: 3.8,


### PR DESCRIPTION
## Fixes to Create tooltip to access the Places of HE future
### Description
- Add Close tooltip button
- Improve search for future places
- Don't show future places by default on NRC

### Testing instructions
- Check future places aoi entry tooltip
- Search for a number or country on the AOI search input
- Check NRC country page, it shouldn't show future places layer by default

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-297?atlOrigin=eyJpIjoiOWExOTYzMjg0OGUwNGRiNWEyMjA5OGFiYTBjMDBhZWMiLCJwIjoiaiJ9