### PR TITLE
Fix Firefox crashing on Challenges page

### DIFF
--- a/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
+++ b/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
@@ -111,7 +111,7 @@ $chart-margin: 14px;
     animation-timing-function:cubic-bezier(1,.01,.91,.46);
   }
   50% {
-    r: 1%;
+    r: 1.1%;
     opacity: 0.2;
     animation-timing-function: linear;
   }


### PR DESCRIPTION
## Fix Firefox crashing on Challenges page
### Description
Firefox crashed because on the pulse animation 2 keyframes had the same `r` value (`1%`). I changed the second one to `1.1%`.
### Testing instructions
Open Firefox and navigate to, for example, https://map.half-earthproject.org/nrc/PER/challenges
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-404