### PR TITLE
(fix): toggle layer by clicking on the map[REF-330]

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
@@ -69,14 +69,14 @@ const AnalyzeAreasCardComponent = ({
             label="Click on the map"
             Icon={AoisClickIcon}
             active={selectedAnalysisTab === 'click'}
-            handleClick={() => handleAnalysisTabClick('click')}
+            handleClick={() => selectedAnalysisTab !== 'click' && handleAnalysisTabClick('click')}
           />
           <Button
             type="square"
             label="Draw or upload a shape"
             Icon={AoisDrawIcon}
             active={selectedAnalysisTab === 'draw'}
-            handleClick={() => handleAnalysisTabClick('draw')}
+            handleClick={() => selectedAnalysisTab !== 'draw' && handleAnalysisTabClick('draw')}
           />
         </div>
         {selectedAnalysisTab === 'click' && (

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -145,7 +145,6 @@ const AnalyzeAreasContainer = (props) => {
 
   const handleLayerToggle = (currentSelectedOption) => {
     // Future places layer will be activated if we select it at some point and never toggled unless we do it from the protection checkbox
-    console.log({ currentSelectedOption })
 
     const getLayersToToggle = () => {
       const futureLayerIsActive = activeLayers.some(l => l.title === HALF_EARTH_FUTURE_TILE_LAYER);

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -38,7 +38,6 @@ const AnalyzeAreasContainer = (props) => {
     description: ''
   })
 
-
   useEffect(() => {
     const activeOption = getSelectedAnalysisLayer(activeLayers);
     if (activeOption) {
@@ -109,11 +108,11 @@ const AnalyzeAreasContainer = (props) => {
       case 'draw':
         setAreaTypeSelected(AREA_TYPES.custom);
         setSelectedAnalysisTab('draw');
-        handleLayerToggle(selectedOption);
+        handleLayerToggle(PRECALCULATED_AOI_OPTIONS[0]);
         break;
       case 'click':
         setSelectedAnalysisTab('click');
-        handleLayerToggle(selectedOption);
+        handleLayerToggle(PRECALCULATED_AOI_OPTIONS[0]);
         if (sketchTool) { handleSketchToolDestroy(); }
         break;
       default:
@@ -146,6 +145,7 @@ const AnalyzeAreasContainer = (props) => {
 
   const handleLayerToggle = (currentSelectedOption) => {
     // Future places layer will be activated if we select it at some point and never toggled unless we do it from the protection checkbox
+    console.log({ currentSelectedOption })
 
     const getLayersToToggle = () => {
       const futureLayerIsActive = activeLayers.some(l => l.title === HALF_EARTH_FUTURE_TILE_LAYER);
@@ -154,9 +154,10 @@ const AnalyzeAreasContainer = (props) => {
         return [selectedOption.slug];
       }
       // Don't remove future layer it if its active and it was selected
-      return (selectedOption.slug === HALF_EARTH_FUTURE_TILE_LAYER) ? [currentSelectedOption] : [selectedOption.slug, currentSelectedOption] ;
+      return (selectedOption.slug === HALF_EARTH_FUTURE_TILE_LAYER) ? [currentSelectedOption] : [selectedOption.slug, currentSelectedOption];
     };
     const category = currentSelectedOption === HALF_EARTH_FUTURE_TILE_LAYER ? LAYERS_CATEGORIES.PROTECTION : undefined;
+
     batchToggleLayers(getLayersToToggle(), activeLayers, changeGlobe, category);
   }
 


### PR DESCRIPTION
## Toggle layer by clicking on the map

### Description
This PR fixes the issue on Analyze Areas when toggle the layer on switching Click/Draw buttons.

### Testing instructions
- [x] Enter the application and check that the layer is activated and that you can hover and click on a country to analyze an area.
- [x] Open the Analyze Areas dropdown, click on "Click on the map" button and check that the layer is not deactivated.
- [x] Click on "Draw or Upload..." button and check that the layer is deactivated.
- [x] Click on "Click on the map" button again and check that it is activated again

### Feature relevant tickets
[HE-330](https://vizzuality.atlassian.net/browse/HE-330)