### PR TITLE
(fix): add SPI 0 case

### DIFF
--- a/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
+++ b/src/components/pdf-reports/national-report-pdf/national-report-pdf-component.jsx
@@ -86,7 +86,7 @@ function NationalReportPdf({
       <section className={styles.indicatorCardsContainer}>
         <IndicatorCard
           className={styles.indicatorCard}
-          indicator={SPI ? getLocaleNumber(SPI, locale) : ''}
+          indicator={!!SPI || SPI === 0 ? getLocaleNumber(SPI, locale) : ''}
           description={
             <p>
               {land ? (

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -60,7 +60,7 @@ function Indicators({ countryData, landMarineSelection }) {
       })}
     >
       <IndicatorCard
-        indicator={SPI ? getLocaleNumber(SPI, locale) : ''}
+        indicator={getLocaleNumber(SPI, locale)}
         description={
           <p>
             {land ? (

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -60,7 +60,7 @@ function Indicators({ countryData, landMarineSelection }) {
       })}
     >
       <IndicatorCard
-        indicator={getLocaleNumber(SPI, locale)}
+        indicator={!!SPI || SPI === 0 ? getLocaleNumber(SPI, locale) : ''}
         description={
           <p>
             {land ? (


### PR DESCRIPTION
## Add SPI 0 on the indicator to the countries with 0 SPI

### Testing instructions
Go to Yemen country card and check that SPI is displayed as 0.

### Feature relevant tickets
[HE-689](https://vizzuality.atlassian.net/browse/HE-689)

[HE-689]: https://vizzuality.atlassian.net/browse/HE-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ