### PR TITLE
(fix): zero cases on human modification indicator card 

### DIFF
--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -36,11 +36,7 @@ function Indicators({ countryData, landMarineSelection }) {
     hm_vh_mar,
     hm_ter,
     hm_mar,
-
-    hm_no_ter,
   } = countryData || {};
-
-  console.log({ some: hm_ter, no: hm_no_ter, vh: hm_vh_ter });
 
   const land = landMarineSelection === 'land';
   const SPI = land ? SPI_ter : SPI_mar;
@@ -53,8 +49,6 @@ function Indicators({ countryData, landMarineSelection }) {
     : protection_needed_mar;
   const hm_vh = land ? hm_vh_ter : hm_vh_mar;
   const hm = land ? hm_ter : hm_mar;
-
-  console.log({ someHM: Math.round(hm) });
 
   const isNumberOr0 = (value) => value === 0 || !!value;
   const isMobile = useMobile();
@@ -248,7 +242,7 @@ function Indicators({ countryData, landMarineSelection }) {
         </IndicatorCard>
       )}
       {/* Some human modification zero cases */}
-      {Math.round(hm) === 0 && (
+      {Math.round(hm) === 0 && Math.round(hm_vh) !== 0 && (
         <IndicatorCard
           color={COLORS['high-modification']}
           indicator={`${Math.round(hm_vh)}%`}
@@ -297,7 +291,7 @@ function Indicators({ countryData, landMarineSelection }) {
         </IndicatorCard>
       )}
       {/* Very high human modification zero cases */}
-      {Math.round(hm_vh) === 0 && (
+      {Math.round(hm_vh) === 0 && Math.round(hm) !== 0 && (
         <IndicatorCard
           color={COLORS['high-modification']}
           indicator={`${Math.round(hm)}%`}

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -189,7 +189,7 @@ function Indicators({ countryData, landMarineSelection }) {
       {Math.round(hm_vh) !== 0 && Math.round(hm) !== 0 && (
         <IndicatorCard
           color={COLORS['high-modification']}
-          indicator={`${Math.round(hm)}%`}
+          indicator={`${Math.round(hm_vh)}%`}
           description={
             <p>
               {land && (

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -302,7 +302,7 @@ function Indicators({ countryData, landMarineSelection }) {
         indicator={total_endemic_ter && getLocaleNumber(total_endemic, locale)}
         description={
           <p>
-            {nspecies &&
+            {isNumberOr0(nspecies) &&
               (land ? (
                 <T
                   _str="{bold} of a total of {totalEndemicNumber} land vertebrates"

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -190,87 +190,161 @@ function Indicators({ countryData, landMarineSelection }) {
           }}
         />
       </IndicatorCard>
-      {console.log(Math.round(hm) > 0)}
-      <IndicatorCard
-        color={COLORS['high-modification']}
-        indicator={
-          Math.round(hm_vh) > 0 ? `${Math.round(hm_vh)}%` : `${Math.round(hm)}%`
-        }
-        description={
-          <p>
-            {Math.round(hm_vh) > 0 && land && (
-              <T
-                _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                _comment="27% { of } land has {very high human modification} and 10% has some modification"
-                veryHighHumanModification={
-                  <b>
-                    <T
-                      _str="very high human modification"
-                      _comment="27% of land has {very high human modification} and 10% has some modification"
-                    />
-                  </b>
-                }
-                someModificationNumber={Math.round(hm)}
-              />
-            )}
-            {Math.round(hm_vh) > 0 && !land && (
-              <T
-                _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
-                veryHighHumanModification={
-                  <b>
-                    <T
-                      _str="very high human modification"
-                      _comment="27% of land has {very high human modification} and 10% has some modification"
-                    />
-                  </b>
-                }
-                someModificationNumber={Math.round(hm)}
-              />
-            )}
 
-            {/* Some human modification zero cases */}
-            {Math.round(hm_vh) === 0 && land && (
-              <T
-                _str="of land has {someModification}"
-                _comment="27% { of } land has {some human modification}"
-                someModification={
-                  <b>
-                    <T _str="some human modification" />
-                  </b>
-                }
-              />
-            )}
+      {/* Very high human modification and some human modification up to zero cases */}
+      {Math.round(hm_vh) !== 0 && Math.round(hm) !== 0 && (
+        <IndicatorCard
+          color={COLORS['high-modification']}
+          indicator={`${Math.round(hm)}%`}
+          description={
+            <p>
+              {land && (
+                <T
+                  _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                  _comment="27% { of } land has {very high human modification} and 10% has some modification"
+                  veryHighHumanModification={
+                    <b>
+                      <T
+                        _str="very high human modification"
+                        _comment="27% of land has {very high human modification} and 10% has some modification"
+                      />
+                    </b>
+                  }
+                  someModificationNumber={Math.round(hm)}
+                />
+              )}
+              {!land && (
+                <T
+                  _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                  _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
+                  veryHighHumanModification={
+                    <b>
+                      <T
+                        _str="very high human modification"
+                        _comment="27% of land has {very high human modification} and 10% has some modification"
+                      />
+                    </b>
+                  }
+                  someModificationNumber={Math.round(hm)}
+                />
+              )}
+            </p>
+          }
+          tooltipInfo={t(
+            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
+          )}
+        >
+          <div
+            className={styles.bar}
+            style={{
+              backgroundImage: getBarStyles({
+                color1: COLORS['high-modification'],
+                value1: hm_vh,
+                color2: COLORS['some-modification'],
+                value2: hm,
+              }),
+            }}
+          />
+        </IndicatorCard>
+      )}
+      {/* Some human modification zero cases */}
+      {Math.round(hm) === 0 && (
+        <IndicatorCard
+          color={COLORS['high-modification']}
+          indicator={`${Math.round(hm_vh)}%`}
+          description={
+            <p>
+              {land && (
+                <T
+                  _str="of land has {veryHighModification}"
+                  _comment="27% { of } land has {very high human modification}"
+                  veryHighModification={
+                    <b>
+                      <T _str="very high human modification" />
+                    </b>
+                  }
+                />
+              )}
 
-            {Math.round(hm_vh) === 0 && !land && (
-              <T
-                _str="of marine area has {someModification}"
-                _comment="27% { of } marine area has {some human modification}"
-                someModification={
-                  <b>
-                    <T _str="some human modification" />
-                  </b>
-                }
-              />
-            )}
-          </p>
-        }
-        tooltipInfo={t(
-          'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
-        )}
-      >
-        <div
-          className={styles.bar}
-          style={{
-            backgroundImage: getBarStyles({
-              color1: COLORS['high-modification'],
-              value1: hm_vh,
-              color2: COLORS['some-modification'],
-              value2: hm,
-            }),
-          }}
-        />
-      </IndicatorCard>
+              {!land && (
+                <T
+                  _str="of marine area has {veryHighModification}"
+                  _comment="27% { of } marine area has {very high human modification}"
+                  veryHighModification={
+                    <b>
+                      <T _str="very high human modification" />
+                    </b>
+                  }
+                />
+              )}
+            </p>
+          }
+          tooltipInfo={t(
+            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
+          )}
+        >
+          <div
+            className={styles.bar}
+            style={{
+              backgroundImage: getBarStyles({
+                color1: COLORS['high-modification'],
+                value1: hm_vh,
+                color2: COLORS['some-modification'],
+                value2: hm,
+              }),
+            }}
+          />
+        </IndicatorCard>
+      )}
+      {/* Very high human modification zero cases */}
+      {Math.round(hm_vh) === 0 && (
+        <IndicatorCard
+          color={COLORS['high-modification']}
+          indicator={`${Math.round(hm)}%`}
+          description={
+            <p>
+              {land && (
+                <T
+                  _str="of land has {someModification}"
+                  _comment="27% { of } land has {some human modification}"
+                  someModification={
+                    <b>
+                      <T _str="some human modification" />
+                    </b>
+                  }
+                />
+              )}
+
+              {!land && (
+                <T
+                  _str="of marine area has {someModification}"
+                  _comment="27% { of } marine area has {some human modification}"
+                  someModification={
+                    <b>
+                      <T _str="some human modification" />
+                    </b>
+                  }
+                />
+              )}
+            </p>
+          }
+          tooltipInfo={t(
+            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
+          )}
+        >
+          <div
+            className={styles.bar}
+            style={{
+              backgroundImage: getBarStyles({
+                color1: COLORS['high-modification'],
+                value1: hm_vh,
+                color2: COLORS['some-modification'],
+                value2: hm,
+              }),
+            }}
+          />
+        </IndicatorCard>
+      )}
     </div>
   );
 }

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -126,7 +126,11 @@ function Indicators({ countryData, landMarineSelection }) {
 
     return (
       <IndicatorCard
-        color={COLORS['protected-areas']}
+        color={
+          noProtectedAreas
+            ? COLORS['protection-needed']
+            : COLORS['protected-areas']
+        }
         indicator={getIndicator()}
         description={getDescription()}
         tooltipInfo={t(
@@ -149,10 +153,10 @@ function Indicators({ countryData, landMarineSelection }) {
   };
 
   const renderModificationIndicator = () => {
-    const noSomeHumanModification =
-      Math.round(hm) === 0 && Math.round(hm_vh) !== 0;
     const noVeryHighHumanModification =
       Math.round(hm_vh) === 0 && Math.round(hm) !== 0;
+    const noSomeHumanModification =
+      Math.round(hm) === 0 && Math.round(hm_vh) !== 0;
 
     const getIndicator = () => {
       if (noVeryHighHumanModification) {
@@ -243,7 +247,11 @@ function Indicators({ countryData, landMarineSelection }) {
 
     return (
       <IndicatorCard
-        color={COLORS['high-modification']}
+        color={
+          noVeryHighHumanModification
+            ? COLORS['some-modification']
+            : COLORS['high-modification']
+        }
         indicator={getIndicator()}
         description={getDescription()}
         tooltipInfo={t(

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -54,13 +54,13 @@ function Indicators({ countryData, landMarineSelection }) {
   const isMobile = useMobile();
 
   const renderProtectionIndicator = () => {
-    const protectionNeeded = prop_protected + protection_needed;
+    const protectionNeeded = Math.round(prop_protected + protection_needed);
     const noProtectedAreas =
       Math.round(prop_protected) === 0 && Math.round(protectionNeeded) !== 0;
 
     const getIndicator = () => {
       if (noProtectedAreas) {
-        return `${Math.round(protectionNeeded)}%`;
+        return `${protectionNeeded}%`;
       }
       return `${Math.round(prop_protected)}%`;
     };
@@ -142,9 +142,9 @@ function Indicators({ countryData, landMarineSelection }) {
           style={{
             backgroundImage: getBarStyles({
               color1: COLORS['protected-areas'],
-              value1: prop_protected,
+              value1: Math.round(prop_protected),
               color2: COLORS['protection-needed'],
-              value2: prop_protected + protection_needed,
+              value2: protectionNeeded,
             }),
           }}
         />

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -53,6 +53,101 @@ function Indicators({ countryData, landMarineSelection }) {
   const isNumberOr0 = (value) => value === 0 || !!value;
   const isMobile = useMobile();
 
+  const renderProtectionIndicator = () => {
+    const protectionNeeded = prop_protected + protection_needed;
+    const noProtectedAreas =
+      Math.round(prop_protected) === 0 && Math.round(protectionNeeded) !== 0;
+
+    const getIndicator = () => {
+      if (noProtectedAreas) {
+        return `${Math.round(protectionNeeded)}%`;
+      }
+      return `${Math.round(prop_protected)}%`;
+    };
+
+    const getDescription = () => {
+      const needsProtectionNumber = getLocaleNumber(protection_needed, locale);
+      if (noProtectedAreas) {
+        return (
+          <p>
+            {isNumberOr0(protection_needed) && (
+              <T
+                _str="of {areaNeedsProtection}"
+                _comment="10% (of) land needs protection"
+                areaNeedsProtection={
+                  <b>
+                    {land ? (
+                      <T
+                        _str="land needs protection"
+                        _comment="10% of {land needs protection} and 2% needs protection"
+                      />
+                    ) : (
+                      <T
+                        _str="marine area needs protection"
+                        _comment="10% of {marine area needs protection} and 2% needs protection"
+                      />
+                    )}
+                  </b>
+                }
+                needsProtectionNumber={needsProtectionNumber}
+              />
+            )}
+          </p>
+        );
+      }
+
+      return (
+        <p>
+          {isNumberOr0(protection_needed) && (
+            <T
+              _str="of {bold} and {needsProtectionNumber}% needs protection"
+              _comment="10% (of) land is protected (and) 2% (needs protection)"
+              bold={
+                <b>
+                  {land ? (
+                    <T
+                      _str="land is protected"
+                      _comment="10% of {land is protected} and 2% needs protection"
+                    />
+                  ) : (
+                    <T
+                      _str="marine area is protected"
+                      _comment="10% of {marine area is protected} and 2% needs protection"
+                    />
+                  )}
+                </b>
+              }
+              needsProtectionNumber={needsProtectionNumber}
+            />
+          )}
+        </p>
+      );
+    };
+
+    return (
+      <IndicatorCard
+        color={COLORS['protected-areas']}
+        indicator={getIndicator()}
+        description={getDescription()}
+        tooltipInfo={t(
+          'Regions that are recognized as currently being managed for long-term nature conservation. An increase of protected areas will result in an increase of the SPI, only if areas aid in achieving species protection targets.'
+        )}
+      >
+        <div
+          className={styles.bar}
+          style={{
+            backgroundImage: getBarStyles({
+              color1: COLORS['protected-areas'],
+              value1: prop_protected,
+              color2: COLORS['protection-needed'],
+              value2: prop_protected + protection_needed,
+            }),
+          }}
+        />
+      </IndicatorCard>
+    );
+  };
+
   const renderModificationIndicator = () => {
     const noSomeHumanModification =
       Math.round(hm) === 0 && Math.round(hm_vh) !== 0;
@@ -253,54 +348,8 @@ function Indicators({ countryData, landMarineSelection }) {
           }}
         />
       </IndicatorCard>
-      <IndicatorCard
-        color={COLORS['protected-areas']}
-        indicator={prop_protected && `${Math.round(prop_protected)}%`}
-        description={
-          <p>
-            {isNumberOr0(protection_needed) && (
-              <T
-                _str="of {bold} and {needsProtectionNumber}% needs protection"
-                _comment="10% (of) land is protected (and) 2% (needs protection)"
-                bold={
-                  <b>
-                    {land ? (
-                      <T
-                        _str="land is protected"
-                        _comment="10% of {land is protected} and 2% needs protection"
-                      />
-                    ) : (
-                      <T
-                        _str="marine area is protected"
-                        _comment="10% of {marine area is protected} and 2% needs protection"
-                      />
-                    )}
-                  </b>
-                }
-                needsProtectionNumber={getLocaleNumber(
-                  protection_needed,
-                  locale
-                )}
-              />
-            )}
-          </p>
-        }
-        tooltipInfo={t(
-          'Regions that are recognized as currently being managed for long-term nature conservation. An increase of protected areas will result in an increase of the SPI, only if areas aid in achieving species protection targets.'
-        )}
-      >
-        <div
-          className={styles.bar}
-          style={{
-            backgroundImage: getBarStyles({
-              color1: COLORS['protected-areas'],
-              value1: prop_protected,
-              color2: COLORS['protection-needed'],
-              value2: prop_protected + protection_needed,
-            }),
-          }}
-        />
-      </IndicatorCard>
+
+      {renderProtectionIndicator()}
       {renderModificationIndicator()}
     </div>
   );

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -53,6 +53,123 @@ function Indicators({ countryData, landMarineSelection }) {
   const isNumberOr0 = (value) => value === 0 || !!value;
   const isMobile = useMobile();
 
+  const renderModificationIndicator = () => {
+    const noSomeHumanModification =
+      Math.round(hm) === 0 && Math.round(hm_vh) !== 0;
+    const noVeryHighHumanModification =
+      Math.round(hm_vh) === 0 && Math.round(hm) !== 0;
+
+    const getIndicator = () => {
+      if (noVeryHighHumanModification) {
+        return `${Math.round(hm)}%`;
+      }
+      return `${Math.round(hm_vh)}%`;
+    };
+
+    const getDescription = () => {
+      const boldVeryHighText = (
+        <b>
+          <T
+            _str="very high human modification"
+            _comment="27% of land has {very high human modification} and 10% has some modification"
+          />
+        </b>
+      );
+      const boldSomeHumanText = (
+        <b>
+          <T _str="some human modification" />
+        </b>
+      );
+
+      if (noSomeHumanModification) {
+        return (
+          <p>
+            {land && (
+              <T
+                _str="of land has {veryHighModification}"
+                _comment="27% { of } land has {very high human modification}"
+                veryHighModification={boldVeryHighText}
+              />
+            )}
+            {!land && (
+              <T
+                _str="of marine area has {veryHighModification}"
+                _comment="27% { of } marine area has {very high human modification}"
+                veryHighModification={boldVeryHighText}
+              />
+            )}
+          </p>
+        );
+      }
+
+      if (noVeryHighHumanModification) {
+        return (
+          <p>
+            {land && (
+              <T
+                _str="of land has {someModification}"
+                _comment="27% { of } land has {some human modification}"
+                someModification={boldSomeHumanText}
+              />
+            )}
+
+            {!land && (
+              <T
+                _str="of marine area has {someModification}"
+                _comment="27% { of } marine area has {some human modification}"
+                someModification={boldSomeHumanText}
+              />
+            )}
+          </p>
+        );
+      }
+
+      return (
+        <p>
+          {land && (
+            <T
+              _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+              _comment="27% { of } land has {very high human modification} and 10% has some modification"
+              veryHighHumanModification={boldVeryHighText}
+              someModificationNumber={Math.round(hm)}
+            />
+          )}
+          {!land && (
+            <T
+              _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+              _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
+              veryHighHumanModification={boldVeryHighText}
+              someModificationNumber={Math.round(hm)}
+            />
+          )}
+        </p>
+      );
+    };
+
+    return (
+      <IndicatorCard
+        color={COLORS['high-modification']}
+        indicator={getIndicator()}
+        description={getDescription()}
+        tooltipInfo={t(
+          'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
+        )}
+      >
+        <div
+          className={styles.bar}
+          style={{
+            backgroundImage: getBarStyles({
+              color1: COLORS['high-modification'],
+              value1: hm_vh,
+              color2: COLORS['some-modification'],
+              value2: hm,
+            }),
+          }}
+        />
+      </IndicatorCard>
+    );
+  };
+
   return (
     <div
       className={cx(styles.indicatorCardsContainer, {
@@ -184,161 +301,7 @@ function Indicators({ countryData, landMarineSelection }) {
           }}
         />
       </IndicatorCard>
-
-      {/* Very high human modification and some human modification up to zero cases */}
-      {Math.round(hm_vh) !== 0 && Math.round(hm) !== 0 && (
-        <IndicatorCard
-          color={COLORS['high-modification']}
-          indicator={`${Math.round(hm_vh)}%`}
-          description={
-            <p>
-              {land && (
-                <T
-                  _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } land has {very high human modification} and 10% has some modification"
-                  veryHighHumanModification={
-                    <b>
-                      <T
-                        _str="very high human modification"
-                        _comment="27% of land has {very high human modification} and 10% has some modification"
-                      />
-                    </b>
-                  }
-                  someModificationNumber={Math.round(hm)}
-                />
-              )}
-              {!land && (
-                <T
-                  _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
-                  veryHighHumanModification={
-                    <b>
-                      <T
-                        _str="very high human modification"
-                        _comment="27% of land has {very high human modification} and 10% has some modification"
-                      />
-                    </b>
-                  }
-                  someModificationNumber={Math.round(hm)}
-                />
-              )}
-            </p>
-          }
-          tooltipInfo={t(
-            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
-          )}
-        >
-          <div
-            className={styles.bar}
-            style={{
-              backgroundImage: getBarStyles({
-                color1: COLORS['high-modification'],
-                value1: hm_vh,
-                color2: COLORS['some-modification'],
-                value2: hm,
-              }),
-            }}
-          />
-        </IndicatorCard>
-      )}
-      {/* Some human modification zero cases */}
-      {Math.round(hm) === 0 && Math.round(hm_vh) !== 0 && (
-        <IndicatorCard
-          color={COLORS['high-modification']}
-          indicator={`${Math.round(hm_vh)}%`}
-          description={
-            <p>
-              {land && (
-                <T
-                  _str="of land has {veryHighModification}"
-                  _comment="27% { of } land has {very high human modification}"
-                  veryHighModification={
-                    <b>
-                      <T _str="very high human modification" />
-                    </b>
-                  }
-                />
-              )}
-
-              {!land && (
-                <T
-                  _str="of marine area has {veryHighModification}"
-                  _comment="27% { of } marine area has {very high human modification}"
-                  veryHighModification={
-                    <b>
-                      <T _str="very high human modification" />
-                    </b>
-                  }
-                />
-              )}
-            </p>
-          }
-          tooltipInfo={t(
-            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
-          )}
-        >
-          <div
-            className={styles.bar}
-            style={{
-              backgroundImage: getBarStyles({
-                color1: COLORS['high-modification'],
-                value1: hm_vh,
-                color2: COLORS['some-modification'],
-                value2: hm,
-              }),
-            }}
-          />
-        </IndicatorCard>
-      )}
-      {/* Very high human modification zero cases */}
-      {Math.round(hm_vh) === 0 && Math.round(hm) !== 0 && (
-        <IndicatorCard
-          color={COLORS['high-modification']}
-          indicator={`${Math.round(hm)}%`}
-          description={
-            <p>
-              {land && (
-                <T
-                  _str="of land has {someModification}"
-                  _comment="27% { of } land has {some human modification}"
-                  someModification={
-                    <b>
-                      <T _str="some human modification" />
-                    </b>
-                  }
-                />
-              )}
-
-              {!land && (
-                <T
-                  _str="of marine area has {someModification}"
-                  _comment="27% { of } marine area has {some human modification}"
-                  someModification={
-                    <b>
-                      <T _str="some human modification" />
-                    </b>
-                  }
-                />
-              )}
-            </p>
-          }
-          tooltipInfo={t(
-            'How much human encroachment occurs from urbanization and other economic activities. Some species are less tolerant than others to human disturbances.'
-          )}
-        >
-          <div
-            className={styles.bar}
-            style={{
-              backgroundImage: getBarStyles({
-                color1: COLORS['high-modification'],
-                value1: hm_vh,
-                color2: COLORS['some-modification'],
-                value2: hm,
-              }),
-            }}
-          />
-        </IndicatorCard>
-      )}
+      {renderModificationIndicator()}
     </div>
   );
 }

--- a/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
+++ b/src/containers/nrc-content/nrc-indicators/nrc-indicators-component.jsx
@@ -36,7 +36,11 @@ function Indicators({ countryData, landMarineSelection }) {
     hm_vh_mar,
     hm_ter,
     hm_mar,
+
+    hm_no_ter,
   } = countryData || {};
+
+  console.log({ some: hm_ter, no: hm_no_ter, vh: hm_vh_ter });
 
   const land = landMarineSelection === 'land';
   const SPI = land ? SPI_ter : SPI_mar;
@@ -49,6 +53,8 @@ function Indicators({ countryData, landMarineSelection }) {
     : protection_needed_mar;
   const hm_vh = land ? hm_vh_ter : hm_vh_mar;
   const hm = land ? hm_ter : hm_mar;
+
+  console.log({ someHM: Math.round(hm) });
 
   const isNumberOr0 = (value) => value === 0 || !!value;
   const isMobile = useMobile();
@@ -184,41 +190,69 @@ function Indicators({ countryData, landMarineSelection }) {
           }}
         />
       </IndicatorCard>
+      {console.log(Math.round(hm) > 0)}
       <IndicatorCard
         color={COLORS['high-modification']}
-        indicator={hm_vh && `${Math.round(hm_vh)}%`}
+        indicator={
+          Math.round(hm_vh) > 0 ? `${Math.round(hm_vh)}%` : `${Math.round(hm)}%`
+        }
         description={
           <p>
-            {hm &&
-              (land ? (
-                <T
-                  _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } land has {very high human modification} and 10% has some modification"
-                  veryHighHumanModification={
-                    <b>
-                      <T
-                        _str="very high human modification"
-                        _comment="27% of land has {very high human modification} and 10% has some modification"
-                      />
-                    </b>
-                  }
-                  someModificationNumber={Math.round(hm)}
-                />
-              ) : (
-                <T
-                  _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
-                  _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
-                  veryHighHumanModification={
-                    <b>
-                      <T
-                        _str="very high human modification"
-                        _comment="27% of land has {very high human modification} and 10% has some modification"
-                      />
-                    </b>
-                  }
-                  someModificationNumber={Math.round(hm)}
-                />
-              ))}
+            {Math.round(hm_vh) > 0 && land && (
+              <T
+                _str="of land has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                _comment="27% { of } land has {very high human modification} and 10% has some modification"
+                veryHighHumanModification={
+                  <b>
+                    <T
+                      _str="very high human modification"
+                      _comment="27% of land has {very high human modification} and 10% has some modification"
+                    />
+                  </b>
+                }
+                someModificationNumber={Math.round(hm)}
+              />
+            )}
+            {Math.round(hm_vh) > 0 && !land && (
+              <T
+                _str="of marine area has {veryHighHumanModification} and {someModificationNumber}% has some modification"
+                _comment="27% { of } marine area has {very high human modification} and 10% has some modification"
+                veryHighHumanModification={
+                  <b>
+                    <T
+                      _str="very high human modification"
+                      _comment="27% of land has {very high human modification} and 10% has some modification"
+                    />
+                  </b>
+                }
+                someModificationNumber={Math.round(hm)}
+              />
+            )}
+
+            {/* Some human modification zero cases */}
+            {Math.round(hm_vh) === 0 && land && (
+              <T
+                _str="of land has {someModification}"
+                _comment="27% { of } land has {some human modification}"
+                someModification={
+                  <b>
+                    <T _str="some human modification" />
+                  </b>
+                }
+              />
+            )}
+
+            {Math.round(hm_vh) === 0 && !land && (
+              <T
+                _str="of marine area has {someModification}"
+                _comment="27% { of } marine area has {some human modification}"
+                someModification={
+                  <b>
+                    <T _str="some human modification" />
+                  </b>
+                }
+              />
+            )}
           </p>
         }
         tooltipInfo={t(


### PR DESCRIPTION
## Fix zero cases on human modification indicator card 
### Description
We should have three different cases:
A. Country has very high and some human modification level data >> should display both.
B. Country has around 0% of very high human modification level data >> should display only some modification.
C. Country has around 0% of some human modification level data >> should display only very high modification.

### Testing instructions
A. Test with Portugal
B. Test with Namibia
C. Not found an example but added just in case

### Feature relevant tickets
[HE-693](https://vizzuality.atlassian.net/browse/HE-693)

[HE-693]: https://vizzuality.atlassian.net/browse/HE-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ