### PR TITLE
Add land marine dropdown and update text

### DIFF
--- a/src/components/country-challenges-chart/country-challenges-chart-component.jsx
+++ b/src/components/country-challenges-chart/country-challenges-chart-component.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import cx from 'classnames';
 
 import ScatterPlot from 'components/charts/scatter-plot';
 import Dropdown from 'components/dropdown';
@@ -6,6 +7,8 @@ import { ReactComponent as ArrowButton } from 'icons/arrow_right.svg';
 
 import { INDICATOR_LABELS } from 'constants/country-mode-constants';
 import styles from './country-challenges-chart-styles.module.scss';
+
+const { REACT_APP_FEATURE_MARINE } = process.env;
 
 const CountryChallengesChartComponent = ({
   data,
@@ -15,8 +18,11 @@ const CountryChallengesChartComponent = ({
   yAxisTicks,
   handleBubbleClick,
   selectedFilterOption,
+  selectedLandMarineOption,
+  handleLandMarineSelection,
   handleFilterSelection,
   challengesFilterOptions,
+  landMarineOptions,
   handleSelectNextIndicator,
   countryChallengesSelectedKey,
   handleSelectPreviousIndicator,
@@ -24,16 +30,44 @@ const CountryChallengesChartComponent = ({
   return (
     <div className={className}>
       <div className={styles.headerContainer}>
-        <span className={styles.chartTitle}>Filter countries</span>
-        <div className={styles.dropdownWrapper}>
-          <Dropdown
-            width="full"
-            parentWidth="530px"
-            options={challengesFilterOptions}
-            selectedOption={selectedFilterOption}
-            handleOptionSelection={handleFilterSelection}
-          />
-        </div>
+        {REACT_APP_FEATURE_MARINE ? (
+          <>
+            <span className={styles.chartTitle}>Show</span>
+            <div className={styles.landMarineDropdownWrapper}>
+              <Dropdown
+                parentWidth="130px"
+                options={landMarineOptions}
+                selectedOption={selectedLandMarineOption}
+                handleOptionSelection={handleLandMarineSelection}
+              />
+            </div>
+            <span className={cx(styles.chartTitle, styles.filterTitle)}>
+              filter countries
+            </span>
+            <div className={styles.dropdownWrapper}>
+              <Dropdown
+                width="full"
+                parentWidth="330px"
+                options={challengesFilterOptions}
+                selectedOption={selectedFilterOption}
+                handleOptionSelection={handleFilterSelection}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <span className={styles.chartTitle}>Filter countries</span>
+            <div className={styles.dropdownWrapper}>
+              <Dropdown
+                width="full"
+                parentWidth="530px"
+                options={challengesFilterOptions}
+                selectedOption={selectedFilterOption}
+                handleOptionSelection={handleFilterSelection}
+              />
+            </div>
+          </>
+        )}
       </div>
       <ScatterPlot
         data={data}

--- a/src/components/country-challenges-chart/country-challenges-chart-selectors.js
+++ b/src/components/country-challenges-chart/country-challenges-chart-selectors.js
@@ -1,11 +1,12 @@
 import { createSelector, createStructuredSelector } from 'reselect';
 import { CONTINENT_COLORS } from 'constants/country-mode-constants';
-import { getCountryChallengesSelectedFilter } from 'pages/nrc/nrc-selectors';
+import { getCountryChallengesSelectedFilter, getLandMarineSelected } from 'pages/nrc/nrc-selectors';
 import { countryChallengesChartFormats, countryChallengesSizes } from 'utils/data-formatting-utils';
 import * as d3 from 'd3';
 import {
   INDICATOR_LABELS,
   CHALLENGES_RELATED_FILTERS_OPTIONS,
+  LAND_MARINE_OPTIONS
 } from 'constants/country-mode-constants';
 import { COUNTRY_ATTRIBUTES } from 'constants/country-data-constants';
 
@@ -99,9 +100,16 @@ const getChallengesFilterOptions = createSelector(
   }
 );
 
+const getLandMarineOptions = () => LAND_MARINE_OPTIONS;
+
 const getSelectedFilterOption = createSelector(
   getCountryChallengesSelectedFilter,
   selectedFilter => CHALLENGES_RELATED_FILTERS_OPTIONS.find(option => option.slug === selectedFilter)
+);
+
+const getSelectedLandMarineOption = createSelector(
+  getLandMarineSelected,
+  landMarineSelection => LAND_MARINE_OPTIONS.find(option => option.slug === landMarineSelection) || LAND_MARINE_OPTIONS.find(option => option.slug === 'land')
 );
 
 
@@ -134,7 +142,9 @@ const mapStateToProps = createStructuredSelector({
   xAxisTicks: getXAxisTicks,
   yAxisTicks: getYAxisTicks,
   selectedFilterOption: getSelectedFilterOption,
-  challengesFilterOptions: getChallengesFilterOptions
+  selectedLandMarineOption: getSelectedLandMarineOption,
+  challengesFilterOptions: getChallengesFilterOptions,
+  landMarineOptions: getLandMarineOptions
 });
 
 export default mapStateToProps;

--- a/src/components/country-challenges-chart/country-challenges-chart-styles.module.scss
+++ b/src/components/country-challenges-chart/country-challenges-chart-styles.module.scss
@@ -7,16 +7,25 @@ $xAxisContainerWidth: 330px;
 .headerContainer {
   display: flex;
   margin-bottom: 70px;
+  align-items: center;
+}
+
+.landMarineDropdownWrapper {
+  width: 130px;
 }
 
 .dropdownWrapper {
-  width: 530px;
+  width: 330px;
 }
 
 .chartTitle {
   @extend %headline;
   color: $alto;
   margin-right: 1rem;
+
+  &.filterTitle {
+    margin-left: 1rem;
+  }
 }
 
 .filtersContainer {

--- a/src/components/country-challenges-chart/country-challenges-chart.js
+++ b/src/components/country-challenges-chart/country-challenges-chart.js
@@ -44,12 +44,18 @@ const CountryChallengesChartContainer = (props) => {
     changeUI({countryChallengesSelectedFilter: selectedFilter.slug});
   }
 
+  const handleLandMarineSelection = (selectedFilter) => {
+    const { changeUI } = props;
+    changeUI({landMarineSelection: selectedFilter.slug});
+  }
+
   return (
   <Component
     handleBubbleClick={handleBubbleClick}
     handleFilterSelection={handleFilterSelection}
     handleSelectNextIndicator={handleSelectNextIndicator}
     handleSelectPreviousIndicator={handleSelectPreviousIndicator}
+    handleLandMarineSelection={handleLandMarineSelection}
     {...props}
   />
   )

--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import { Tooltip } from 'react-tippy';
 import { ReactComponent as Arrow } from 'icons/arrow_right.svg';
 import SearchInput from 'components/search-input';
-import Dropdown from "components/dropdown";
+import Dropdown from 'components/dropdown';
 import styles from './ranking-chart-styles.module.scss';
 import {
   SORT_GROUPS,
@@ -12,7 +12,9 @@ import {
   RANKING_LEGEND,
   SORT_GROUPS_SLUGS,
   RANKING_HEADER_LABELS,
-} from "constants/country-mode-constants";
+} from 'constants/country-mode-constants';
+
+const { REACT_APP_FEATURE_MARINE } = process.env;
 
 const categories = Object.keys(SORT_GROUPS_SLUGS);
 const RankingChart = ({
@@ -25,6 +27,9 @@ const RankingChart = ({
   handleCountryClick,
   scrollIndex,
   searchTerm,
+  landMarineOptions,
+  selectedLandMarineOption,
+  handleLandMarineSelection,
 }) => {
   const [hasScrolled, changeHasScrolled] = useState(false);
 
@@ -89,17 +94,47 @@ const RankingChart = ({
   return (
     <div className={className}>
       <div className={styles.chartTitleContainer}>
-        <span className={styles.chartTitle}>Sort countries by</span>
-        <div className={styles.dropdownWrapper}>
-          <Dropdown
-            width="full"
-            parentWidth="410px"
-            options={SORT_OPTIONS}
-            groups={SORT_GROUPS}
-            selectedOption={selectedFilterOption}
-            handleOptionSelection={handleFilterSelection}
-          />
-        </div>
+        {REACT_APP_FEATURE_MARINE ? (
+          <>
+            <span className={styles.chartTitle}>Show</span>
+            <div className={styles.landMarineDropdownWrapper}>
+              <Dropdown
+                width="full"
+                parentWidth="130px"
+                options={landMarineOptions}
+                selectedOption={selectedLandMarineOption}
+                handleOptionSelection={handleLandMarineSelection}
+              />
+            </div>
+            <span className={cx(styles.chartTitle, styles.filterTitle)}>
+              sort countries
+            </span>
+            <div className={styles.dropdownWrapper}>
+              <Dropdown
+                width="full"
+                parentWidth="410px"
+                options={SORT_OPTIONS}
+                groups={SORT_GROUPS}
+                selectedOption={selectedFilterOption}
+                handleOptionSelection={handleFilterSelection}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <span className={styles.chartTitle}>Sort countries by</span>
+            <div className={styles.dropdownWrapper}>
+              <Dropdown
+                width="full"
+                parentWidth="410px"
+                options={SORT_OPTIONS}
+                groups={SORT_GROUPS}
+                selectedOption={selectedFilterOption}
+                handleOptionSelection={handleFilterSelection}
+              />
+            </div>
+          </>
+        )}
       </div>
       <div className={styles.header}>
         <SearchInput
@@ -113,11 +148,14 @@ const RankingChart = ({
           <div
             key={category}
             className={cx(styles.headerItem, {
-              [styles.spiHeader]: category === 'spi'
+              [styles.spiHeader]: category === 'spi',
             })}
           >
-            {RANKING_HEADER_LABELS[category].split(" ").map(word => (
-              <p key={word} className={styles.titleText}>{`${word.toUpperCase()}`}</p>
+            {RANKING_HEADER_LABELS[category].split(' ').map((word) => (
+              <p
+                key={word}
+                className={styles.titleText}
+              >{`${word.toUpperCase()}`}</p>
             ))}
           </div>
         ))}
@@ -132,10 +170,12 @@ const RankingChart = ({
         >
           <div className={styles.table}>
             {data.map((d, i) => (
-              <div className={cx(styles.row, {
-                [styles.selectedCountry]: countryISO === d.iso,
-              }
-              )} key={d.name}>
+              <div
+                className={cx(styles.row, {
+                  [styles.selectedCountry]: countryISO === d.iso,
+                })}
+                key={d.name}
+              >
                 <button
                   className={styles.spiCountryButton}
                   onClick={() => handleCountryClick(d.iso, d.name)}
@@ -157,7 +197,18 @@ const RankingChart = ({
                     {d.name}
                   </span>
                 </button>
-                {categories.map((category) => category === 'spi' ? <span key={category} className={cx(styles.titleText, styles.spiIndex)}>{d[category]}</span> : renderBar(category, d))}
+                {categories.map((category) =>
+                  category === 'spi' ? (
+                    <span
+                      key={category}
+                      className={cx(styles.titleText, styles.spiIndex)}
+                    >
+                      {d[category]}
+                    </span>
+                  ) : (
+                    renderBar(category, d)
+                  )
+                )}
               </div>
             ))}
           </div>

--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -3,6 +3,8 @@ import sortBy from 'lodash/sortBy';
 import get from 'lodash/get';
 import { SORT_OPTIONS, RANKING_INDICATORS, RANKING_GROUPS_SLUGS, RANKING_INDICATOR_GROUPS } from 'constants/country-mode-constants';
 import { COUNTRY_ATTRIBUTES } from 'constants/country-data-constants';
+import { LAND_MARINE_OPTIONS } from 'constants/country-mode-constants';
+import { getLandMarineSelected } from 'pages/nrc/nrc-selectors';
 
 const selectCountriesData = ({ countryData }) => (countryData && countryData.data) || null;
 const getSortRankingCategory = ({ location }) => (location && get(location, 'query.ui.sortRankingCategory')) || null;
@@ -53,9 +55,18 @@ const getSelectedFilterOption = createSelector([getSortRankingCategory], (sortRa
   return SORT_OPTIONS.find(o => o.slug === sortRankingCategory.slug) || SORT_OPTIONS[0];
 });
 
+const getLandMarineOptions = () => LAND_MARINE_OPTIONS;
+
+const getSelectedLandMarineOption = createSelector(
+  getLandMarineSelected,
+  landMarineSelection => LAND_MARINE_OPTIONS.find(option => option.slug === landMarineSelection) || LAND_MARINE_OPTIONS.find(option => option.slug === 'land')
+);
+
 const mapStateToProps = createStructuredSelector({
   data: getSortedData,
   selectedFilterOption: getSelectedFilterOption,
+  selectedLandMarineOption: getSelectedLandMarineOption,
+  landMarineOptions: getLandMarineOptions
 });
 
 export default mapStateToProps;

--- a/src/components/ranking-chart/ranking-chart-styles.module.scss
+++ b/src/components/ranking-chart/ranking-chart-styles.module.scss
@@ -6,11 +6,20 @@
   @extend %headline;
   color: $grey-text;
   margin-right: 1rem;
+
+  &.filterTitle {
+    margin-left: 1rem;
+  }
 }
 
 .chartTitleContainer {
   margin-bottom: 3rem;
   display: flex;
+  align-items: center;
+}
+
+.landMarineDropdownWrapper {
+  width: 130px;
 }
 
 .dropdownWrapper {
@@ -82,8 +91,6 @@ $scroll-bar-width: 7px;
 .spiCountry {
   width: 25%;
   cursor: pointer;
-
-  
 }
 
 .spiCountryButton {

--- a/src/components/ranking-chart/ranking-chart.js
+++ b/src/components/ranking-chart/ranking-chart.js
@@ -44,11 +44,18 @@ const RankingChartContainer = (props) => {
     const { value } = event.target;
     setSearchTerm(value);
   };
+
+  const handleLandMarineSelection = (selectedFilter) => {
+    const { changeUI } = props;
+    changeUI({ landMarineSelection: selectedFilter.slug });
+  }
+
   return (
     <Component
       handleCountryClick={handleCountryClick}
       handleSearchChange={handleSearchChange}
       handleFilterSelection={handleFilterSelection}
+      handleLandMarineSelection={handleLandMarineSelection}
       scrollIndex={scrollIndex}
       searchTerm={searchTerm}
       {...props}

--- a/src/constants/country-mode-constants.js
+++ b/src/constants/country-mode-constants.js
@@ -163,3 +163,14 @@ export const SORT_OPTIONS = [
     group: SORT_GROUPS_SLUGS.protection,
   },
 ];
+
+export const LAND_MARINE_OPTIONS = [
+  {
+    label: 'LAND SPI',
+    slug: 'land',
+  },
+  {
+    label: 'MARINE SPI',
+    slug: 'marine',
+  },
+];

--- a/src/pages/nrc/nrc-selectors.js
+++ b/src/pages/nrc/nrc-selectors.js
@@ -37,6 +37,7 @@ const getHalfEarthModalOpen = createSelector(getUiSettings, uiSettings => uiSett
 const getCountryChallengesSelectedKey = createSelector(getUiSettings, uiSettings => uiSettings.countryChallengesSelectedKey);
 export const getLocalSceneFilters = createSelector(getUiSettings, uiSettings => uiSettings.localSceneFilters);
 export const getCountryChallengesSelectedFilter = createSelector(getUiSettings, uiSettings => uiSettings.countryChallengesSelectedFilter);
+export const getLandMarineSelected = createSelector(getUiSettings, uiSettings => uiSettings.landMarineSelection);
 const getCountryName = createSelector(getGlobeSettings, globeSettings => globeSettings.countryName)
 export const getOnboardingType = createSelector(getUiSettings, uiSettings => uiSettings.onboardingType);
 export const getOnboardingStep = createSelector(getUiSettings, uiSettings => uiSettings.onboardingStep);


### PR DESCRIPTION
## Add land - marine data filter to challenges and ranking
### Description
[X] Add marine data filter
[ ] Filter data on the challenges chart
[ ] Filter data on the ranking chart

### Designs
https://www.figma.com/file/2YAp3AS5lYCj2IWEAN8AJw/HE---Map?node-id=4%3A14646
### Testing instructions
Go to a NRC of a country and to the challenges and ranking tabs. You should be able to see different data when switching the land-marine dropdown

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-337?atlOrigin=eyJpIjoiMTIwZTgyODI5NmFhNDY1NGJjOWQ5MzM5YTlkMDMyNDciLCJwIjoiaiJ9