### PR TITLE
Fix/nrc-sort

### DIFF
--- a/src/components/species-table/species-table-component.jsx
+++ b/src/components/species-table/species-table-component.jsx
@@ -127,13 +127,6 @@ function SpeciesTable({
 
   const PX_TO_TOP = 300;
   const tableHeight = height - PX_TO_TOP;
-
-  if (speciesList.length === 0 || !speciesList)
-    return (
-      <div className={styles.loader} style={{ height: tableHeight }}>
-        <Loading />
-      </div>
-    );
   return (
     <div className={styles.scrolleableArea}>
       <section className={styles.section}>
@@ -209,12 +202,17 @@ function SpeciesTable({
             ))}
           </div>
         </div>
-
-        <Virtuoso
-          className={styles.rowsContainer}
-          totalCount={speciesList.length}
-          item={renderRow}
-        />
+        {speciesList.length === 0 || !speciesList ? (
+          <div className={styles.loader} style={{ height: tableHeight }}>
+            <Loading />
+          </div>
+        ) : (
+          <Virtuoso
+            className={styles.rowsContainer}
+            totalCount={speciesList.length}
+            item={renderRow}
+          />
+        )}
       </div>
       <section />
     </div>

--- a/src/components/species-table/species-table-selectors.js
+++ b/src/components/species-table/species-table-selectors.js
@@ -62,9 +62,9 @@ export const getSortedSpeciesList = createSelector(
     const direction = speciesModalSort && speciesModalSort.split('-')[1];
     const category =
       {
-        'species group': 'speciesgroup',
+        group: 'speciesgroup',
         'range within country protected': 'percentprotected',
-        'species protection score': 'NSPS',
+        sps: 'NSPS',
       }[sortedCategory] || sortedCategory;
     const sortedData = sortBy(filteredSpeciesList, (d) => d[category]);
     return direction === SORT.DESC ? sortedData.reverse() : sortedData;

--- a/src/components/species-table/species-table.js
+++ b/src/components/species-table/species-table.js
@@ -48,6 +48,8 @@ function SpeciesModalContainer(props) {
       vertebrateType === LAND_MARINE.marine && marineSpeciesTotal === 0;
     if (!isMarineAndEmpty && layer && state.location.payload.iso) {
       const getFeatures = async () => {
+        // Set empty species so we show the loading spinner
+        setSpeciesList([]);
         const query = await layer.createQuery();
         query.where = `iso3 = '${state.location.payload.iso}'`;
         query.maxRecordCountFactor = '10000';


### PR DESCRIPTION
## Fix sort on NRC vertebrates table
### Description
- Fix sort for Marine groups and SPS
- Reposition Loader so we always show the header
- Dont show land species while we are loading the marine ones
### Testing instructions
In the new Country NDC page / Go to the all vertebrates button and click / in the vertebrates modal click on the header for SPS and on the marine tab the group header to see that they sort correctly
### Feature relevant tickets
_Link to the related task manager tickets_