### PR TITLE
Fix pause and mute audio start position

### DIFF
--- a/src/containers/onboarding/sound-btn/audio-player/audio-player-component.jsx
+++ b/src/containers/onboarding/sound-btn/audio-player/audio-player-component.jsx
@@ -15,6 +15,7 @@ const AudioPlayer = ({
   script,
   textMark,
   setTextMark,
+  setPlayedSeconds,
 }) => (
   <ReactPlayer
     url={[`${file}#t=${startTime},${endTime}`]}
@@ -45,6 +46,8 @@ const AudioPlayer = ({
           setTextMark(textMark + 1);
         }
       }
+
+      setPlayedSeconds(playedSeconds);
     }}
     progressInterval={50}
     config={{

--- a/src/containers/onboarding/sound-btn/sound-btn-component.jsx
+++ b/src/containers/onboarding/sound-btn/sound-btn-component.jsx
@@ -36,6 +36,8 @@ const ButtonIcon = ({
   stepsNumber,
   onBoardingStep,
   pauseIcon,
+  setPausedTime,
+  playedSeconds,
 }) => {
   const renderAudioBars = () => (
     <div className={styles.audioBars} onMouseEnter={() => setPauseIcon(true)}>
@@ -87,6 +89,7 @@ const ButtonIcon = ({
               onMouseLeave={() => setPauseIcon(false)}
               onClick={() => {
                 setPlaying(false);
+                setPausedTime(playedSeconds);
               }}
             >
               <PauseIcon className={styles.pauseIcon} />
@@ -108,6 +111,8 @@ const SoundButtonComponent = ({
   waitingInteraction,
 }) => {
   const [playing, setPlaying] = useState(true);
+  const [playedSeconds, setPlayedSeconds] = useState(0);
+  const [pausedTime, setPausedTime] = useState(0);
   const [muted, setMuted] = useState(false);
 
   // There is no autoplay on chrome and firefos. We always need a previous user click on the page.
@@ -124,6 +129,7 @@ const SoundButtonComponent = ({
 
   const toggleMuted = () => {
     setMuted(!muted);
+    setPausedTime(playedSeconds);
   };
 
   const handlePlay = () => {
@@ -221,7 +227,6 @@ const SoundButtonComponent = ({
           <AudioPlayer
             {...{
               file,
-              startTime,
               endTime,
               muted,
               freeToPlay,
@@ -233,7 +238,11 @@ const SoundButtonComponent = ({
               script,
               textMark,
               setTextMark,
+              setPlayedSeconds,
+              setPausedTime,
+              pausedTime,
             }}
+            startTime={pausedTime || startTime}
           />
           <ButtonIcon
             {...{
@@ -246,6 +255,8 @@ const SoundButtonComponent = ({
               stepsNumber,
               onBoardingStep,
               pauseIcon,
+              setPausedTime,
+              playedSeconds,
             }}
           />
         </div>


### PR DESCRIPTION
## Fix pause and mute audio start position
### Description
The mute and pause actions on the onboarding were not resuming the audio in the right position
### Testing instructions
- Try the mute and pause buttons. They should resume the audio correctly
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-329?atlOrigin=eyJpIjoiNzMzYzRkNjk4M2EwNDA2M2EwMDBmMWFhNjQ5YTA5MjYiLCJwIjoiaiJ9