### PR TITLE
Fix Featured Place content not loading

### DIFF
--- a/src/containers/sidebars/featured-place-card/featured-place-card.js
+++ b/src/containers/sidebars/featured-place-card/featured-place-card.js
@@ -25,7 +25,7 @@ const FeaturedPlaceCardContainer = props => {
 
   useEffect(() => {
     featuredMapPlaces && selectedFeaturedMap && selectedFeaturedPlace && setFeaturedPlace({...featuredMapPlaces[selectedFeaturedMap][selectedFeaturedPlace]});
-  },[selectedFeaturedPlace, selectedFeaturedMap])
+  },[selectedFeaturedPlace, selectedFeaturedMap, featuredMapPlaces])
 
   useEffect(() => {
     if (featuredMapsList) {


### PR DESCRIPTION
### Description
When copying and pasting the URL for a Featured Place inside Discover Stories for sharing, the content for the Featured Place (which comes from Contentful) doesn't show.
### Testing instructions
Open any featured place, copy the URL and paste it on a new window. If all the content shows up, that means it's fixed! Also, here's an example URL: https://half-earth-16wmmw108-half-earth-map.vercel.app/featuredGlobe?ui=%7B%22selectedFeaturedPlace%22%3A%22atewa%22%7D If you can see the content (title, description and image) then it's OK!
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-60