### PR TITLE
Feature/onboarding updates

### DIFF
--- a/src/constants/onboarding-constants.js
+++ b/src/constants/onboarding-constants.js
@@ -3,6 +3,10 @@ export const NO_INTERACTION_STEPS = {
   'national-report-cards': []
 };
 
+export const ONBOARDING_TYPE_CENTER = {
+  'priority-places': [-51.9, -14.2]
+};
+
 export const SCRIPTS = {
   'priority-places': {
     intro: [

--- a/src/containers/landing/hero/hero-component.jsx
+++ b/src/containers/landing/hero/hero-component.jsx
@@ -49,7 +49,8 @@ const HeroComponent = ({ className, changeUI, browsePage }) => {
           delay: 1.5,
         }}
       >
-        {!isMobile && 'SELECT ONE OF THE AUDIO TOURS BELOW TO LEARN MORE ABOUT IT'}
+        {!isMobile &&
+          'SELECT ONE OF THE AUDIO TOURS BELOW TO LEARN MORE ABOUT IT'}
       </motion.p>
 
       {!isMobile && (
@@ -65,7 +66,7 @@ const HeroComponent = ({ className, changeUI, browsePage }) => {
           >
             <AudioCard
               number="01"
-              duration={'4-7'}
+              duration={'7-8'}
               gif={AUDIO_CARD_1_GIF}
               title="Priority places"
               description="Understand where the suggested priority places should happen for vertebrates."
@@ -89,7 +90,7 @@ const HeroComponent = ({ className, changeUI, browsePage }) => {
           >
             <AudioCard
               number="02"
-              duration={'4-7'}
+              duration={'10'}
               gif={AUDIO_CARD_2_GIF}
               title="National Report cards"
               description="Analyze national and other areas of interest. Download reports to share with others."

--- a/src/containers/onboarding/sound-btn/sound-btn-component.jsx
+++ b/src/containers/onboarding/sound-btn/sound-btn-component.jsx
@@ -62,6 +62,7 @@ const ButtonIcon = ({
   pauseIcon,
   setPausedTime,
   playedSeconds,
+  changeUI,
 }) => {
   const renderAudioBars = () => (
     <div className={styles.audioBars} onMouseEnter={() => setPauseIcon(true)}>
@@ -100,7 +101,16 @@ const ButtonIcon = ({
 
   return (
     <>
-      <StepsArcs numberOfArcs={stepsNumber} currentStep={onboardingStep} />
+      <StepsArcs
+        numberOfArcs={stepsNumber}
+        currentStep={onboardingStep}
+        handleClick={(e, i) => {
+          changeUI({
+            onboardingStep: i,
+            waitingInteraction: false,
+          });
+        }}
+      />
       {!waitingInteraction && (waitingStartAudioClick || !playing) ? (
         <button onClick={handlePlay} className={styles.playButton}>
           <PlayIcon className={styles.playIcon} />
@@ -201,11 +211,13 @@ const SoundButtonComponent = ({
     const dontWaitStep = NO_INTERACTION_STEPS[onboardingType].includes(
       Object.keys(SCRIPTS[onboardingType])[onboardingStep]
     );
+
     if (dontWaitStep) {
       return changeUI({
         onboardingStep: onboardingStep + 1,
       });
     }
+
     changeUI({ waitingInteraction: true });
   };
 
@@ -291,6 +303,7 @@ const SoundButtonComponent = ({
               pauseIcon,
               setPausedTime,
               playedSeconds,
+              changeUI,
             }}
           />
         </div>

--- a/src/containers/onboarding/sound-btn/sound-btn-selectors.js
+++ b/src/containers/onboarding/sound-btn/sound-btn-selectors.js
@@ -8,7 +8,7 @@ const getWaitingInteraction = createSelector(selectUiUrlState, uiSettings => uiS
 const mapStateToProps = createStructuredSelector({
   onboardingType: getOnboardingType,
   onboardingStep: getOnboardingStep,
-  waitingInteraction: getWaitingInteraction
+  waitingInteraction: getWaitingInteraction,
 });
 
 export default mapStateToProps;

--- a/src/containers/onboarding/step-arcs/step-arcs-component.jsx
+++ b/src/containers/onboarding/step-arcs/step-arcs-component.jsx
@@ -7,6 +7,7 @@ const StepsArcs = ({
   currentStep,
   radius = 33,
   strokeWidth = 3,
+  handleClick,
 }) => {
   const polarToCartesian = (centerX, centerY, radius, angleInDegrees) => {
     const angleInRadians = ((angleInDegrees - 90) * Math.PI) / 180.0;
@@ -53,6 +54,9 @@ const StepsArcs = ({
     <svg className={styles.stepsCircle}>
       {arcsArray.map((arcStartEnd, i) => (
         <path
+          role="button"
+          aria-pressed={currentStep === i}
+          onClick={(e) => handleClick(e, i)}
           key={`$arc-${i}`}
           className={cx(styles.stepsArc, {
             [styles.active]: currentStep >= i,

--- a/src/containers/onboarding/step-arcs/step-arcs-styles.module.scss
+++ b/src/containers/onboarding/step-arcs/step-arcs-styles.module.scss
@@ -9,7 +9,12 @@
   z-index: $default-z-index;
 
   .stepsArc {
+    cursor: pointer;
     stroke: $dark-text;
+
+    &:hover {
+      stroke-width: 6px;
+    }
 
     &.active {
       stroke: $brand-color-main;

--- a/src/containers/scenes/data-scene/data-scene-component.jsx
+++ b/src/containers/scenes/data-scene/data-scene-component.jsx
@@ -17,6 +17,7 @@ import OnboardingTooltip from 'containers/onboarding/tooltip';
 import Widgets from 'containers/widgets';
 // Constants
 import { MobileOnly, useMobile } from 'constants/responsive';
+import { ONBOARDING_TYPE_CENTER } from 'constants/onboarding-constants';
 // Styles
 import animationStyles from 'styles/common-animations.module.scss';
 import styles from './data-scene-styles.module.scss';
@@ -55,8 +56,15 @@ const DataSceneComponent = ({
   const isMobile = useMobile();
   const sidebarHidden = isLandscapeMode || isFullscreenActive || isMobile;
   const updatedSceneSettings = useMemo(
-    () => ({ ...sceneSettings, ...(isMobile && { padding: { left: 0 } }) }),
-    [isMobile]
+    () => ({
+      ...sceneSettings,
+      center:
+        onboardingType === 'priority-places'
+          ? ONBOARDING_TYPE_CENTER['priority-places']
+          : sceneSettings.center,
+      ...(isMobile && { padding: { left: 0 } }),
+    }),
+    [isMobile, onboardingType]
   );
 
   return (
@@ -70,6 +78,7 @@ const DataSceneComponent = ({
         disabled={!!onboardingType}
       >
         {!!onboardingType && <SoundButton />}
+        <OnboardingTooltip />
 
         <ArcgisLayerManager
           userConfig={userConfig}
@@ -96,8 +105,6 @@ const DataSceneComponent = ({
             [animationStyles.leftHidden]: sidebarHidden,
           })}
         />
-
-        <OnboardingTooltip />
         <MobileOnly>
           <MenuFooter
             activeOption={activeOption}


### PR DESCRIPTION
## Updates to the onboarding feature
### Description
- Update estimated time of onboarding cards
- Add clicks to the arc steps to the onboarding to be able to switch through the steps
- Center the map on the amazon if the first onboarding is active
### Testing instructions
- Go to the first onboarding: the map should be centered on the Amazon
- Click through the buttons on the onboarding steps to switch the audio and text step

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-366?atlOrigin=eyJpIjoiMTdlOTMzNDJhYWM1NGI4NDk3YTc4OTNkNmVjMzQwNGQiLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/HE-368?atlOrigin=eyJpIjoiNzU5ODk5YTJlZmYwNGNlOTgyMmE3ZGViMTUyYjJiMDQiLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/HE-367?atlOrigin=eyJpIjoiNzg3MDQ5NjQ1MDI3NGNmMzkwMmZjMWEzZjBlM2ZmMGMiLCJwIjoiaiJ9