### PR TITLE
Filter non-marine countries on Marine SPI ranking

### DIFF
--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -14,7 +14,7 @@ const getRankingData = createSelector([selectCountriesData, getLandMarineSelecte
   if(!countriesData) return null;
   const attributes = LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection];
   return Object.keys(countriesData)
-    .filter((iso) => countriesData[iso]["Marine"] !== "False")
+    .filter((iso) => countriesData[iso].Marine && countriesData[iso].Marine === "True")
     .map((iso) => {
     const d = countriesData[iso];
     return {

--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -10,7 +10,17 @@ const getSortRankingCategory = ({ location }) => (location && get(location, 'que
 
 const { REACT_APP_FEATURE_MARINE } = process.env;
 
-const getRankingData = createSelector([selectCountriesData, getLandMarineSelected], (countriesData, landMarineSelection) => {
+const filterMarineCountriesWhenMarine = createSelector([selectCountriesData, getLandMarineSelected], (countriesData, landMarineSelection) => {
+  if(!countriesData) return null;
+
+  const capitalLandMarine = landMarineSelection[0].toUpperCase() + landMarineSelection.slice(1);
+
+  return Object.keys(countriesData)
+    .filter((iso) => countriesData[iso][capitalLandMarine] !== "False")
+    .map((iso) => countriesData[iso]);
+});
+
+const getRankingData = createSelector([filterMarineCountriesWhenMarine, getLandMarineSelected], (countriesData, landMarineSelection) => {
   if(!countriesData) return null;
   const attributes = LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection];
   return Object.keys(countriesData).map((iso) => {

--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -10,13 +10,11 @@ const getSortRankingCategory = ({ location }) => (location && get(location, 'que
 
 const { REACT_APP_FEATURE_MARINE } = process.env;
 
-const filterMarineCountriesWhenMarine = createSelector([selectCountriesData, getLandMarineSelected], (countriesData, landMarineSelection) => {
-  if(!countriesData) return null;
-
-  const capitalLandMarine = landMarineSelection[0].toUpperCase() + landMarineSelection.slice(1);
+const filterMarineCountriesWhenMarine = createSelector([selectCountriesData], (countriesData,) => {
+  if (!countriesData) return null;
 
   return Object.keys(countriesData)
-    .filter((iso) => countriesData[iso][capitalLandMarine] !== "False")
+    .filter((iso) => countriesData[iso]["Marine"] !== "False")
     .map((iso) => countriesData[iso]);
 });
 

--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -10,18 +10,12 @@ const getSortRankingCategory = ({ location }) => (location && get(location, 'que
 
 const { REACT_APP_FEATURE_MARINE } = process.env;
 
-const filterMarineCountriesWhenMarine = createSelector([selectCountriesData], (countriesData,) => {
-  if (!countriesData) return null;
-
-  return Object.keys(countriesData)
-    .filter((iso) => countriesData[iso]["Marine"] !== "False")
-    .map((iso) => countriesData[iso]);
-});
-
-const getRankingData = createSelector([filterMarineCountriesWhenMarine, getLandMarineSelected], (countriesData, landMarineSelection) => {
+const getRankingData = createSelector([selectCountriesData, getLandMarineSelected], (countriesData, landMarineSelection) => {
   if(!countriesData) return null;
   const attributes = LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection];
-  return Object.keys(countriesData).map((iso) => {
+  return Object.keys(countriesData)
+    .filter((iso) => countriesData[iso]["Marine"] !== "False")
+    .map((iso) => {
     const d = countriesData[iso];
     return {
       [RANKING_INDICATORS.spi]: d[attributes.SPI],

--- a/src/components/ranking-chart/ranking-chart-selectors.js
+++ b/src/components/ranking-chart/ranking-chart-selectors.js
@@ -14,7 +14,7 @@ const getRankingData = createSelector([selectCountriesData, getLandMarineSelecte
   if(!countriesData) return null;
   const attributes = LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection];
   return Object.keys(countriesData)
-    .filter((iso) => countriesData[iso].Marine && countriesData[iso].Marine === "True")
+    .filter((iso) => landMarineSelection === 'marine' ? countriesData[iso].Marine === 'True' : true)
     .map((iso) => {
     const d = countriesData[iso];
     return {


### PR DESCRIPTION
### Description
When the Marine SPI filter is selected, it will check if the country has Marine value "True"
### Testing instructions
Open PR, navigate to NRC, select country (for example Brazil), and filter by Marine SPI: you should only see countries that have Marine SPI. 
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-431