### PR TITLE
(feat): under protection chart

### DIFF
--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -1,64 +1,60 @@
 import React from 'react';
 
-import STYLES from 'styles/settings';
+import {
+  RadialBar,
+  RadialBarChart,
+  ResponsiveContainer,
+  PolarAngleAxis,
+} from 'recharts';
+
+import COLORS from 'styles/settings';
 
 // import styles from './arc-chart-styles.module.scss';
 
 function ArcChartComponent({
-  color = STYLES['protected-areas'],
+  color = COLORS['protected-areas'],
   paPercentage = 30,
   strokeWidth = 8,
 }) {
-  const getStrokeDasharray = () => {
-    const strokeDasharray = `${(240 * paPercentage) / 100} 300`;
-    return strokeDasharray;
-  };
-
+  const DATA = [{ percentage: paPercentage / 10, fill: color }];
   return (
-    <div>
-      <svg
-        id="paths"
-        style={{
-          width: 270,
-          height: 150,
-          transform: 'scale(1.2)',
-          border: '1px solid red',
-        }}
+    <ResponsiveContainer width="95%" aspect={1}>
+      <RadialBarChart
+        width={243}
+        height={243}
+        data={DATA}
+        // cx={30}
+        // cy={30}
+        innerRadius={25}
+        // outerRadius={300}
+        barSize={strokeWidth}
+        startAngle={180}
+        endAngle={0}
       >
-        <path
-          d="M100 100 A 40 40 90 0 1 250 100"
-          style={{
-            fill: 'transparent',
-            fillOpacity: 1,
-            stroke: STYLES['athens-gray'],
-            strokeWidth,
-            strokeLinecap: 'round',
-          }}
+        <PolarAngleAxis
+          type="number"
+          domain={[0, 10]}
+          angleAxisId={0}
+          tick={false}
         />
-        <path
-          d="M100 100 A 40 40 90 0 1 250 100"
-          style={{
-            fill: 'transparent',
-            fillOpacity: 1,
-            stroke: color,
-            strokeDasharray: getStrokeDasharray(),
-            strokeWidth,
-            strokeLinecap: 'round',
-          }}
+        <RadialBar
+          background
+          dataKey="percentage"
+          cornerRadius={30 / 2}
+          fill={COLORS['athens-gray']}
         />
-        <text
-          x="175"
-          y="70"
-          fill="black"
-          textAnchor="middle"
-          fontSize="24px"
-          fontFamily={STYLES['font-family-serif']}
-          fontWeight="lighter"
-        >
-          {paPercentage}%
-        </text>
-      </svg>
-    </div>
+
+        {/* <text
+        x={30 / 2}
+        y={33 / 2}
+        textAnchor="middle"
+        dominantBaseline="middle"
+        className="progress-label"
+      >
+        89
+      </text> */}
+      </RadialBarChart>
+    </ResponsiveContainer>
   );
 }
 

--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import COLORS from 'styles/settings';
+import STYLES from 'styles/settings';
 
 // import styles from './arc-chart-styles.module.scss';
 
 function ArcChartComponent({
-  color = COLORS['protected-areas'],
+  color = STYLES['protected-areas'],
   paPercentage = 30,
-  strokeWidth = 10,
+  strokeWidth = 8,
 }) {
   const getStrokeDasharray = () => {
     const strokeDasharray = `${(240 * paPercentage) / 100} 300`;
@@ -16,13 +16,21 @@ function ArcChartComponent({
 
   return (
     <div>
-      <svg id="paths" style={{ width: 320, height: 150 }}>
+      <svg
+        id="paths"
+        style={{
+          width: 270,
+          height: 150,
+          transform: 'scale(1.2)',
+          border: '1px solid red',
+        }}
+      >
         <path
           d="M100 100 A 40 40 90 0 1 250 100"
           style={{
             fill: 'transparent',
             fillOpacity: 1,
-            stroke: COLORS['athens-gray'],
+            stroke: STYLES['athens-gray'],
             strokeWidth,
             strokeLinecap: 'round',
           }}
@@ -38,6 +46,17 @@ function ArcChartComponent({
             strokeLinecap: 'round',
           }}
         />
+        <text
+          x="175"
+          y="70"
+          fill="black"
+          textAnchor="middle"
+          fontSize="24px"
+          fontFamily={STYLES['font-family-serif']}
+          fontWeight="lighter"
+        >
+          {paPercentage}%
+        </text>
       </svg>
     </div>
   );

--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -7,26 +7,27 @@ import {
   PolarAngleAxis,
 } from 'recharts';
 
-import COLORS from 'styles/settings';
+import STYLES from 'styles/settings';
 
 // import styles from './arc-chart-styles.module.scss';
 
 function ArcChartComponent({
-  color = COLORS['protected-areas'],
-  paPercentage = 30,
+  color = STYLES['protected-areas'],
+  parentHeight,
+  parentWidth,
+  paPercentage,
   strokeWidth = 8,
 }) {
   const DATA = [{ percentage: paPercentage / 10, fill: color }];
   return (
-    <ResponsiveContainer width="95%" aspect={1}>
+    <ResponsiveContainer width="100%" height="100%">
       <RadialBarChart
-        width={243}
-        height={243}
+        width="100%"
+        height="100%"
         data={DATA}
-        // cx={30}
-        // cy={30}
-        innerRadius={25}
-        // outerRadius={300}
+        cy={100}
+        innerRadius={94}
+        outerRadius={180}
         barSize={strokeWidth}
         startAngle={180}
         endAngle={0}
@@ -41,18 +42,34 @@ function ArcChartComponent({
           background
           dataKey="percentage"
           cornerRadius={30 / 2}
-          fill={COLORS['athens-gray']}
+          fill={STYLES['athens-gray']}
         />
-
-        {/* <text
-        x={30 / 2}
-        y={33 / 2}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        className="progress-label"
-      >
-        89
-      </text> */}
+        {paPercentage && (
+          <>
+            <text
+              x={parentWidth / 2}
+              y={parentHeight / 2 + 28}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={45}
+              fontFamily={STYLES['font-family-serif']}
+              fontWeight="lighter"
+            >
+              {paPercentage.toFixed()}
+            </text>
+            <text
+              x={parentWidth / 2 + 14}
+              y={parentHeight / 2 + 33.5}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fontSize={24}
+              fontFamily={STYLES['font-family-serif']}
+              fontWeight="lighter"
+            >
+              %
+            </text>
+          </>
+        )}
       </RadialBarChart>
     </ResponsiveContainer>
   );

--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -7,12 +7,12 @@ import {
   PolarAngleAxis,
 } from 'recharts';
 
-import STYLES from 'styles/settings';
+import COLORS from 'styles/settings';
 
-// import styles from './arc-chart-styles.module.scss';
+import styles from './arc-chart-styles.module.scss';
 
 function ArcChartComponent({
-  color = STYLES['protected-areas'],
+  color = COLORS['protected-areas'],
   parentHeight,
   parentWidth,
   paPercentage,
@@ -42,29 +42,21 @@ function ArcChartComponent({
           background
           dataKey="percentage"
           cornerRadius={30 / 2}
-          fill={STYLES['athens-gray']}
+          fill={COLORS['athens-gray']}
         />
         {paPercentage && (
           <>
             <text
               x={parentWidth / 2}
-              y={parentHeight / 2 + 28}
-              textAnchor="middle"
-              dominantBaseline="middle"
-              fontSize={45}
-              fontFamily={STYLES['font-family-serif']}
-              fontWeight="lighter"
+              y={parentHeight / 2 + 40}
+              className={styles.label}
             >
               {paPercentage.toFixed()}
             </text>
             <text
               x={parentWidth / 2 + 14}
-              y={parentHeight / 2 + 33.5}
-              textAnchor="middle"
-              dominantBaseline="middle"
-              fontSize={24}
-              fontFamily={STYLES['font-family-serif']}
-              fontWeight="lighter"
+              y={parentHeight / 2 + 40}
+              className={styles.labelPercentage}
             >
               %
             </text>

--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import COLORS from 'styles/settings';
+
+// import styles from './arc-chart-styles.module.scss';
+
+function ArcChartComponent({
+  color = COLORS['protected-areas'],
+  paPercentage = 30,
+  strokeWidth = 10,
+}) {
+  const getStrokeDasharray = () => {
+    const strokeDasharray = `${(240 * paPercentage) / 100} 300`;
+    return strokeDasharray;
+  };
+
+  return (
+    <div>
+      <svg id="paths" style={{ width: 320, height: 150 }}>
+        <path
+          d="M100 100 A 40 40 90 0 1 250 100"
+          style={{
+            fill: 'transparent',
+            fillOpacity: 1,
+            stroke: COLORS['athens-gray'],
+            strokeWidth,
+            strokeLinecap: 'round',
+          }}
+        />
+        <path
+          d="M100 100 A 40 40 90 0 1 250 100"
+          style={{
+            fill: 'transparent',
+            fillOpacity: 1,
+            stroke: color,
+            strokeDasharray: getStrokeDasharray(),
+            strokeWidth,
+            strokeLinecap: 'round',
+          }}
+        />
+      </svg>
+    </div>
+  );
+}
+
+export default ArcChartComponent;

--- a/src/components/charts/arc-chart/arc-chart-component.jsx
+++ b/src/components/charts/arc-chart/arc-chart-component.jsx
@@ -45,22 +45,14 @@ function ArcChartComponent({
           fill={COLORS['athens-gray']}
         />
         {paPercentage && (
-          <>
-            <text
-              x={parentWidth / 2}
-              y={parentHeight / 2 + 40}
-              className={styles.label}
-            >
-              {paPercentage.toFixed()}
-            </text>
-            <text
-              x={parentWidth / 2 + 14}
-              y={parentHeight / 2 + 40}
-              className={styles.labelPercentage}
-            >
-              %
-            </text>
-          </>
+          <text
+            x={parentWidth / 2 + 6}
+            y={parentHeight / 2 + 40}
+            className={styles.label}
+          >
+            {paPercentage.toFixed()}
+            <tspan className={styles.labelPercentage}>%</tspan>
+          </text>
         )}
       </RadialBarChart>
     </ResponsiveContainer>

--- a/src/components/charts/arc-chart/arc-chart-styles.module.scss
+++ b/src/components/charts/arc-chart/arc-chart-styles.module.scss
@@ -12,5 +12,4 @@
   @extend %display2;
   font-size: 24px;
   font-weight: 100;
-  text-anchor: middle;
 }

--- a/src/components/charts/arc-chart/arc-chart-styles.module.scss
+++ b/src/components/charts/arc-chart/arc-chart-styles.module.scss
@@ -1,0 +1,16 @@
+@import 'styles/settings';
+
+.areaChart {
+  display: block;
+  position: relative;
+  margin: 0;
+}
+
+.label {
+  font-size: $font-size-xxs;
+  text-anchor: end;
+  font-family: $font-family-1;
+
+  // Readjust text. TODO: Improve positioning
+  transform: translate(18px, 0);
+}

--- a/src/components/charts/arc-chart/arc-chart-styles.module.scss
+++ b/src/components/charts/arc-chart/arc-chart-styles.module.scss
@@ -1,16 +1,1 @@
 @import 'styles/settings';
-
-.areaChart {
-  display: block;
-  position: relative;
-  margin: 0;
-}
-
-.label {
-  font-size: $font-size-xxs;
-  text-anchor: end;
-  font-family: $font-family-1;
-
-  // Readjust text. TODO: Improve positioning
-  transform: translate(18px, 0);
-}

--- a/src/components/charts/arc-chart/arc-chart-styles.module.scss
+++ b/src/components/charts/arc-chart/arc-chart-styles.module.scss
@@ -1,1 +1,16 @@
 @import 'styles/settings';
+@import 'styles/typography-extends';
+
+.label {
+  @extend %display1;
+  font-size: 45px;
+  font-weight: 100;
+  text-anchor: middle;
+}
+
+.labelPercentage {
+  @extend %display2;
+  font-size: 24px;
+  font-weight: 100;
+  text-anchor: middle;
+}

--- a/src/components/charts/arc-chart/arc-chart.js
+++ b/src/components/charts/arc-chart/arc-chart.js
@@ -1,0 +1,3 @@
+import Component from './arc-chart-component.jsx';
+
+export default Component;

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -70,6 +70,8 @@ export const {
 
 export const DEFAULT_SOURCE = ADMINISTRATIVE_BOUNDARIES;
 
+const { REACT_APP_FEATURE_AOI_CHANGES } = process.env;
+
 export const getPrecalculatedAOIOptions = () => [
   {
     title: ADMINISTRATIVE_BOUNDARIES,
@@ -145,7 +147,9 @@ export const getSidebarCardsConfig = (locale) => ({
     ),
   },
   [PROTECTION_SLUG]: {
-    title: t('Current protection status'),
+    title: REACT_APP_FEATURE_AOI_CHANGES
+      ? t('What is already protected in this area?')
+      : t('Current protection status'),
     description: ({ protectionPercentage, percentage, DESIG }) => {
       const isProtectedArea = !!DESIG;
       if (isProtectedArea) return null;

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { useT, useLocale } from '@transifex/react';
+import { T, useT, useLocale } from '@transifex/react';
 
 import ReactMarkdown from 'react-markdown/with-html';
 
@@ -21,6 +21,8 @@ import {
 import styles from './styles.module.scss';
 
 import { ReactComponent as WarningIcon } from 'icons/warning.svg';
+
+const { REACT_APP_FEATURE_AOI_CHANGES } = process.env;
 
 function SidebarCard({
   map,
@@ -45,12 +47,38 @@ function SidebarCard({
     () => getSidebarCardsConfig(locale),
     [locale]
   );
-
+  const protectedAreaChartHeight = 100;
+  const protectedAreaChartWidth = 320;
   return (
     <SidebarCardWrapper className={styles.cardWrapper}>
       <div>
         <p className={styles.title}>{cardTitle}</p>
-        <ArcChart />
+        {cardCategory === PROTECTION_SLUG && REACT_APP_FEATURE_AOI_CHANGES && (
+          <div className={styles.protectedAreaChartContainer}>
+            <div
+              style={{
+                height: protectedAreaChartHeight,
+                width: protectedAreaChartWidth,
+              }}
+            >
+              <ArcChart
+                parentHeight={protectedAreaChartHeight}
+                parentWidth={protectedAreaChartWidth}
+                paPercentage={contextualData?.protectionPercentage}
+              />
+            </div>
+            <p className={styles.protectedAreaChartLegend}>
+              <T
+                _str="Of the current area is {bold}"
+                bold={
+                  <b>
+                    <T _str="under protection" />
+                  </b>
+                }
+              />
+            </p>
+          </div>
+        )}
         {hasLegend && (
           <SidebarLegend
             legendItem={cardCategory}
@@ -68,7 +96,11 @@ function SidebarCard({
               type="rectangular"
               className={styles.fullwidthButton}
               handleClick={handleAllProtectedAreasClick}
-              label={t('ALL PROTECTED AREAS')}
+              label={
+                REACT_APP_FEATURE_AOI_CHANGES
+                  ? t('EXPLORE PROTECTED AREAS')
+                  : t('ALL PROTECTED AREAS')
+              }
             />
             <ProtectedAreasModal
               isOpen={isProtectedAreasModalOpen}

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -115,7 +115,7 @@ function SidebarCard({
           className={styles.sourceContainer}
         />
       </div>
-      {displayWarning ? (
+      {displayWarning && (
         <div className={styles.warningWrapper}>
           <WarningIcon className={styles.warning} />
           <ReactMarkdown
@@ -123,7 +123,8 @@ function SidebarCard({
             source={sidebarCardsConfig[cardCategory].warning}
           />
         </div>
-      ) : (
+      )}
+      {!displayWarning && !REACT_APP_FEATURE_AOI_CHANGES && (
         <div className={styles.togglesContainer}>
           {layers.map((layer) => (
             <LayerToggle

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -4,26 +4,20 @@ import { useT, useLocale } from '@transifex/react';
 
 import ReactMarkdown from 'react-markdown/with-html';
 
-// icons
-
-// components
 import ProtectedAreasModal from 'containers/modals/protected-areas-modal';
 import SidebarCardWrapper from 'containers/sidebars/sidebar-card-wrapper';
 import SidebarLegend from 'containers/sidebars/sidebar-legend';
 
 import Button from 'components/button';
+import ArcChart from 'components/charts/arc-chart';
 import LayerToggle from 'components/layer-toggle';
 import SourceAnnotation from 'components/source-annotation';
 
-// containers
-
-// constants
 import {
   PROTECTION_SLUG,
   getSidebarCardsConfig,
 } from 'constants/analyze-areas-constants';
 
-// styles
 import styles from './styles.module.scss';
 
 import { ReactComponent as WarningIcon } from 'icons/warning.svg';
@@ -56,6 +50,7 @@ function SidebarCard({
     <SidebarCardWrapper className={styles.cardWrapper}>
       <div>
         <p className={styles.title}>{cardTitle}</p>
+        <ArcChart />
         {hasLegend && (
           <SidebarLegend
             legendItem={cardCategory}

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
@@ -47,3 +47,12 @@
     fill: $warning;
   }
 }
+
+.protectedAreaChartContainer {
+  margin-top: 4px;
+  .protectedAreaChartLegend {
+    @extend %bodyText;
+    text-align: center;
+    margin: 6px 0 44px 0;
+  }
+}

--- a/src/containers/sidebars/aoi-sidebar/species-card-legacy/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/species-card-legacy/styles.module.scss
@@ -50,7 +50,6 @@
 
 }
 
-
 .cardWrapper {
   margin-top: $site-gutter;
 }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -240,4 +240,6 @@
     white-opacity: $white-opacity;
     athens-gray: $athens-gray;
 
+    // FONT FAMILIES
+    font-family-serif: $font-family-serif;
   }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -239,6 +239,5 @@
     white: $white;
     white-opacity: $white-opacity;
     athens-gray: $athens-gray;
-    // FONTS
-    font-family-serif: $font-family-serif;
+
   }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -223,6 +223,7 @@
   $desktop: 'screen and (min-width: #{$breakpoint-desktop})';
 
   :export {
+    // COLORS
     conifer: $conifer;
     dark-text: $dark-text;
     gold: $gold;
@@ -238,4 +239,6 @@
     white: $white;
     white-opacity: $white-opacity;
     athens-gray: $athens-gray;
+    // FONTS
+    font-family-serif: $font-family-serif;
   }


### PR DESCRIPTION
## New under protection chart on AOI sidebar.

### Description

- Arc chart to display protected percentage in new AOI summaries.
- Protected area section in AOI Sidebar.

### Designs
[Figma Protoype](https://www.figma.com/proto/2YAp3AS5lYCj2IWEAN8AJw/HE-Map---Work-in-Progress?node-id=4%3A17672&scaling=scale-down&page-id=0%3A1&starting-point-node-id=4%3A19661&show-proto-sidebar=1)

### Testing
<img width="365" alt="Screenshot 2023-02-06 at 19 07 52" src="https://user-images.githubusercontent.com/51995866/217050825-aa00e2d0-7f7c-47ec-8dfe-01475f4c4610.png">

### Feature relevant tickets
[HE-678](https://vizzuality.atlassian.net/browse/HE-678)

[HE-678]: https://vizzuality.atlassian.net/browse/HE-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ