### PR TITLE
Fix/navigation-bugs

### DIFF
--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -212,9 +212,14 @@ function RankingChart({
         <div className={styles.blank} />
         {Object.values(groupBy(LEGEND_ITEMS, 'category')).map(
           (categoryItems) => (
-            <div className={styles.legendCategoryContainer}>
+            <div
+              key={
+                categoryItems && categoryItems[0] && categoryItems[0].category
+              }
+              className={styles.legendCategoryContainer}
+            >
               {categoryItems.map((i) => (
-                <div className={styles.legendItem}>
+                <div key={i.legend} className={styles.legendItem}>
                   <div
                     className={styles.legendColor}
                     style={{ background: i.color }}

--- a/src/components/species-table/species-table-component.jsx
+++ b/src/components/species-table/species-table-component.jsx
@@ -34,6 +34,8 @@ function SpeciesTable({
   speciesList,
   searchTerm,
   vertebrateType,
+  loaded,
+  hasData,
 }) {
   const t = useT();
   const locale = useLocale();
@@ -127,6 +129,38 @@ function SpeciesTable({
 
   const PX_TO_TOP = 300;
   const tableHeight = height - PX_TO_TOP;
+
+  const renderTable = () => {
+    if (!loaded) {
+      return (
+        <div className={styles.loader} style={{ height: tableHeight }}>
+          <Loading />
+        </div>
+      );
+    }
+    if (!hasData) {
+      return (
+        <p className={styles.message}>
+          <T _str="No data" />
+        </p>
+      );
+    }
+    if (speciesList.length === 0) {
+      return (
+        <p className={styles.message}>
+          <T _str="No data for this search" />
+        </p>
+      );
+    }
+    return (
+      <Virtuoso
+        className={styles.rowsContainer}
+        totalCount={speciesList.length}
+        item={renderRow}
+      />
+    );
+  };
+
   return (
     <div className={styles.scrolleableArea}>
       <section className={styles.section}>
@@ -202,17 +236,7 @@ function SpeciesTable({
             ))}
           </div>
         </div>
-        {speciesList.length === 0 || !speciesList ? (
-          <div className={styles.loader} style={{ height: tableHeight }}>
-            <Loading />
-          </div>
-        ) : (
-          <Virtuoso
-            className={styles.rowsContainer}
-            totalCount={speciesList.length}
-            item={renderRow}
-          />
-        )}
+        {renderTable()}
       </div>
       <section />
     </div>

--- a/src/components/species-table/species-table-styles.module.scss
+++ b/src/components/species-table/species-table-styles.module.scss
@@ -260,3 +260,8 @@
   margin-top: 25%;
   width: 100%,
 }
+
+.message {
+  @extend %bodyText;
+  color: $white;
+}

--- a/src/components/species-table/species-table.js
+++ b/src/components/species-table/species-table.js
@@ -31,13 +31,22 @@ const mapStateToProps = (state) => ({
 });
 
 function SpeciesModalContainer(props) {
-  const { changeUI, speciesModalSort, state, countryData } = props;
+  const {
+    changeUI,
+    speciesModalSort,
+    state,
+    countryData,
+    selectedLandMarineOption,
+  } = props;
   const { marineSpeciesTotal } = countryData || {};
+  const isLandSelected = selectedLandMarineOption.slug === LAND_MARINE.land;
 
   const locale = useLocale();
   const vertebrateTabs = useMemo(() => getVertebrateTabs(), [locale]);
 
-  const [vertebrateType, setVertebrateType] = useState(vertebrateTabs[0].slug);
+  const [vertebrateType, setVertebrateType] = useState(
+    isLandSelected ? vertebrateTabs[0].slug : vertebrateTabs[1].slug
+  );
   const [loaded, setLoaded] = useState(false);
   const [hasData, setHasData] = useState(false);
   const [speciesList, setSpeciesList] = useState([]);

--- a/src/components/species-table/species-table.js
+++ b/src/components/species-table/species-table.js
@@ -38,6 +38,8 @@ function SpeciesModalContainer(props) {
   const vertebrateTabs = useMemo(() => getVertebrateTabs(), [locale]);
 
   const [vertebrateType, setVertebrateType] = useState(vertebrateTabs[0].slug);
+  const [loaded, setLoaded] = useState(false);
+  const [hasData, setHasData] = useState(false);
   const [speciesList, setSpeciesList] = useState([]);
 
   const landLayer = useFeatureLayer({ layerSlug: SPECIES_LIST });
@@ -49,6 +51,7 @@ function SpeciesModalContainer(props) {
     if (!isMarineAndEmpty && layer && state.location.payload.iso) {
       const getFeatures = async () => {
         // Set empty species so we show the loading spinner
+        setLoaded(false);
         setSpeciesList([]);
         const query = await layer.createQuery();
         query.where = `iso3 = '${state.location.payload.iso}'`;
@@ -57,6 +60,14 @@ function SpeciesModalContainer(props) {
         const { features } = results;
         if (features) {
           setSpeciesList(features.map((f) => f.attributes));
+          if (features.length) {
+            setHasData(true);
+            setLoaded(true);
+          } else {
+            setHasData(false);
+          }
+        } else {
+          setHasData(false);
         }
       };
 
@@ -92,6 +103,8 @@ function SpeciesModalContainer(props) {
       sortCategory={speciesModalSort}
       handleVertebrateChange={handleVertebrateChange}
       vertebrateType={vertebrateType}
+      loaded={loaded}
+      hasData={hasData}
     />
   );
 }

--- a/src/containers/nrc-content/nrc-content-component.jsx
+++ b/src/containers/nrc-content/nrc-content-component.jsx
@@ -33,12 +33,8 @@ import { ReactComponent as BackArrowIcon } from 'icons/back_arrow.svg';
 import { ReactComponent as DownloadIcon } from 'icons/download.svg';
 import { ReactComponent as ShareIcon } from 'icons/share.svg';
 
+import { NRCSidebar } from './nrc-content';
 import styles from './nrc-content-styles.module.scss';
-
-const NRCSidebar = {
-  main: 'main',
-  vertebrates: 'vertebrates',
-};
 
 function NrcContent({
   trendChartData,

--- a/src/containers/nrc-content/nrc-content-component.jsx
+++ b/src/containers/nrc-content/nrc-content-component.jsx
@@ -272,7 +272,7 @@ function NrcContent({
               )}
             </div>
           </header>
-          <SpeciesTable />
+          <SpeciesTable selectedLandMarineOption={selectedLandMarineOption} />
         </motion.div>
       )}
     </div>

--- a/src/containers/nrc-content/nrc-content.js
+++ b/src/containers/nrc-content/nrc-content.js
@@ -28,6 +28,11 @@ const actions = {
   downloadNrcPdfAnalytics,
 };
 
+export const NRCSidebar = {
+  main: 'main',
+  vertebrates: 'vertebrates',
+};
+
 function NrcContainer(props) {
   const {
     browsePage,
@@ -36,6 +41,7 @@ function NrcContainer(props) {
     countryId,
     changeUI,
     setNRCSidebarView,
+    NRCSidebarView,
   } = props;
 
   const locale = useLocale();
@@ -53,6 +59,11 @@ function NrcContainer(props) {
   }, []);
 
   const handleClose = () => {
+    // Close vertebrates table if its open
+    if (NRCSidebarView !== NRCSidebar.main) {
+      setNRCSidebarView(NRCSidebar.main);
+    }
+
     browsePage({ type: NATIONAL_REPORT_CARD_LANDING });
     if (onboardingType)
       changeUI({


### PR DESCRIPTION
## Navigation bugs
### Description


- __Vertebrate table default view__

From NRC globe, click on any country

Click on "All Vertebrates"

Hit the X to return to the NRC globe

Click on any country again, and get taken straight to that country's main view instead of 'All vertebrates'
 

- __Vertebrate table search bar__

Go to any country's vertebrate table

In the search bar, type a word that doesn't exist in the table 

Get a message saying that we don't have that data for that search
 

- __Marine Vertebrates__

Select any country, then click "Marine SPI"

Click "All Vertebrates"

it should show the marine vertebrate table instead of the land one

### Designs
_Link to the related design prototypes (if relevant)_
### Testing instructions
_Explain how the reviewer should test this PR (which URL should be joined, which steps should be performed...)_
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-694?atlOrigin=eyJpIjoiYjJiYWU4NWY1MjYxNDMzM2JkNTU3ZGZmOGQ2OGE5ZTMiLCJwIjoiaiJ9