### PR TITLE
Dont toggle future layer on analyze areas if it was selected

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -138,16 +138,26 @@ const AnalyzeAreasContainer = (props) => {
         setAreaTypeSelected(AREA_TYPES.futurePlaces);
         break;
     }
-    const layerIsAlreadyActive = activeLayers.some(l => l.title === option.slug);
-    if (!layerIsAlreadyActive) {
-      handleLayerToggle(option);
-    }
+
+    handleLayerToggle(option.slug);
     setSelectedOption(option);
     setTooltipIsVisible(false);
   }
 
-  const handleLayerToggle = (option) => {
-    batchToggleLayers([selectedOption.slug, option.slug], activeLayers, changeGlobe)
+  const handleLayerToggle = (currentSelectedOption) => {
+    // Future places layer will be activated if we select it at some point and never toggled unless we do it from the protection checkbox
+
+    const getLayersToToggle = () => {
+      const futureLayerIsActive = activeLayers.some(l => l.title === HALF_EARTH_FUTURE_TILE_LAYER);
+      // Don't remove future layer it if its active and we select it
+      if (currentSelectedOption === HALF_EARTH_FUTURE_TILE_LAYER && futureLayerIsActive) {
+        return [selectedOption.slug];
+      }
+      // Don't remove future layer it if its active and it was selected
+      return (selectedOption.slug === HALF_EARTH_FUTURE_TILE_LAYER) ? [currentSelectedOption] : [selectedOption.slug, currentSelectedOption] ;
+    };
+
+    batchToggleLayers(getLayersToToggle(), activeLayers, changeGlobe);
   }
 
 


### PR DESCRIPTION
## Fix conflict on selecting future layers on AOI analyze
### Description
There was a conflict between toggling the future layers on the protection section and selecting them on the AOI analyze section.

The solution is not perfect but once we select the future layer we will always keep it on until we deselect it from the protection section

### Testing instructions
Toggle the Future places layer from the protection section
Select any option from the AOI analyze section. The Future places layer should be always on and the selected option selectable.
If you deselect the layer from the protection section it should be deselected
If you select the future places AOI analyze option the future places layers should be activated

This solution is not perfect. We could handle the layers selection separately but we will have to think how we do it as the current page selection is only taking into account the activeLayers, we might have to separate this layer selection from where they were selected and it will be a bit cumbersome.

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-298?atlOrigin=eyJpIjoiNzAxODUwMmZhNzQ3NDAzNmFiY2UyM2RhYzAyOWM4ZDQiLCJwIjoiaiJ9