### PR TITLE
Fix/nrc-adjustments

### DIFF
--- a/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
+++ b/src/components/charts/scatter-plot/scatter-plot-styles.module.scss
@@ -100,7 +100,6 @@ $chart-margin: 14px;
       @extend %title;
       color: $_temporary-dark-text;
       letter-spacing: 0;
-      text-transform: initial;
     }
   }
 }

--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
@@ -172,8 +172,8 @@ function NationalReportPdf({
                         />
                       ) : (
                         <T
-                          _str="marine is protected"
-                          _comment="10% of {land is protected} and 2% needs protection"
+                          _str="marine area is protected"
+                          _comment="10% of {marine area is protected} and 2% needs protection"
                         />
                       )}
                     </b>
@@ -222,8 +222,8 @@ function NationalReportPdf({
                 />
               ) : (
                 <T
-                  _str="of marine has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } marine has {very high human modification} and 10% has some modification"
+                  _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                  _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
                   veryHighHumanModification={
                     <b>
                       <T

--- a/src/components/search-location/index.js
+++ b/src/components/search-location/index.js
@@ -71,7 +71,14 @@ function SearchLocationContainer(props) {
     const { title, subtitle, id, iso } = tooltipConfig;
     const { geometry, attributes } = feature;
 
-    if (searchType !== SEARCH_TYPES.simple) {
+    // National Report Card search
+    if (iso) {
+      setCountryTooltip({
+        countryIso: attributes[iso],
+        countryName: countryNames[attributes[title]] || attributes[title],
+        changeGlobe,
+      });
+    } else if (searchType !== SEARCH_TYPES.simple) {
       setBatchTooltipData({
         isVisible: true,
         geometry,
@@ -80,16 +87,10 @@ function SearchLocationContainer(props) {
       });
     }
 
-    flyToCentroid(view, geometry, 4);
-
-    // National Report Card search
-    if (iso) {
-      setCountryTooltip({
-        countryIso: attributes[iso],
-        countryName: countryNames[attributes[title]] || attributes[title],
-        changeGlobe,
-      });
-    }
+    flyToCentroid(view, geometry, 5, { maxDuration: 100000 }).catch(() => {
+      // If it fails just go without animation
+      flyToCentroid(view, geometry, 5, { animate: false });
+    });
   };
 
   const getSearchResults = (e) => {
@@ -156,7 +157,9 @@ function SearchLocationContainer(props) {
   const onOptionSelection = (selectedOption) => {
     handleSearchSuggestionClick(selectedOption);
     setIsSearchResultsVisible(false);
-    setSearchLocationModal(false);
+    if (setSearchLocationModal) {
+      setSearchLocationModal(false);
+    }
   };
   const handleCloseOptionList = () => setIsSearchResultsVisible(false);
 

--- a/src/components/species-table/species-table-component.jsx
+++ b/src/components/species-table/species-table-component.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import { T, useLocale, useT } from '@transifex/react';
@@ -38,12 +38,18 @@ function SpeciesTable({
   const t = useT();
   const locale = useLocale();
   const vertebrateTabs = useMemo(() => getVertebrateTabs(), [locale]);
-
   const translatedSpeciesGroup = useMemo(getSpeciesGroup, [locale]);
   const { height } = useWindowSize();
   const [expandedRow, setExpandedRow] = useState(null);
-
+  const [landTab, marineTab] = vertebrateTabs;
   const { landSpeciesTotal, marineSpeciesTotal } = countryData;
+
+  // Select the land tab if we dont have marine species
+  useEffect(() => {
+    if (vertebrateType === marineTab.slug && marineSpeciesTotal === 0) {
+      handleVertebrateChange(landTab.slug);
+    }
+  }, [vertebrateTabs, vertebrateType, marineSpeciesTotal]);
 
   const toggleExpand = (index) => {
     setExpandedRow(index === expandedRow ? null : index);
@@ -146,12 +152,12 @@ function SpeciesTable({
         <div className={styles.tabs}>
           <button
             type="button"
-            onClick={() => handleVertebrateChange(vertebrateTabs[0].slug)}
+            onClick={() => handleVertebrateChange(landTab.slug)}
           >
             <p
               className={cx({
                 [styles.tab]: true,
-                [styles.selectedTab]: vertebrateType === vertebrateTabs[0].slug,
+                [styles.selectedTab]: vertebrateType === landTab.slug,
               })}
             >
               <T
@@ -163,12 +169,13 @@ function SpeciesTable({
           </button>
           <button
             type="button"
-            onClick={() => handleVertebrateChange(vertebrateTabs[1].slug)}
+            onClick={() => handleVertebrateChange(marineTab.slug)}
+            disabled={marineSpeciesTotal === 0}
           >
             <p
               className={cx({
                 [styles.tab]: true,
-                [styles.selectedTab]: vertebrateType === vertebrateTabs[1].slug,
+                [styles.selectedTab]: vertebrateType === marineTab.slug,
               })}
             >
               <T

--- a/src/components/species-table/species-table.js
+++ b/src/components/species-table/species-table.js
@@ -31,7 +31,8 @@ const mapStateToProps = (state) => ({
 });
 
 function SpeciesModalContainer(props) {
-  const { changeUI, speciesModalSort, state } = props;
+  const { changeUI, speciesModalSort, state, countryData } = props;
+  const { marineSpeciesTotal } = countryData || {};
 
   const locale = useLocale();
   const vertebrateTabs = useMemo(() => getVertebrateTabs(), [locale]);
@@ -41,10 +42,11 @@ function SpeciesModalContainer(props) {
 
   const landLayer = useFeatureLayer({ layerSlug: SPECIES_LIST });
   const marineLayer = useFeatureLayer({ layerSlug: MARINE_SPECIES_LIST });
-
   useEffect(() => {
     const layer = vertebrateType === LAND_MARINE.land ? landLayer : marineLayer;
-    if (layer && state.location.payload.iso) {
+    const isMarineAndEmpty =
+      vertebrateType === LAND_MARINE.marine && marineSpeciesTotal === 0;
+    if (!isMarineAndEmpty && layer && state.location.payload.iso) {
       const getFeatures = async () => {
         const query = await layer.createQuery();
         query.where = `iso3 = '${state.location.payload.iso}'`;

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -71,7 +71,7 @@ function Indicators({ countryData, landMarineSelection }) {
           </p>
         }
         tooltipInfo={t(
-          'The Species Protection Index (SPI) reflects the average amount of area-based conservation targets that have been met for all endemic species within the country each year, weighted by a country`s stewardship of those species (the proportion of the species population present in that country).'
+          'The Species Protection Index (SPI) reflects the average amount of area-based conservation targets that have been met for all species within the country each year, weighted by a country`s stewardship of those species (the proportion of the species population present in that country).'
         )}
       >
         <div>
@@ -154,8 +154,8 @@ function Indicators({ countryData, landMarineSelection }) {
                       />
                     ) : (
                       <T
-                        _str="marine is protected"
-                        _comment="10% of {land is protected} and 2% needs protection"
+                        _str="marine area is protected"
+                        _comment="10% of {marine area is protected} and 2% needs protection"
                       />
                     )}
                   </b>
@@ -169,7 +169,7 @@ function Indicators({ countryData, landMarineSelection }) {
           </p>
         }
         tooltipInfo={t(
-          'Regions that are recognized as currently being managed for long-term nature conservation. An increase of protected areas will result in an increase of the SPI.'
+          'Regions that are recognized as currently being managed for long-term nature conservation. An increase of protected areas will result in an increase of the SPI, only if areas aid in achieving species protection targets.'
         )}
       >
         <div
@@ -206,8 +206,8 @@ function Indicators({ countryData, landMarineSelection }) {
                 />
               ) : (
                 <T
-                  _str="of marine has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } marine has {very high human modification} and 10% has some modification"
+                  _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                  _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
                   veryHighHumanModification={
                     <b>
                       <T

--- a/src/containers/sidebars/aoi-sidebar/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/component.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { DATA } from 'router';
@@ -65,6 +65,7 @@ function AOISidebar({
   shareAoiAnalytics,
   handleClose,
   sidebarTabActive,
+  setSidebarTabActive,
   isShareModalOpen,
   setShareModalOpen,
   dataLoaded,
@@ -78,6 +79,13 @@ function AOISidebar({
   const [mapLayersTab, analyzeAreasTab] = getSidebarTabs();
   const t = useT();
   const locale = useLocale();
+
+  // If we have an active area go to the analyze areas tab first
+  useEffect(() => {
+    if (sidebarTabActive === mapLayersTab.slug && aoiId) {
+      setSidebarTabActive(analyzeAreasTab.slug);
+    }
+  }, []);
 
   const WDPALayers = useMemo(() => getWDPALayers(), [locale]);
 

--- a/src/containers/sidebars/aoi-sidebar/index.js
+++ b/src/containers/sidebars/aoi-sidebar/index.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
+import uiActions from 'redux_modules/ui';
 
 import { DATA } from 'router';
 
@@ -19,7 +20,7 @@ import { CATEGORY_LAYERS } from 'constants/category-layers-constants';
 
 import Component from './component';
 
-const actions = { ...urlActions, ...aoiAnalyticsActions };
+const actions = { ...urlActions, ...uiActions, ...aoiAnalyticsActions };
 
 function AoiSidebarContainer(props) {
   const {
@@ -36,6 +37,7 @@ function AoiSidebarContainer(props) {
 
   const locale = useLocale();
 
+  // Effect to set parsed values TODO: move to selector
   useEffect(() => {
     if (Object.keys(contextualData).length > 0) {
       // Custom AOIs rely on percentage instead of protectionPercentage

--- a/src/utils/globe-events-utils.js
+++ b/src/utils/globe-events-utils.js
@@ -107,13 +107,17 @@ export const flyToLayerGeometry = (view, layerFeatures) => {
   }
 };
 
-export const flyToCentroid = (view, geometry, zoom) => {
+export const flyToCentroid = (view, geometry, zoom, options) => {
   if (geometry && geometry.centroid) {
-    view.goTo({
-      target: geometry.centroid,
-      ...(zoom && { zoom }),
-    });
+    return view.goTo(
+      {
+        target: geometry.centroid,
+        ...(zoom ? { zoom } : {}),
+      },
+      options
+    );
   }
+  return undefined;
 };
 
 export const setCountryTooltip = ({ countryIso, countryName, changeGlobe }) => {


### PR DESCRIPTION
## NRC fixes
### Description
Feedback fixes for NRC page

1. When a country does not have marine species  dont let the user click the marine table tab

2. When using the search bar to find a country from the home page and that country is not visible on the map, and you are zoomed into an area (even slightly from global view), the map aborts sometimes the goTo. So we fallback to goTo without zoom

3. Info button text for % land protected was changed to - “Regions that are recognized as currently being managed for long-term nature conservation. An increase of protected areas will result in an increase of the SPI, only if areas aid in achieving species protection targets.”

4. Info button for SPI card box should omit the word “endemic” IN PROGRESS

5. In the hover window when selecting a country circle, capitalize the continent name. Senegal and “africa” example shown below. 

6. Show Analyze areas tab always if we have a AOI selected (When you click the Analyze Areas button at the bottom, it takes you to the Map Layers tab first. This should show the Analyze Areas tab first. )

8. When we say “marine” in these cards, we should say “marine area”.

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-687?atlOrigin=eyJpIjoiYzYyNGYzN2NmYTkzNDU5MGI5N2RlMWIyY2Q5MjE5NTgiLCJwIjoiaiJ9