### PR TITLE
(fix): mobile (2)

### DIFF
--- a/src/pages/mobile/landing-mobile/landing-mobile-styles.module.scss
+++ b/src/pages/mobile/landing-mobile/landing-mobile-styles.module.scss
@@ -1,3 +1,5 @@
+@import 'styles/settings';
+
 .container {
   position: relative;
   background-size: cover;
@@ -11,5 +13,6 @@
     position: absolute;
     right: 20px;
     top: 5px;
+    z-index: $over-front;
   }
 }

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -6,11 +6,11 @@
   bottom: auto;
 
   @media #{$mobile-only} {
-    bottom: 0;
+    bottom: 60px;
   }
 
   @media #{$mobile-landscape} {
-    bottom: 0 !important;
+    bottom: 60px !important;
   }
 }
 

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -10,7 +10,7 @@
   }
 
   @media #{$mobile-landscape} {
-    bottom: 60px !important;
+    bottom: 10px !important;
   }
 }
 


### PR DESCRIPTION
## Mobile fixes (2)

### Description

- Once the home is fully loaded, the language selector disappears and can’t be clicked. 
- At the NRC, can’t see the button to access the dashboard (reported by POCO F3)

### Testing instructions

### Feature relevant tickets
[HE-674](https://vizzuality.atlassian.net/browse/HE-674)

[HE-674]: https://vizzuality.atlassian.net/browse/HE-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ