### PR TITLE
adds marine filter to species table

### DIFF
--- a/src/components/header-item/header-item.module.scss
+++ b/src/components/header-item/header-item.module.scss
@@ -1,22 +1,31 @@
 @import 'styles/settings';
 @import 'styles/mixins';
+@import 'styles/typography-extends';
 
 .headerItem {
+  @extend %subtitle;
   display: flex;
-  padding-right: 20px;
-  align-items: flex-end;
-  align-self: flex-end;
+  align-items: center;
+  flex: 1 1 0;
+  color: $white;
+  text-align: left;
+  font-weight: 500;
+  padding: 0 25px 0 10px;
+
+  &:first-child {
+    padding-left: 0;
+  }
 }
 
 .sortArrows {
   display: inline-block;
   position: relative;
-  margin-left: 5px;
+  transform: translate(5px, -2px);
 
   .arrowUp {
     @include caret($_temporary-light-text, 'up');
     position: absolute;
-    top: -1px;
+    top: 5px;
     &.highlightedSort::after {
       border-top-color: $white;
     }
@@ -25,31 +34,7 @@
   .arrowDown {
     @include caret($_temporary-light-text, 'down');
     position: absolute;
-    top: -26px;
-    &.highlightedSort::after {
-      border-bottom-color: $white;
-    }
-  }
-}
-
-
-.sortArrows {
-  display: inline-block;
-  position: relative;
-  margin-left: 5px;
-
-  .arrowUp {
-    @include caret($_temporary-light-text, 'up');
-    position: absolute;
-    &.highlightedSort::after {
-      border-top-color: $white;
-    }
-  }
-
-  .arrowDown {
-    @include caret($_temporary-light-text, 'down');
-    position: absolute;
-    top: -26px;
+    bottom: 0;
     &.highlightedSort::after {
       border-bottom-color: $white;
     }

--- a/src/components/species-modal/expanded-info/expanded-info-component.jsx
+++ b/src/components/species-modal/expanded-info/expanded-info-component.jsx
@@ -60,14 +60,11 @@ const ExpandedInfo = (props) => {
           href={`https://mol.org/species/${scientificname}`}
           title={`${speciesName} MoL link`}
           alt={`${speciesName} MoL link`}
-          rel="noopener"
-          // eslint-disable-next-line react/jsx-no-target-blank
           target="_blank"
+          rel="noopener noreferrer"
           className={styles.link}
         >
-          <Button theme={buttonTheme} className={styles.button}>
-            View more on Map of Life
-          </Button>
+          View more on Map of Life
         </a>
       </div>
     </div>

--- a/src/components/species-modal/expanded-info/expanded-info-styles.module.scss
+++ b/src/components/species-modal/expanded-info/expanded-info-styles.module.scss
@@ -40,6 +40,7 @@
   font-size: $font-size-sm;
   flex: 1;
   text-align: left;
+  color: $white;
 
   // To add ellipsis after 4 lines
   display: -webkit-box;
@@ -51,5 +52,8 @@
 }
 
 .link {
-  text-decoration: none;
+  font-family: $font-family-1;
+  color: $brand-color-main;
+  text-transform: uppercase;
+  text-underline-position: from-font;
 }

--- a/src/components/species-modal/species-modal-component.jsx
+++ b/src/components/species-modal/species-modal-component.jsx
@@ -127,12 +127,14 @@ const SpeciesModalComponent = ({
             />
           </div>
           <div className={styles.summary}>
-            <Tabs
-              tabs={VERTEBRATE_TABS}
-              onClick={handleVertebrateChange}
-              className={styles.speciesTab}
-              defaultTabSlug={vertebrateType}
-            />
+            {process.env.REACT_APP_FEATURE_MARINE === "true" && (
+              <Tabs
+                tabs={VERTEBRATE_TABS}
+                onClick={handleVertebrateChange}
+                className={styles.speciesTab}
+                defaultTabSlug={vertebrateType}
+              />
+            )}
             <span className={styles.speciesTabTitle}>{summaryText}</span>
           </div>
         </section>

--- a/src/components/species-modal/species-modal-constants.js
+++ b/src/components/species-modal/species-modal-constants.js
@@ -1,0 +1,12 @@
+export const VERTEBRATE_TABS = [
+  {slug: 'land', title: 'Land'},
+  {slug: 'marine', title: 'Marine'},
+];
+
+export const SPECIES_GROUP_STYLE_CLASS_DICTIONARY = {
+  'marine fishes': 'fishes',
+  'marine mammals': 'mar-mammals',
+};
+
+
+export default { VERTEBRATE_TABS, SPECIES_GROUP_STYLE_CLASS_DICTIONARY };

--- a/src/components/species-modal/species-modal-selectors.js
+++ b/src/components/species-modal/species-modal-selectors.js
@@ -19,10 +19,12 @@ export const getCountryData = createSelector(
   (countriesData, iso) => {
     if (!countriesData) return null;
     const countryData = countriesData[iso];
+
     return {
       iso: countryData.GID_0,
       name: countryData.NAME_0,
-      speciesNumber: countryData[COUNTRY_ATTRIBUTES.nspecies_richness_ter]
+      landSpeciesTotal: countryData[COUNTRY_ATTRIBUTES.nspecies_richness_ter],
+      marineSpeciesTotal: countryData['nspecies_mar'],
     };
   }
 );

--- a/src/components/species-modal/species-modal-styles.module.scss
+++ b/src/components/species-modal/species-modal-styles.module.scss
@@ -11,7 +11,7 @@
   z-index: 11;
 
   @media #{$tablet-portrait} {
-    background-color: $modal-light-background;
+    background-color: $elephant;
     height: 100vh;
     overflow-y: unset;
     position: absolute;
@@ -25,20 +25,17 @@
   }
 
   .title {
-    @extend %headline;
-  }
-
-  .summary,
-  .search {
-    font-family: $font-family-1;
-    font-size: $font-size-xs;
-    margin-bottom: 25px;
+    margin: 0;
+    font-family: $font-family-serif;
+    color: $white;
+    font-weight: 100;
   }
 
   .closeButton {
     position: absolute;
     top: $site-gutter;
     right: $site-gutter;
+    fill: $white;
     svg g {
       fill: $brand-color-secondary;
       stroke: $brand-color-secondary;
@@ -55,12 +52,33 @@
   .section {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 25px;
+  }
+
+  .summary {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end
+  }
+
+  .speciesTab {
+    width: 210px;
+  }
+
+  .speciesTabTitle {
+    display: inline-block;
+    margin-top: 15px;
+    font-family: $font-family-1;
+    font-size: $font-size-xxs;
+    font-weight: $font-weight-bold;
+    text-transform: uppercase;
+    color: $white;
   }
 
   .tableHeaderContainer {
     min-height: 60px;
     padding: 15px 74px 15px 40px;
-    background-color: $white;
+    background-color: $firefly;
     padding-top: 30px;
     border-radius: 5px 5px 0 0;
     margin-bottom: 2px;
@@ -70,38 +88,29 @@
     display: flex;
   }
 
-  .tableHeaderItem {
-    color: $_temporary-light-text;
-    @extend %subtitle;
-    text-align: left;
-    width: 20%;
-    padding-right: 60px;
-
-  }
-
-  .arrowUp {
-    top: -3px;
-  }
-
 
   .tableRowContainer {
     display: flex;
     position: relative;
     min-height: 50px;
     width: 100%;
-    background-color: $white;
-    border: solid $alto;
-    border-width: 2px 0;
+    // background-color: $white;
+    border: 1px solid $firefly;
   }
 
   .tableRow {
     display: flex;
     flex-direction: column;
     width: 100%;
+    background-color: $elephant;
+
+    > button {
+      padding: 0;
+    }
   }
 
   .arrowIcon {
-    fill: $_temporary-dark-text;
+    fill: $white;
     transform: rotate(90deg);
 
     &.isOpened {
@@ -109,6 +118,10 @@
     }
 
     transition: transform 0.2s ease;
+
+    > path {
+      fill: inherit;
+    }
   }
 
   .mainInfo {
@@ -121,7 +134,7 @@
     color: $_temporary-dark-text;
 
     &.isOpened, &:hover {
-      background-color: $athens-gray;
+      background-color: $firefly;
     }
   }
 
@@ -138,8 +151,10 @@
   }
 
   .tableItem {
-    width: 20%;
+    flex: 1 1 0;
     text-align: left;
+    color: $white;
+    padding: 0 25px 0 0;
 
     &.bold {
       font-family: $font-family-1;
@@ -156,17 +171,26 @@
     justify-content: center;
   }
 
+  .search {
+    display: flex;
+    align-items: center;
+  }
+
   .searchInput {
-    @extend %title;
-    background-color: $modal-light-background;
+    // @extend %title;
+    background-color: transparent;
     min-width: 300px;
     border: none;
     margin-left: 1em;
-    color: $_temporary-dark-text;
+    color: $white;
+    &::placeholder {
+      color: $accent-grey;
+      text-transform: uppercase;
+    }
   }
 
   .searchIcon {
-    transform: translate(0, 9px) scale(0.5);
+    fill: $accent-grey;
 
     g {
       stroke: $_temporary-dark-text;
@@ -175,14 +199,17 @@
 
   .groupColor {
     position: absolute;
-    width: 6px;
+    width: 3px;
     top: 0;
     left: 0;
     height: 100%;
-    border-left: 2px solid $alto;
 
     &.mammals {
       background-color: $mammals-color;
+    }
+
+    &.mar-mammals {
+      background-color: $mar-mammals-color;
     }
 
     &.amphibians {
@@ -195,6 +222,10 @@
 
     &.birds {
       background-color: $birds-color;
+    }
+
+    &.fishes {
+      background-color: $fishes-color;
     }
   }
 }

--- a/src/components/species-modal/species-modal-styles.module.scss
+++ b/src/components/species-modal/species-modal-styles.module.scss
@@ -94,7 +94,6 @@
     position: relative;
     min-height: 50px;
     width: 100%;
-    // background-color: $white;
     border: 1px solid $firefly;
   }
 
@@ -177,7 +176,6 @@
   }
 
   .searchInput {
-    // @extend %title;
     background-color: transparent;
     min-width: 300px;
     border: none;

--- a/src/components/species-modal/species-modal.js
+++ b/src/components/species-modal/species-modal.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useCallback } from 'react';
-// import usePrevious from 'hooks/use-previous';
 import { useFeatureLayer } from 'hooks/esri';
 import { SPECIES_LIST, MARINE_SPECIES_LIST } from 'constants/layers-slugs';
 import { SORT } from 'components/header-item';
@@ -33,16 +32,14 @@ const SpeciesModalContainer = (props) => {
   const landLayer = useFeatureLayer({ layerSlug:  SPECIES_LIST });
   const marineLayer = useFeatureLayer({ layerSlug:  MARINE_SPECIES_LIST });
 
-  // const previousCountryData = usePrevious(countryData);
   useEffect(() => {
     const layer = vertebrateType === 'land' ? landLayer : marineLayer;
     if (layer && countryData.iso
-      // && (countryData.iso !== previousCountryData.iso)
       ) {
       const getFeatures = async () => {
         const query = await layer.createQuery();
         query.where = `iso3 = '${countryData.iso}'`;
-        query.maxRecordCountFactor = '5000';
+        query.maxRecordCountFactor = '10000';
         const results = await layer.queryFeatures(query);
         const { features } = results;
         if (features) {

--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -131,7 +131,7 @@ export const HUMMINGBIRDS_RARITY = 'hummingbirds-rare';
 export const HUMMINGBIRDS_RICHNESS = 'hummingbirds-rich';
 // Species modal
 export const SPECIES_LIST = 'species-list';
-export const MARINE_SPECIES_LIST = 'species-list';
+export const MARINE_SPECIES_LIST = 'marine-species-list';
 // AOIs precalculated layers
 export const GADM_0_ADMIN_AREAS_FEATURE_LAYER = 'gadm-0-admin-areas-feature-layer';
 export const GADM_0_ADMIN_AREAS_WITH_WDPAS_FEATURE_LAYER = 'gadm-0-admin-areas-with-wdpas-feature-layer';

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -239,7 +239,7 @@ export const LAYERS_URLS = {
   // Vertebrate species modal
 
   [SPECIES_LIST]:
-    'https://utility.arcgis.com/usrsvcs/servers/04986e0b667c4ad29539683d6ba2314f/rest/services/NRC_species_data_20200817_formatted/FeatureServer',
+    'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/NRC_species_data_20200817_updated2/FeatureServer',
   [MARINE_SPECIES_LIST]:
     'https://utility.arcgis.com/usrsvcs/servers/5df959008b444568836d12a3ba215a90/rest/services/NRC_marine_species_data_20220323/FeatureServer',
 

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -239,7 +239,7 @@ export const LAYERS_URLS = {
   // Vertebrate species modal
 
   [SPECIES_LIST]:
-    'https://utility.arcgis.com/usrsvcs/servers/5df959008b444568836d12a3ba215a90/rest/services/NRC_marine_species_data_20220323/FeatureServer',
+    'https://utility.arcgis.com/usrsvcs/servers/04986e0b667c4ad29539683d6ba2314f/rest/services/NRC_species_data_20200817_formatted/FeatureServer',
   [MARINE_SPECIES_LIST]:
     'https://utility.arcgis.com/usrsvcs/servers/5df959008b444568836d12a3ba215a90/rest/services/NRC_marine_species_data_20220323/FeatureServer',
 

--- a/src/containers/sidebars/national-report-sidebar/national-report-sidebar.js
+++ b/src/containers/sidebars/national-report-sidebar/national-report-sidebar.js
@@ -16,8 +16,6 @@ const NationalReportSidebarContainer = (props) => {
     onboardingType,
   } = props;
 
-  console.log({ onboardingType });
-
   const handleClose = () => {
     const { changeUI } = props;
     browsePage({ type: NATIONAL_REPORT_CARD_LANDING });


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes
- Adds tabs to switch between land and marine vertebrates data.
- update styles according to design.
![image](https://user-images.githubusercontent.com/999124/165791205-9340a776-8a7d-4031-a4f7-bc34dd0a91c1.png)


### Description
_Describe what the code changes introduced by this PR do._
### Designs
https://www.figma.com/file/2YAp3AS5lYCj2IWEAN8AJw/HE---Map?node-id=4%3A15065
### Testing instructions
Open [this URL](http://localhost:3000/nrc/BRA?globe=%7B%22center%22%3A%5B-54.398754351074615%2C-15.121042836690911%5D%2C%22zoom%22%3A4.816064929542014%7D&ui=%7B%22openedModal%22%3A%22SPECIES%22%2C%22speciesModalSearch%22%3A%22%22%2C%22speciesModalSort%22%3A%22Species%20group-ASC%22%7D), the modal with the table should appear. There's a tab in the right side to filter and design of the table has been updated.
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-351