### PR TITLE
Add protected addtional layers and refactor

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 // constants
 import { PRECALCULATED_AOI_OPTIONS, HIGHER_AREA_SIZE_LIMIT, WARNING_MESSAGES } from 'constants/analyze-areas-constants';
-import { GADM_1_ADMIN_AREAS_FEATURE_LAYER, WDPA_OECM_FEATURE_LAYER, GADM_0_ADMIN_AREAS_FEATURE_LAYER, HALF_EARTH_FUTURE_TILE_LAYER, SPECIFIC_REGIONS_TILE_LAYER } from 'constants/layers-slugs';
+import { PROTECTED_AREAS_VECTOR_TILE_LAYER,COMMUNITY_AREAS_VECTOR_TILE_LAYER,  GADM_1_ADMIN_AREAS_FEATURE_LAYER, WDPA_OECM_FEATURE_LAYER, GADM_0_ADMIN_AREAS_FEATURE_LAYER, HALF_EARTH_FUTURE_TILE_LAYER, SPECIFIC_REGIONS_TILE_LAYER } from 'constants/layers-slugs';
 import { AREA_TYPES } from 'constants/aois.js';
 import { LAYERS_CATEGORIES } from 'constants/mol-layers-configs';
 
@@ -139,7 +139,7 @@ const AnalyzeAreasContainer = (props) => {
         setAreaTypeSelected(AREA_TYPES.national);
         break;
       case WDPA_OECM_FEATURE_LAYER:
-        setAreaTypeSelected(AREA_TYPES.custom);
+        setAreaTypeSelected(AREA_TYPES.protected);
         break;
       case HALF_EARTH_FUTURE_TILE_LAYER:
         setAreaTypeSelected(AREA_TYPES.futurePlaces);
@@ -147,25 +147,43 @@ const AnalyzeAreasContainer = (props) => {
       case SPECIFIC_REGIONS_TILE_LAYER:
         setAreaTypeSelected(AREA_TYPES.specificRegions);
         break;
+      default:
+        setAreaTypeSelected(AREA_TYPES.custom)
+        break;
     }
     handleLayerToggle(option.slug);
     setSelectedOption(option);
     setTooltipIsVisible(false);
   }
 
-  const handleLayerToggle = (currentSelectedOption) => {
-    // Future places layer will be activated if we select it at some point and never toggled unless we do it from the protection checkbox
+  const handleLayerToggle = (newSelectedOption) => {
 
     const getLayersToToggle = () => {
-      const futureLayerIsActive = activeLayers.some(l => l.title === HALF_EARTH_FUTURE_TILE_LAYER);
-      // Don't remove future layer it if its active and we select it
-      if (currentSelectedOption === HALF_EARTH_FUTURE_TILE_LAYER && futureLayerIsActive) {
-        return [selectedOption.slug];
+      const formerSelectedSlug = selectedOption.slug;
+
+      let layersToToggle = [formerSelectedSlug, newSelectedOption];
+
+      const protectedAreasSelected = newSelectedOption === WDPA_OECM_FEATURE_LAYER;
+      if (protectedAreasSelected) {
+        const additionalProtectedAreasLayers = [PROTECTED_AREAS_VECTOR_TILE_LAYER, COMMUNITY_AREAS_VECTOR_TILE_LAYER];
+        additionalProtectedAreasLayers.forEach(layer => {
+          if (!activeLayers.some(l => l.title === layer)) {
+            layersToToggle.push(layer);
+          }
+        })
       }
-      // Don't remove future layer it if its active and it was selected
-      return (selectedOption.slug === HALF_EARTH_FUTURE_TILE_LAYER) ? [currentSelectedOption] : [selectedOption.slug, currentSelectedOption];
+
+      // Never toggle (remove) future places layer if its active
+      // Future places layer will be activated if we select it at some point and never toggled unless we do it from the protection checkbox
+      const futureLayerIsActive = activeLayers.some(l => l.title === HALF_EARTH_FUTURE_TILE_LAYER);
+      if (futureLayerIsActive && layersToToggle.includes(HALF_EARTH_FUTURE_TILE_LAYER)) {
+        layersToToggle = layersToToggle.filter(l => l !== HALF_EARTH_FUTURE_TILE_LAYER)
+      }
+
+      return layersToToggle;
     };
-    const category = currentSelectedOption === HALF_EARTH_FUTURE_TILE_LAYER ? LAYERS_CATEGORIES.PROTECTION : undefined;
+
+    const category = newSelectedOption === HALF_EARTH_FUTURE_TILE_LAYER ? LAYERS_CATEGORIES.PROTECTION : undefined;
 
     batchToggleLayers(getLayersToToggle(), activeLayers, changeGlobe, category);
   }


### PR DESCRIPTION
## Add protected additional layers and refactor
### Description
Add protected addtional layers when we select the precalculated protected areas option
### Testing instructions
Select protected areas on the Aoi dropdown on the data globe:
- Both protected areas layers should be selected
- These areas won't be deselected unless we do it manually on the checkboxes of the protected areas section

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-403?atlOrigin=eyJpIjoiNWU1MjI2NWJjMzgyNDgwNDg0NDU2ZjVmOGVhNzYwNzQiLCJwIjoiaiJ9