### PR TITLE
Fix ProtectedAreasModal call

### DIFF
--- a/src/containers/modals/protected-areas-modal/index.js
+++ b/src/containers/modals/protected-areas-modal/index.js
@@ -158,7 +158,7 @@ const Container = (props) => {
     // ---------------- REST OF CASES ------------------
       EsriFeatureService.getFeatures({
         url: urlValue,
-        whereClause: `MOL_ID = '${aoiId}'`,
+        whereClause: `MOL_IDg = '${aoiId}'`,
         returnGeometry: false
       }).then((features) => {
         if (features) {


### PR DESCRIPTION
## Fix ProtectedAreasModal call
### Description
The wdpa_with_gadm0 call was checking for MOL_ID instead of MOL_IDg
### Testing instructions
Go to a country precalculated area. It should show the correct protected areas when we click on `ALL PROTECTED AREAS`
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-428?atlOrigin=eyJpIjoiMjg2MDYxOTFjZGM3NGM2YTg0MjVmOWZlMjZlNGZiYWEiLCJwIjoiaiJ9