### PR TITLE
Fix/update mask

### DIFF
--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -114,7 +114,9 @@ const COUNTRIES_DATA_URL = REACT_APP_FEATURE_MARINE ?
   'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/NRC_final_20220623/FeatureServer' :
   'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_centroid/FeatureServer';
 
+const EEZ_MARINE_BORDERS_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Country_boundaries_with_EEZ/FeatureServer';
 
+export const EEZ_MARINE_GEOMETRY_BORDERS_URL = `${EEZ_MARINE_BORDERS_URL}/0`;
 export const GRID_URL = "https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/gadm_grid_55k_dis/FeatureServer";
 export const METADATA_SERVICE_URL = isNotProduction ? 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/metadata_staging/FeatureServer/0' : 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/metadata_prod/FeatureServer/0';
 export const MONITORING_HE_GOAL_SERVICE_URL = 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/monitoringHEgoal/FeatureServer/0'
@@ -137,7 +139,7 @@ export const LAYERS_URLS = {
     'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/nrc_prior_bioRamp_clip/MapServer',
   [MARINE_COUNTRY_PRIORITY_LAYER]:
     'https://tiles.arcgis.com/tiles/IkktFdUAcY3WrH25/arcgis/rest/services/nrc_prior_bioRamp_clip_marine3/MapServer',
-  [EEZ_MARINE_BORDERS]: 'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Country_boundaries_with_EEZ/FeatureServer',
+  [EEZ_MARINE_BORDERS]: EEZ_MARINE_BORDERS_URL,
   [PLEDGES_LAYER]:
     'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/PledgeLocationsURL/FeatureServer',
   [EDUCATOR_AMBASSADORS_LAYER]:

--- a/src/containers/scenes/nrc-scene/nrc-scene.js
+++ b/src/containers/scenes/nrc-scene/nrc-scene.js
@@ -4,7 +4,7 @@ import Component from './nrc-scene-component';
 // Services
 import EsriFeatureService from 'services/esri-feature-service';
 // Constants
-import { COUNTRIES_GEOMETRIES_SERVICE_URL } from 'constants/layers-urls';
+import { COUNTRIES_GEOMETRIES_SERVICE_URL, EEZ_MARINE_GEOMETRY_BORDERS_URL } from 'constants/layers-urls';
 import { LOCAL_SCENE_TABS_SLUGS } from 'constants/ui-params';
 // Actions
 import countriesGeometriesActions from 'redux_modules/countries-geometries';
@@ -13,6 +13,8 @@ import { visitCountryReportCardAnalyticsEvent } from 'actions/google-analytics-a
 import { DATA, NATIONAL_REPORT_CARD } from 'router'
 import mapStateToProps from './nrc-scene-selectors';
 const actions = { ...countriesGeometriesActions, ...urlActions, visitCountryReportCardAnalyticsEvent }
+
+const { REACT_APP_FEATURE_MARINE } = process.env;
 
 const NrcSceneContainer = (props) => {
   const {
@@ -25,10 +27,11 @@ const NrcSceneContainer = (props) => {
   // Get country borders
   useEffect(() => {
     EsriFeatureService.getFeatures({
-      url: COUNTRIES_GEOMETRIES_SERVICE_URL,
+      url: REACT_APP_FEATURE_MARINE ? EEZ_MARINE_GEOMETRY_BORDERS_URL : COUNTRIES_GEOMETRIES_SERVICE_URL,
       whereClause: `GID_0 = '${countryISO}'`,
       returnGeometry: true
     }).then((features) => {
+      console.log('f', features)
       const { geometry } = features[0];
       setCountryBorderReady({ iso: countryISO, borderGraphic: geometry });
     }).catch(error => {

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
@@ -38,6 +38,7 @@ const AnalyzeAreasCardComponent = ({
   handlePromptModalToggle,
   aoiHistoryModalOpenAnalytics,
   onboardingStep,
+  onboardingType,
 }) => {
   const [isOpen, setOpen] = useState(false);
   const t = useT();
@@ -55,7 +56,8 @@ const AnalyzeAreasCardComponent = ({
     <div
       className={cx(styles.sidebarCardContainer, className, {
         [styles.open]: isOpen,
-        [styles.onboardingOverlay]: onboardingStep === 2,
+        [styles.onboardingOverlay]:
+          onboardingType === 'priority-places' && onboardingStep === 2,
       })}
     >
       <CategoryBox

--- a/src/containers/sidebars/data-global-sidebar/data-global-sidebar-component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/data-global-sidebar-component.jsx
@@ -33,6 +33,7 @@ const DataGlobalSidebarComponent = ({
         activeLayers={activeLayers}
         view={view}
         onboardingStep={onboardingStep}
+        onboardingType={onboardingType}
       />
       <BiodiversitySidebarCard
         map={map}

--- a/src/containers/sidebars/national-report-sidebar/overview-sidebar/country-data-card/country-data-card-component.jsx
+++ b/src/containers/sidebars/national-report-sidebar/overview-sidebar/country-data-card/country-data-card-component.jsx
@@ -129,10 +129,12 @@ const CountryDataCardComponent = ({
                     <b>
                       protected land (
                       {`${prop_protected_ter && prop_protected_ter.toFixed()}%`}
-                      ),
+                      )
                     </b>
-                    the <b>total of ({nspecies_ter})</b> and the amount of which
-                    of these are <b>endemic ({total_endemic_ter}).</b>
+                    , the total number of{' '}
+                    <b>terrestrial vertebrates ({nspecies_ter})</b> and the
+                    amount of these which are{' '}
+                    <b>endemic ({total_endemic_ter})</b>.
                   </p>
                 </div>
               </div>
@@ -163,11 +165,11 @@ const CountryDataCardComponent = ({
                         {`${
                           prop_protected_mar && prop_protected_mar.toFixed()
                         }%`}
-                        ),
+                        )
                       </b>
-                      the <b>total of fishes ({nspecies_mar})</b> species and
-                      the amount of which of these are{' '}
-                      <b>endemic ({total_endemic_mar}).</b>
+                      , the total number of{' '}
+                      <b>marine vertebrates ({nspecies_mar})</b> and the amount
+                      of these which are <b>endemic ({total_endemic_mar})</b>.
                     </p>
                   </div>
                 </div>

--- a/src/containers/sidebars/national-report-sidebar/overview-sidebar/country-data-card/country-data-card-styles.module.scss
+++ b/src/containers/sidebars/national-report-sidebar/overview-sidebar/country-data-card/country-data-card-styles.module.scss
@@ -81,6 +81,7 @@
 .donutContainer {
   display: flex;
   align-items: center;
+  margin-bottom: $sidebar-paddings;
 }
 
 .legendText {

--- a/src/containers/sidebars/nrc-landing-sidebar/index.js
+++ b/src/containers/sidebars/nrc-landing-sidebar/index.js
@@ -38,10 +38,9 @@ const Container = (props) => {
     }).then((features) => {
       const { attributes } = features[0];
       const { Global_SPI_ter, Global_SPI_mar } = attributes;
-
       setGlobalAverage({
-        landAverage: Global_SPI_ter && Global_SPI_ter.toFixed(),
-        marineAverage: Global_SPI_mar && Global_SPI_mar.toFixed(),
+        landAverage: Global_SPI_ter && parseFloat(Global_SPI_ter).toFixed(),
+        marineAverage: Global_SPI_mar && parseFloat(Global_SPI_mar).toFixed(),
       });
     })
   }, [])


### PR DESCRIPTION
## Fix mask in NRCs
### Description
- Fixes mask in NRCs adding the marine part
- Update Padding and text on the NRC - SPI cards
- Fix analyse card being obscured when we selected a nationality
### Testing instructions
- Go to nrc/ECU - You should see the marine part highlighted
-  Check there the text of the SPI card
- Go to the dataglobe, click on analyze areas, select subnational boundaries, search for porto, click on one of the options. You shouldn't see the card obscured

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-454?atlOrigin=eyJpIjoiNTM0NTRjYWMxNzgyNDEyOWE1NTlmMWFjNTIyMjZjYjciLCJwIjoiaiJ9
https://vizzuality.atlassian.net/browse/HE-460
https://vizzuality.atlassian.net/browse/HE-453
https://vizzuality.atlassian.net/browse/HE-454
