### PR TITLE
fix: remove admin layer on map layers aoi sidebar tab

### DIFF
--- a/src/containers/scenes/data-scene/data-scene.js
+++ b/src/containers/scenes/data-scene/data-scene.js
@@ -49,12 +49,18 @@ function Container(props) {
   const [updatedActiveLayers, setUpdatedActiveLayers] = useState(activeLayers);
 
   useEffect(() => {
-    if (sidebarTabActive === sidebarTabs[0].slug) {
-      return setUpdatedActiveLayers(updatedActiveLayers
-        .filter((ual) => ual.title !== ADMIN_AREAS_FEATURE_LAYER));
+    const hasAdminLayer = !!updatedActiveLayers
+      .find((ual) => ual.title === ADMIN_AREAS_FEATURE_LAYER);
+
+    if (sidebarTabActive === sidebarTabs[0].slug && hasAdminLayer) {
+      const layersWithoutAdmin = updatedActiveLayers
+        .filter((ual) => ual.title !== ADMIN_AREAS_FEATURE_LAYER);
+      setUpdatedActiveLayers(layersWithoutAdmin);
     }
-    return setUpdatedActiveLayers([...updatedActiveLayers, { title: ADMIN_AREAS_FEATURE_LAYER }]);
-  }, [sidebarTabActive]);
+    if (sidebarTabActive === sidebarTabs[1].slug && !hasAdminLayer) {
+      setUpdatedActiveLayers([...updatedActiveLayers, { title: ADMIN_AREAS_FEATURE_LAYER }]);
+    }
+  }, [sidebarTabActive, updatedActiveLayers]);
 
   const locale = useLocale();
   const t = useT();

--- a/src/containers/scenes/data-scene/data-scene.js
+++ b/src/containers/scenes/data-scene/data-scene.js
@@ -46,7 +46,9 @@ function Container(props) {
   const { content: mapTooltipContent, precalculatedLayerSlug } = mapTooltipData;
   const sidebarTabs = getSidebarTabs();
   const [selectedAnalysisLayer, setSelectedAnalysisLayer] = useState();
-  const [updatedActiveLayers, setUpdatedActiveLayers] = useState(activeLayers);
+  const activeLayersWithoutAdmin = activeLayers
+    .filter((ual) => ual.title !== ADMIN_AREAS_FEATURE_LAYER);
+  const [updatedActiveLayers, setUpdatedActiveLayers] = useState(activeLayersWithoutAdmin);
 
   useEffect(() => {
     const hasAdminLayer = !!updatedActiveLayers

--- a/src/containers/scenes/data-scene/data-scene.js
+++ b/src/containers/scenes/data-scene/data-scene.js
@@ -40,11 +40,16 @@ function Container(props) {
     precomputedAoiAnalytics,
     changeUI,
     activeCategoryLayers,
+    sidebarTabActive,
   } = props;
-
   const { content: mapTooltipContent, precalculatedLayerSlug } = mapTooltipData;
   const [selectedAnalysisLayer, setSelectedAnalysisLayer] = useState();
   const [updatedActiveLayers, setUpdatedActiveLayers] = useState(activeLayers);
+
+  useEffect(() => {
+    if (sidebarTabActive === 'map-layers') return setUpdatedActiveLayers(updatedActiveLayers.filter((ual) => ual.title !== 'admin_areas_feature_layer'));
+    return setUpdatedActiveLayers([...updatedActiveLayers, { title: 'admin_areas_feature_layer' }]);
+  }, [sidebarTabActive]);
 
   const locale = useLocale();
   const t = useT();

--- a/src/containers/scenes/data-scene/data-scene.js
+++ b/src/containers/scenes/data-scene/data-scene.js
@@ -16,6 +16,7 @@ import { getTooltipContent } from 'utils/tooltip-utils';
 import intersectionBy from 'lodash/intersectionBy';
 import unionBy from 'lodash/unionBy';
 
+import { getSidebarTabs } from 'constants/aois';
 import { CATEGORY_LAYERS } from 'constants/category-layers-constants';
 import {
   HALF_EARTH_FUTURE_TILE_LAYER,
@@ -43,12 +44,16 @@ function Container(props) {
     sidebarTabActive,
   } = props;
   const { content: mapTooltipContent, precalculatedLayerSlug } = mapTooltipData;
+  const sidebarTabs = getSidebarTabs();
   const [selectedAnalysisLayer, setSelectedAnalysisLayer] = useState();
   const [updatedActiveLayers, setUpdatedActiveLayers] = useState(activeLayers);
 
   useEffect(() => {
-    if (sidebarTabActive === 'map-layers') return setUpdatedActiveLayers(updatedActiveLayers.filter((ual) => ual.title !== 'admin_areas_feature_layer'));
-    return setUpdatedActiveLayers([...updatedActiveLayers, { title: 'admin_areas_feature_layer' }]);
+    if (sidebarTabActive === sidebarTabs[0].slug) {
+      return setUpdatedActiveLayers(updatedActiveLayers
+        .filter((ual) => ual.title !== ADMIN_AREAS_FEATURE_LAYER));
+    }
+    return setUpdatedActiveLayers([...updatedActiveLayers, { title: ADMIN_AREAS_FEATURE_LAYER }]);
   }, [sidebarTabActive]);
 
   const locale = useLocale();


### PR DESCRIPTION
## Remove admin layer on map layers AOI sidebar tab

### Description
Tiny PR to remove admin layer with country borders on `map layers` AOI tab and enable on `analyze areas` one.