### PR TITLE
(feat): protected attributes widget + translate human pressures chart titles

### DIFF
--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -40,6 +40,7 @@ export const LAND_HUMAN_PRESSURES_SLUG = 'land-human-pressures';
 export const MARINE_HUMAN_PRESSURES_SLUG = 'marine-human-pressures';
 export const BIODIVERSITY_SLUG = 'biodiversity';
 export const PROTECTION_SLUG = 'protected-areas';
+export const PROTECTED_ATTRIBUTES_SLUG = 'protected_attributes';
 export const SPECIES_SLUG = 'species';
 export const FUTURE_PLACES_SLUG = 'future-places';
 export const SPECIFIC_REGIONS = 'specific-regions';
@@ -168,6 +169,10 @@ export const getSidebarCardsConfig = (locale) => ({
         />
       );
     },
+    warning: null,
+  },
+  [PROTECTED_ATTRIBUTES_SLUG]: {
+    title: t('Protected Area attributes'),
     warning: null,
   },
   [LAND_HUMAN_PRESSURES_SLUG]: {

--- a/src/constants/analyze-areas-constants.js
+++ b/src/constants/analyze-areas-constants.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React from 'react';
 
 import { t } from '@transifex/native';
@@ -106,6 +107,61 @@ export const AOIS_HISTORIC =
     : AOIS_HISTORIC_PRODUCTION;
 
 const capPercentage = (percentage) => (percentage > 100 ? 100 : percentage);
+
+export const getProtectedAttribuesConfig = (contextualData) => {
+  const protectedAttributes = [
+    {
+      title: t('Designation'),
+      value: (
+        <T
+          _str="{designation}"
+          _comment="Cultural Park"
+          designation={contextualData.DESIG_E}
+        />
+      ),
+      tooltipContent: 'Lorem impsum',
+    },
+    {
+      title: t('Status'),
+      value: (
+        <T
+          _str="{status}"
+          _comment="Designated"
+          status={contextualData.STATUS}
+        />
+      ),
+      tooltipContent: 'Lorem impsum',
+    },
+    {
+      title: t('Status year'),
+      value: +contextualData.STATUS_,
+      tooltipContent: 'Lorem impsum',
+    },
+    {
+      title: t('IUCN category'),
+      value: (
+        <T
+          _str="{iucnCat}"
+          _comment="Not Reported"
+          iucnCat={contextualData.IUCN_CA}
+        />
+      ),
+      tooltipContent: 'Lorem impsum',
+    },
+    {
+      title: t('Governance'),
+      value: (
+        <T
+          _str="{governance}"
+          _comment="Federal or national ministry or agency"
+          governance={contextualData.GOV_TYP}
+        />
+      ),
+      tooltipContent: 'Lorem impsum',
+    },
+  ];
+  return protectedAttributes;
+};
 
 // Custom AOIs on the PROTECTION_SLUG rely on percentage instead of protectionPercentage
 export const getSidebarCardsConfig = (locale) => ({

--- a/src/containers/sidebars/aoi-sidebar/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/component.jsx
@@ -22,10 +22,14 @@ import {
   LAND_HUMAN_PRESSURES_SLUG,
   BIODIVERSITY_SLUG,
   PROTECTION_SLUG,
+  PROTECTED_ATTRIBUTES_SLUG,
 } from 'constants/analyze-areas-constants';
 import { getAOIBiodiversityToggles } from 'constants/biodiversity-layers-constants';
 import { getHumanPressuresLandUse } from 'constants/human-pressures';
-import { PROTECTED_AREAS_VECTOR_TILE_LAYER } from 'constants/layers-slugs';
+import {
+  WDPA_OECM_FEATURE_LAYER,
+  PROTECTED_AREAS_VECTOR_TILE_LAYER,
+} from 'constants/layers-slugs';
 import {
   MERGED_LAND_HUMAN_PRESSURES,
   ALL_TAXA_PRIORITY,
@@ -77,6 +81,7 @@ function AOISidebar({
   browsePage,
   changeUI,
   handleGlobeUpdating,
+  precalculatedLayerSlug,
   onboardingType,
   onboardingStep,
   waitingInteraction,
@@ -85,6 +90,7 @@ function AOISidebar({
   const t = useT();
   const locale = useLocale();
 
+  const isProtectedAreaAOI = precalculatedLayerSlug === WDPA_OECM_FEATURE_LAYER;
   // If we have an active area go to the analyze areas tab first
   useEffect(() => {
     if (sidebarTabActive === mapLayersTab.slug && aoiId) {
@@ -290,15 +296,30 @@ function AOISidebar({
                 layers={aoiBiodiversityToggles}
                 metadataSlug={ALL_TAXA_PRIORITY}
               />
-              <SidebarCard
-                map={map}
-                layers={WDPALayers}
-                toggleType="checkbox"
-                activeLayers={activeLayers}
-                cardCategory={PROTECTION_SLUG}
-                contextualData={contextualData}
-                metadataSlug={PROTECTED_AREAS_VECTOR_TILE_LAYER}
-              />
+              {!isProtectedAreaAOI && (
+                <SidebarCard
+                  map={map}
+                  layers={WDPALayers}
+                  toggleType="checkbox"
+                  activeLayers={activeLayers}
+                  cardCategory={PROTECTION_SLUG}
+                  contextualData={contextualData}
+                  metadataSlug={PROTECTED_AREAS_VECTOR_TILE_LAYER}
+                />
+              )}
+
+              {isProtectedAreaAOI && (
+                <SidebarCard
+                  map={map}
+                  layers={WDPALayers}
+                  toggleType="checkbox"
+                  activeLayers={activeLayers}
+                  cardCategory={PROTECTED_ATTRIBUTES_SLUG}
+                  contextualData={contextualData}
+                  metadataSlug={PROTECTED_AREAS_VECTOR_TILE_LAYER}
+                />
+              )}
+
               <SidebarCard
                 map={map}
                 toggleType="checkbox"
@@ -308,6 +329,7 @@ function AOISidebar({
                 cardCategory={LAND_HUMAN_PRESSURES_SLUG}
                 metadataSlug={MERGED_LAND_HUMAN_PRESSURES}
               />
+
               {isCustomArea && REACT_APP_FEATURE_AOI_CHANGES && (
                 <div className={styles.goalSection}>
                   <div className={styles.goalHeader}>

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -20,6 +20,7 @@ import {
   PROTECTION_SLUG,
   PROTECTED_ATTRIBUTES_SLUG,
   getSidebarCardsConfig,
+  getProtectedAttribuesConfig,
 } from 'constants/analyze-areas-constants';
 
 import COLORS from 'styles/settings';
@@ -56,6 +57,11 @@ function SidebarCard({
     [locale]
   );
 
+  const protectedAttribuesConfig = useMemo(
+    () => getProtectedAttribuesConfig(contextualData),
+    [contextualData, locale]
+  );
+
   const {
     hpAgriculture,
     hpEnergy,
@@ -63,35 +69,6 @@ function SidebarCard({
     hpTransportation,
     hpUrban,
   } = humanPressuresData || {};
-
-  const PROTECTED_ATTRIBUTES = [
-    {
-      title: 'Designation',
-      value: contextualData.DESIG_E,
-      tooltipContent: 'More info',
-    },
-    {
-      title: 'Status',
-      value: contextualData.STATUS,
-      tooltipContent: 'More info',
-    },
-    {
-      title: 'Status year',
-      // eslint-disable-next-line no-underscore-dangle
-      value: +contextualData.STATUS_,
-      tooltipContent: 'More info',
-    },
-    {
-      title: 'IUCN category',
-      value: contextualData.IUCN_CA,
-      tooltipContent: 'More info',
-    },
-    {
-      title: 'Governance',
-      value: contextualData.GOV_TYP,
-      tooltipContent: 'More info',
-    },
-  ];
 
   // !TODO: byYear data is mocked. Please, change it as possible.
   const HUMAN_PRESSURE_DATA = [
@@ -238,9 +215,9 @@ function SidebarCard({
 
         {REACT_APP_FEATURE_AOI_CHANGES &&
           cardCategory === PROTECTED_ATTRIBUTES_SLUG &&
-          contextualData && (
+          contextualData.DESIG && (
             <div className={styles.attributtesContainer}>
-              {PROTECTED_ATTRIBUTES.map((a) => (
+              {protectedAttribuesConfig.map((a) => (
                 <div className={styles.attributtesItem}>
                   <div className={styles.titleWrapper}>
                     <h6 className={styles.title}>{a.title}</h6>

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -73,7 +73,7 @@ function SidebarCard({
   // !TODO: byYear data is mocked. Please, change it as possible.
   const HUMAN_PRESSURE_DATA = [
     {
-      title: 'Agriculture',
+      title: t('Agriculture'),
       percentage: hpAgriculture,
       byYear: [
         { year: 1980, value: 12.5 },
@@ -84,7 +84,7 @@ function SidebarCard({
       ],
     },
     {
-      title: 'Energy',
+      title: t('Energy'),
       percentage: hpEnergy,
       byYear: [
         { year: 1980, value: 12.5 },
@@ -95,7 +95,7 @@ function SidebarCard({
       ],
     },
     {
-      title: 'Human Intrusion',
+      title: t('Human Intrusion'),
       percentage: hpHumanIntrusion,
       byYear: [
         { year: 1980, value: 12.5 },
@@ -106,7 +106,7 @@ function SidebarCard({
       ],
     },
     {
-      title: 'Transportation',
+      title: t('Transportation'),
       percentage: hpTransportation,
       byYear: [
         { year: 1980, value: 12.5 },
@@ -117,7 +117,7 @@ function SidebarCard({
       ],
     },
     {
-      title: 'Urban',
+      title: t('Urban'),
       percentage: hpUrban,
       byYear: [
         { year: 1980, value: 12.5 },

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { T, useT, useLocale } from '@transifex/react';
 
+import Tooltip from '@tippyjs/react';
 import ReactMarkdown from 'react-markdown/with-html';
 
 import ProtectedAreasModal from 'containers/modals/protected-areas-modal';
@@ -17,6 +18,7 @@ import SourceAnnotation from 'components/source-annotation';
 import {
   LAND_HUMAN_PRESSURES_SLUG,
   PROTECTION_SLUG,
+  PROTECTED_ATTRIBUTES_SLUG,
   getSidebarCardsConfig,
 } from 'constants/analyze-areas-constants';
 
@@ -24,6 +26,7 @@ import COLORS from 'styles/settings';
 
 import styles from './styles.module.scss';
 
+import { ReactComponent as InfoIcon } from 'icons/infoTooltip.svg';
 import { ReactComponent as WarningIcon } from 'icons/warning.svg';
 
 const { REACT_APP_FEATURE_AOI_CHANGES } = process.env;
@@ -60,6 +63,35 @@ function SidebarCard({
     hpTransportation,
     hpUrban,
   } = humanPressuresData || {};
+
+  const PROTECTED_ATTRIBUTES = [
+    {
+      title: 'Designation',
+      value: contextualData.DESIG_E,
+      tooltipContent: 'More info',
+    },
+    {
+      title: 'Status',
+      value: contextualData.STATUS,
+      tooltipContent: 'More info',
+    },
+    {
+      title: 'Status year',
+      // eslint-disable-next-line no-underscore-dangle
+      value: +contextualData.STATUS_,
+      tooltipContent: 'More info',
+    },
+    {
+      title: 'IUCN category',
+      value: contextualData.IUCN_CA,
+      tooltipContent: 'More info',
+    },
+    {
+      title: 'Governance',
+      value: contextualData.GOV_TYP,
+      tooltipContent: 'More info',
+    },
+  ];
 
   // !TODO: byYear data is mocked. Please, change it as possible.
   const HUMAN_PRESSURE_DATA = [
@@ -184,7 +216,7 @@ function SidebarCard({
             source={cardDescription}
           />
         )}
-        {cardCategory === PROTECTION_SLUG && (
+        {REACT_APP_FEATURE_AOI_CHANGES && cardCategory === PROTECTION_SLUG && (
           <div>
             <Button
               type="rectangular"
@@ -203,6 +235,36 @@ function SidebarCard({
             />
           </div>
         )}
+
+        {REACT_APP_FEATURE_AOI_CHANGES &&
+          cardCategory === PROTECTED_ATTRIBUTES_SLUG &&
+          contextualData && (
+            <div className={styles.attributtesContainer}>
+              {PROTECTED_ATTRIBUTES.map((a) => (
+                <div className={styles.attributtesItem}>
+                  <div className={styles.titleWrapper}>
+                    <h6 className={styles.title}>{a.title}</h6>
+                    <span className={styles.iconWrapper}>
+                      <Tooltip
+                        className="light"
+                        content={
+                          <div className={styles.tooltip}>
+                            {a.tooltipContent}
+                          </div>
+                        }
+                        delay={100}
+                        position="bottom"
+                      >
+                        <InfoIcon className={styles.icon} />
+                      </Tooltip>
+                    </span>
+                  </div>
+                  <p className={styles.value}>{a.value}</p>
+                </div>
+              ))}
+            </div>
+          )}
+
         {cardCategory === LAND_HUMAN_PRESSURES_SLUG &&
           REACT_APP_FEATURE_AOI_CHANGES && (
             <div className={styles.humanPressureIndicators}>

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/component.jsx
@@ -156,7 +156,7 @@ function SidebarCard({
               <p className={styles.protectedAreaChartLegend}>
                 <T
                   _str="Of the current area is {bold}"
-                  _comment="{Of the current area is} under protection"
+                  _comment="{Of the current area is"
                   bold={
                     <b>
                       <T _str="under protection" />
@@ -178,10 +178,12 @@ function SidebarCard({
             theme="light"
           />
         )}
-        <ReactMarkdown
-          className={styles.description}
-          source={cardDescription}
-        />
+        {cardDescription && (
+          <ReactMarkdown
+            className={styles.description}
+            source={cardDescription}
+          />
+        )}
         {cardCategory === PROTECTION_SLUG && (
           <div>
             <Button

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/index.js
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/index.js
@@ -96,7 +96,7 @@ function Container(props) {
   }, [locale]);
 
   useEffect(() => {
-    if (Object.keys(contextualData).length > 0) {
+    if (Object.keys(contextualData).length > 0 && !contextualData.WDPA_PID) {
       setCardDescription(getDescription(contextualData));
     }
     // Don't remove locale. Is here to recalculate the description translation

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
@@ -17,6 +17,7 @@
   text-align: center;
   margin: 0;
   padding-bottom: $site-gutter;
+  letter-spacing: 0.8px;
 }
 
 .description {

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
@@ -125,6 +125,7 @@
       font-size: 12px;
       margin: 0 0 0 38px;
       line-height: 22px;
+      text-align: right;
     }
   }
 }

--- a/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/sidebar-card-content/styles.module.scss
@@ -87,6 +87,7 @@
     }
   }
 }
+
 .protectedAreaChartContainer {
   margin-top: 4px;
   .protectedAreaChartLegend {
@@ -94,4 +95,47 @@
     text-align: center;
     margin: 6px 0 44px 0;
   }
+}
+
+.attributtesContainer {
+
+  .attributtesItem {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px dashed rgba(34, 34, 34, 0.1);
+
+    .titleWrapper {
+      align-items: center;
+      display: flex;
+
+      .title {
+        @extend %bodyText;
+        color: $oslo-gray;
+        font-size: 12px;
+        font-weight: $font-weight;
+        margin: 0 9px 0 0;
+        padding: 0;
+      }
+    }
+
+    .value {
+      @extend %bodyText;
+      font-size: 12px;
+      margin: 0 0 0 38px;
+      line-height: 22px;
+    }
+  }
+}
+
+.tooltip {
+  @extend %annotation;
+  background-color: $white;
+  border-radius: $border-radius-desktop;
+  box-shadow: $box-shadow-light-bottom-large;
+  color: $dark-text;
+  padding: 2px 6px;
+  width: 65px;
+  margin-bottom: 5px;
 }


### PR DESCRIPTION
## Add protected attributes widget to AOI protected areas sidebar + translate human pressures chart titles

### Designs
[Figma designs](https://www.figma.com/file/8lZsKUaGM6K9JOIG0orY76/HE---Design-System?node-id=385%3A15881&t=7nYs6YfpWWVOeCU4-0)

### Testing
<img width="331" alt="Screenshot 2023-02-09 at 15 28 40" src="https://user-images.githubusercontent.com/51995866/217840821-83b483fe-7579-4354-a100-ee8ef66a1968.png">

### Feature relevant tickets
[HE-709](https://vizzuality.atlassian.net/browse/HE-709)