### PR TITLE
 Add new 1km richness and rarity layers

### DIFF
--- a/src/constants/biodiversity-layers-constants.js
+++ b/src/constants/biodiversity-layers-constants.js
@@ -1,6 +1,6 @@
 import {
-  SA_AMPHIB_RARITY,
-  SA_AMPHIB_RICHNESS,
+  AMPHIB_RARITY_1KM,
+  AMPHIB_RICHNESS_1KM,
   SA_DRAGONFLIES_RARITY,
   SA_DRAGONFLIES_RICHNESS,
   SA_MAMMALS_RARITY,
@@ -11,8 +11,8 @@ import {
   SA_RESTIO_RICHNESS,
   SA_PROTEA_RARITY,
   SA_PROTEA_RICHNESS,
-  SA_REPTILES_RARITY,
-  SA_REPTILES_RICHNESS,
+  REPTILES_RARITY_1KM,
+  REPTILES_RICHNESS_1KM,
   AMPHIB_PRIORITY,
   AMPHIB_RARITY,
   AMPHIB_RICHNESS,
@@ -30,6 +30,8 @@ import {
   BIRDS_RICHNESS,
   ANTS_RICHNESS,
   BUTTERFLIES_RICHNESS,
+  BUTTERFLIES_RICHNESS_1KM,
+  BUTTERFLIES_RARITY_1KM,
   ODONATES_RICHNESS,
   SAPINDALES_RICHNESS,
   ALL_TAXA_RARITY,
@@ -186,9 +188,9 @@ export const LAYERS_TOGGLE_CONFIG = {
           layer: HUMMINGBIRDS_RICHNESS
         },
         {
-          value: SA_AMPHIB_RICHNESS,
+          value: AMPHIB_RICHNESS_1KM,
           name: 'amphibians',
-          layer: SA_AMPHIB_RICHNESS
+          layer: AMPHIB_RICHNESS_1KM
         },
         {
           value: SA_DRAGONFLIES_RICHNESS,
@@ -216,9 +218,14 @@ export const LAYERS_TOGGLE_CONFIG = {
           layer: SA_PROTEA_RICHNESS
         },
         {
-          value: SA_REPTILES_RICHNESS,
+          value: REPTILES_RICHNESS_1KM,
           name: 'reptiles',
-          layer: SA_REPTILES_RICHNESS
+          layer: REPTILES_RICHNESS_1KM
+        },
+        {
+          value: BUTTERFLIES_RICHNESS_1KM,
+          name: 'butterflies',
+          layer: BUTTERFLIES_RICHNESS_1KM
         },
       ],
       'COUNTRY': [
@@ -310,9 +317,9 @@ export const LAYERS_TOGGLE_CONFIG = {
           layer: HUMMINGBIRDS_RARITY
         },
         {
-          value: SA_AMPHIB_RARITY,
+          value: AMPHIB_RARITY_1KM,
           name: 'amphibians',
-          layer: SA_AMPHIB_RARITY
+          layer: AMPHIB_RARITY_1KM
         },
         {
           value: SA_DRAGONFLIES_RARITY,
@@ -340,10 +347,15 @@ export const LAYERS_TOGGLE_CONFIG = {
           layer: SA_PROTEA_RARITY
         },
         {
-          value: SA_REPTILES_RARITY,
+          value: REPTILES_RARITY_1KM,
           name: 'reptiles',
-          layer: SA_REPTILES_RARITY
-        }
+          layer: REPTILES_RARITY_1KM
+        },
+        {
+          value: BUTTERFLIES_RARITY_1KM,
+          name: 'butterflies',
+          layer: BUTTERFLIES_RARITY_1KM
+        },
       ]
     },
     [MARINE]: {

--- a/src/constants/layers-slugs.js
+++ b/src/constants/layers-slugs.js
@@ -84,8 +84,8 @@ export const COUNTRIES_DATA_FEATURE_LAYER = 'countries_data_layer';
 export const PRIORITY_PLACES_POLYGONS = 'priority_places_polygons';
 export const PRIORITY_POLYGONS_GRAPHIC_LAYER = 'priority_polygons_graphic_layer';
 // South Africa layers
-export const SA_AMPHIB_RARITY = 'amphib-rarity-sa';
-export const SA_AMPHIB_RICHNESS = 'amphib-rich-sa';
+export const AMPHIB_RARITY_1KM = 'amphib-rarity-sa';
+export const AMPHIB_RICHNESS_1KM = 'amphib-rich-sa';
 export const SA_DRAGONFLIES_RARITY = 'dragonflies-rare-sa';
 export const SA_DRAGONFLIES_RICHNESS = 'dragonflies-rich-sa';
 export const SA_MAMMALS_RARITY = 'mammals-rare-sa';
@@ -96,8 +96,8 @@ export const SA_RESTIO_RARITY = 'restio-rare-sa';
 export const SA_RESTIO_RICHNESS = 'restio-rich-sa';
 export const SA_PROTEA_RARITY = 'protea-rare-sa';
 export const SA_PROTEA_RICHNESS = 'protea-rich-sa';
-export const SA_REPTILES_RARITY = 'reptiles-rare-sa';
-export const SA_REPTILES_RICHNESS = 'reptiles-rich-sa';
+export const REPTILES_RARITY_1KM = 'reptiles-rare-sa';
+export const REPTILES_RICHNESS_1KM = 'reptiles-rich-sa';
 // Global biodiversity
 
 export const ALL_TAXA_PRIORITY = 'all-taxa-priority';
@@ -130,6 +130,9 @@ export const CONIFERS_RICHNESS = 'conifers-rich';
 export const REPTILES_PRIORITY = 'reptiles-priority';
 export const REPTILES_RARITY = 'reptiles-rarity';
 export const REPTILES_RICHNESS = 'reptiles-richness';
+
+export const BUTTERFLIES_RICHNESS_1KM = 'butterflies-richness-1km';
+export const BUTTERFLIES_RARITY_1KM = 'butterflies-rarity-1km';
 
 export const ANTS_RICHNESS = 'ants-richness';
 export const BUTTERFLIES_RICHNESS = 'butterflies-richness';

--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -35,8 +35,8 @@ import {
   MARINE_OCEAN_DRIVERS_HUMAN_PRESSURES_TILE_LAYER,
   COMMERCIAL_FISHING_HUMAN_PRESSURES_TILE_LAYER,
   ARTISANAL_FISHING_HUMAN_PRESSURES_TILE_LAYER,
-  SA_AMPHIB_RARITY,
-  SA_AMPHIB_RICHNESS,
+  AMPHIB_RARITY_1KM,
+  AMPHIB_RICHNESS_1KM,
   SA_DRAGONFLIES_RARITY,
   SA_DRAGONFLIES_RICHNESS,
   SA_MAMMALS_RARITY,
@@ -47,8 +47,8 @@ import {
   SA_RESTIO_RICHNESS,
   SA_PROTEA_RARITY,
   SA_PROTEA_RICHNESS,
-  SA_REPTILES_RARITY,
-  SA_REPTILES_RICHNESS,
+  REPTILES_RARITY_1KM,
+  REPTILES_RICHNESS_1KM,
   AMPHIB_PRIORITY,
   AMPHIB_RARITY,
   AMPHIB_RICHNESS,
@@ -83,6 +83,8 @@ import {
   BUTTERFLIES_RICHNESS,
   ODONATES_RICHNESS,
   SAPINDALES_RICHNESS,
+  BUTTERFLIES_RARITY_1KM,
+  BUTTERFLIES_RICHNESS_1KM,
   PLEDGES_LAYER,
   EDUCATOR_AMBASSADORS_LAYER,
   SPECIES_LIST,
@@ -180,9 +182,10 @@ export const LAYERS_URLS = {
   [MARINE_OCEAN_DRIVERS_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Ocean_Based_Drivers_MeriamNelson_cont/MapServer',
   [COMMERCIAL_FISHING_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Commercial_Fishing_MeriamNelson_cont/MapServer',
   [ARTISANAL_FISHING_HUMAN_PRESSURES_TILE_LAYER]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Artisanal_Fishing_MeriamNelson_cont/MapServer',
+
   // REGIONAL 1km BIODIVERSITY
-  [SA_AMPHIB_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/amph_rar_sa_tif/MapServer`,
-  [SA_AMPHIB_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/amph_rich_sa_tif/MapServer`,
+  [AMPHIB_RARITY_1KM]: [`https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/amph_rar_sa_tif/MapServer`, `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Amphibian_Total_Rarity/MapServer`],
+  [AMPHIB_RICHNESS_1KM]: [`https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/amph_rich_sa_tif/MapServer`, `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Amphibian_Richness/MapServer`],
   [SA_DRAGONFLIES_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/df_rar_sa_tif/MapServer`,
   [SA_DRAGONFLIES_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/df_rich_sa_tif/MapServer`,
   [SA_MAMMALS_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/mamm_rar_sa_tif/MapServer`,
@@ -193,8 +196,8 @@ export const LAYERS_URLS = {
   [SA_RESTIO_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/restio_rich_sa_tif/MapServer`,
   [SA_PROTEA_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/protea_rar_sa_tif/MapServer`,
   [SA_PROTEA_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/protea_rich_sa_tif/MapServer`,
-  [SA_REPTILES_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/rept_rar_sa_tif/MapServer`,
-  [SA_REPTILES_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/rept_rich_sa_tif/MapServer`,
+  [REPTILES_RARITY_1KM]: ['https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/rept_rar_sa_tif/MapServer', 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Rarity_Patterns_for_Reptile_Species_of_North_America/MapServer'],
+  [REPTILES_RICHNESS_1KM]: [`https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/rept_rich_sa_tif/MapServer`, 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Richness_Patterns_for_Reptile_Species_of_North_America/MapServer'],
   [HUMMINGBIRDS_RARITY]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/hb_rarity_raw_tif/MapServer`,
   [HUMMINGBIRDS_RICHNESS]: `https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/hb_rich_1km_tif/MapServer`,
   // Global biodiversity services
@@ -216,6 +219,9 @@ export const LAYERS_URLS = {
 
   [REPTILES_RARITY]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/rarity_025d_reptiles/MapServer',
   [REPTILES_RICHNESS]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/richness_025d_reptiles/MapServer',
+
+  [BUTTERFLIES_RICHNESS_1KM]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Richness_Patterns_for_Butterfly_Species_of_North_America/MapServer',
+  [BUTTERFLIES_RARITY_1KM]: 'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/Rarity_Patterns_of_Butterfly_Species_of_North_America/MapServer',
 
   //// Terrestrial richness and rarity country level services
 

--- a/src/constants/metadata.js
+++ b/src/constants/metadata.js
@@ -1,7 +1,7 @@
 import {
   MERGED_WDPA_VECTOR_TILE_LAYER,
-  SA_AMPHIB_RARITY,
-  SA_AMPHIB_RICHNESS,
+  AMPHIB_RARITY_1KM,
+  AMPHIB_RICHNESS_1KM,
   SA_DRAGONFLIES_RARITY,
   SA_DRAGONFLIES_RICHNESS,
   SA_MAMMALS_RARITY,
@@ -12,8 +12,10 @@ import {
   SA_RESTIO_RICHNESS,
   SA_PROTEA_RARITY,
   SA_PROTEA_RICHNESS,
-  SA_REPTILES_RARITY,
-  SA_REPTILES_RICHNESS,
+  REPTILES_RARITY_1KM,
+  REPTILES_RICHNESS_1KM,
+  BUTTERFLIES_RARITY_1KM,
+  BUTTERFLIES_RICHNESS_1KM,
   HUMMINGBIRDS_RICHNESS,
   HUMMINGBIRDS_RARITY,
   MAMMALS_RARITY,
@@ -88,12 +90,12 @@ export default {
     slug: SPECIES_PROTECTION_INDEX,
     title: 'Species Protection Index'
   },
-  [SA_AMPHIB_RARITY]: {
-    slug: SA_AMPHIB_RARITY,
+  [AMPHIB_RARITY_1KM]: {
+    slug: AMPHIB_RARITY_1KM,
     title: 'Amphibian regional rarity'
   },
-  [SA_AMPHIB_RICHNESS]: {
-    slug: SA_AMPHIB_RICHNESS,
+  [AMPHIB_RICHNESS_1KM]: {
+    slug: AMPHIB_RICHNESS_1KM,
     title: 'Amphibian regional richness'
   },
   [SA_DRAGONFLIES_RARITY]: {
@@ -136,13 +138,21 @@ export default {
     slug: SA_PROTEA_RICHNESS,
     title: 'Protea regional richness'
   },
-  [SA_REPTILES_RARITY]: {
-    slug: SA_REPTILES_RARITY,
+  [REPTILES_RARITY_1KM]: {
+    slug: REPTILES_RARITY_1KM,
     title: 'Reptiles regional rarity'
   },
-  [SA_REPTILES_RICHNESS]: {
-    slug: SA_REPTILES_RICHNESS,
+  [REPTILES_RICHNESS_1KM]: {
+    slug: REPTILES_RICHNESS_1KM,
     title: 'Reptiles regional richness'
+  },
+  [BUTTERFLIES_RICHNESS_1KM]: {
+    slug: BUTTERFLIES_RICHNESS_1KM,
+    title: 'Butterflies regional richness'
+  },
+  [BUTTERFLIES_RARITY_1KM]: {
+    slug: BUTTERFLIES_RARITY_1KM,
+    title: 'Butterflies regional rarity'
   },
   // Hummingbirds
   [HUMMINGBIRDS_RICHNESS]: {

--- a/src/constants/mol-layers-configs.js
+++ b/src/constants/mol-layers-configs.js
@@ -37,8 +37,8 @@ import {
   MARINE_OCEAN_DRIVERS_HUMAN_PRESSURES_TILE_LAYER,
   COMMERCIAL_FISHING_HUMAN_PRESSURES_TILE_LAYER,
   ARTISANAL_FISHING_HUMAN_PRESSURES_TILE_LAYER,
-  SA_AMPHIB_RARITY,
-  SA_AMPHIB_RICHNESS,
+  AMPHIB_RARITY_1KM,
+  AMPHIB_RICHNESS_1KM,
   SA_DRAGONFLIES_RARITY,
   SA_DRAGONFLIES_RICHNESS,
   SA_MAMMALS_RARITY,
@@ -49,8 +49,10 @@ import {
   SA_RESTIO_RICHNESS,
   SA_PROTEA_RARITY,
   SA_PROTEA_RICHNESS,
-  SA_REPTILES_RARITY,
-  SA_REPTILES_RICHNESS,
+  REPTILES_RARITY_1KM,
+  REPTILES_RICHNESS_1KM,
+  BUTTERFLIES_RICHNESS_1KM,
+  BUTTERFLIES_RARITY_1KM,
   AMPHIB_PRIORITY,
   AMPHIB_RARITY,
   AMPHIB_RICHNESS,
@@ -418,19 +420,17 @@ export const layersConfig = {
     url: LAYERS_URLS[ARTISANAL_FISHING_HUMAN_PRESSURES_TILE_LAYER],
     bbox: null
   },
-  [SA_AMPHIB_RARITY]: {
-    title: SA_AMPHIB_RARITY,
-    slug: SA_AMPHIB_RARITY,
+  [AMPHIB_RARITY_1KM]: {
+    title: AMPHIB_RARITY_1KM,
+    slug: AMPHIB_RARITY_1KM,
     type: LAYER_TYPES.TILE_LAYER,
-    url: LAYERS_URLS[SA_AMPHIB_RARITY],
-    bbox: [13,-37,34,-27.7]
+    url: LAYERS_URLS[AMPHIB_RARITY_1KM],
   },
-  [SA_AMPHIB_RICHNESS]: {
-    title: SA_AMPHIB_RICHNESS,
-    slug: SA_AMPHIB_RICHNESS,
+  [AMPHIB_RICHNESS_1KM]: {
+    title: AMPHIB_RICHNESS_1KM,
+    slug: AMPHIB_RICHNESS_1KM,
     type: LAYER_TYPES.TILE_LAYER,
-    url: LAYERS_URLS[SA_AMPHIB_RICHNESS],
-    bbox: [13,-37,34,-27.7]
+    url: LAYERS_URLS[AMPHIB_RICHNESS_1KM],
   },
   [SA_DRAGONFLIES_RARITY]: {
     title: SA_DRAGONFLIES_RARITY,
@@ -502,19 +502,29 @@ export const layersConfig = {
     url: LAYERS_URLS[SA_PROTEA_RICHNESS],
     bbox: [13,-37,34,-27.7]
   },
-  [SA_REPTILES_RARITY]: {
-    title: SA_REPTILES_RARITY,
-    slug: SA_REPTILES_RARITY,
+  [REPTILES_RARITY_1KM]: {
+    title: REPTILES_RARITY_1KM,
+    slug: REPTILES_RARITY_1KM,
     type: LAYER_TYPES.TILE_LAYER,
-    url: LAYERS_URLS[SA_REPTILES_RARITY],
-    bbox: [13,-37,34,-27.7]
+    url: LAYERS_URLS[REPTILES_RARITY_1KM],
   },
-  [SA_REPTILES_RICHNESS]: {
-    title: SA_REPTILES_RICHNESS,
-    slug: SA_REPTILES_RICHNESS,
+  [REPTILES_RICHNESS_1KM]: {
+    title: REPTILES_RICHNESS_1KM,
+    slug: REPTILES_RICHNESS_1KM,
     type: LAYER_TYPES.TILE_LAYER,
-    url: LAYERS_URLS[SA_REPTILES_RICHNESS],
-    bbox: [13,-37,34,-27.7]
+    url: LAYERS_URLS[REPTILES_RICHNESS_1KM],
+  },
+  [BUTTERFLIES_RICHNESS_1KM]: {
+    title: BUTTERFLIES_RICHNESS_1KM,
+    slug: BUTTERFLIES_RICHNESS_1KM,
+    type: LAYER_TYPES.TILE_LAYER,
+    url: LAYERS_URLS[BUTTERFLIES_RICHNESS_1KM],
+  },
+  [BUTTERFLIES_RARITY_1KM]: {
+    title: BUTTERFLIES_RARITY_1KM,
+    slug: BUTTERFLIES_RARITY_1KM,
+    type: LAYER_TYPES.TILE_LAYER,
+    url: LAYERS_URLS[BUTTERFLIES_RARITY_1KM],
   },
   [HUMMINGBIRDS_RARITY]: {
     title: HUMMINGBIRDS_RARITY,
@@ -778,12 +788,12 @@ export const BIODIVERSITY_LAYERS_COLOUR_RAMP = [
 
 export const legendConfigs = {
   // South Africa
-  [SA_AMPHIB_RARITY]: {
+  [AMPHIB_RARITY_1KM]: {
     type: "gradient",
     items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Amphibian regional rarity"
   },
-  [SA_AMPHIB_RICHNESS]: {
+  [AMPHIB_RICHNESS_1KM]: {
     type: "gradient",
     items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Amphibian regional richness"
@@ -838,12 +848,12 @@ export const legendConfigs = {
     items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Protea regional richness"
   },
-  [SA_REPTILES_RARITY]: {
+  [REPTILES_RARITY_1KM]: {
     type: "gradient",
     items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Reptiles regional rarity"
   },
-  [SA_REPTILES_RICHNESS]: {
+  [REPTILES_RICHNESS_1KM]: {
     type: "gradient",
     items: getLegendGradient(BIODIVERSITY_LAYERS_COLOUR_RAMP, 'low', 'high'),
     title: "Reptiles regional richness"


### PR DESCRIPTION
## Add new 1km richness and rarity layers
### Description
- Add reptiles and amphibians 1km layers to existing ones and remove bounds for South Africa
- Add new butterflies layers
### Testing instructions
Go to Data globe - Biodiversity - Richness - 1km: You should see Butterflies, Reptiles (US and SA), and Amphibians (US and SA)
Go to Data globe - Biodiversity - Rarity - 1km: You should see Butterflies, Reptiles (US and SA), and Amphibians (US and SA)

Missing the metadata for butterflies

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-410?atlOrigin=eyJpIjoiYTQxMjQ3NDY3N2RmNDE0NGJmYTZiMDFkZWZlNTRjN2YiLCJwIjoiaiJ9