### PR TITLE
(fix): improve protected areas AOI data loading

### DIFF
--- a/src/containers/sidebars/aoi-sidebar/component.jsx
+++ b/src/containers/sidebars/aoi-sidebar/component.jsx
@@ -185,6 +185,7 @@ function AOISidebar({
                   ) : (
                     <p className={styles.areaName}>{areaName}</p>
                   )}
+                  {!areaName && <div className={styles.loadingAreaName} />}
                   {area && (
                     <p className={styles.area}>
                       {`${area} `}
@@ -194,6 +195,7 @@ function AOISidebar({
                       </span>
                     </p>
                   )}
+                  {!area && <div className={styles.loadingArea} />}
                 </div>
                 {isEditingName ? (
                   <div className={styles.actionButtons}>
@@ -232,7 +234,8 @@ function AOISidebar({
               <div className={styles.contextualDataRow}>
                 <div className={styles.contextualIndicator} title="population">
                   <PopulationIcon />
-                  <span>{population}</span>
+                  {population && <span>{population}</span>}
+                  {!population && <div className={styles.loadingIndicator} />}
                 </div>
                 <div
                   className={styles.contextualIndicator}
@@ -243,11 +246,14 @@ function AOISidebar({
                   }`}
                 >
                   <LandCoverIcon />
-                  <span>
-                    {AOIContextualTranslations[
-                      landCover && landCover.toLowerCase()
-                    ] || landCover}
-                  </span>
+                  {landCover && (
+                    <span>
+                      {AOIContextualTranslations[
+                        landCover && landCover.toLowerCase()
+                      ] || landCover}
+                    </span>
+                  )}
+                  {!landCover && <div className={styles.loadingIndicator} />}
                 </div>
                 <div
                   className={styles.contextualIndicator}
@@ -258,11 +264,16 @@ function AOISidebar({
                   }`}
                 >
                   <ClimateRegimeIcon />
-                  <span>
-                    {AOIContextualTranslations[
-                      climateRegime && climateRegime.toLowerCase()
-                    ] || climateRegime}
-                  </span>
+                  {climateRegime && (
+                    <span>
+                      {AOIContextualTranslations[
+                        climateRegime && climateRegime.toLowerCase()
+                      ] || climateRegime}
+                    </span>
+                  )}
+                  {!climateRegime && (
+                    <div className={styles.loadingIndicator} />
+                  )}
                 </div>
               </div>
               {REACT_APP_FEATURE_AOI_CHANGES && (

--- a/src/containers/sidebars/aoi-sidebar/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/styles.module.scss
@@ -241,3 +241,26 @@ $sidebar-content-top: 180px;
     }
   }
 }
+
+.loadingAreaName {
+  background-color: $white;
+  height: 1px;
+  margin: 18px 0;
+  width: 200px;
+}
+
+.loadingArea {
+  background-color: $white;
+  opacity: 0.8;
+  height: 1px;
+  width: 100px;
+  margin: 12px 0;
+}
+
+.loadingIndicator {
+  background-color: $white;
+  height: 1px;
+  width: 50px;
+  margin: 2px 8px;
+
+}

--- a/src/containers/sidebars/aoi-sidebar/styles.module.scss
+++ b/src/containers/sidebars/aoi-sidebar/styles.module.scss
@@ -192,7 +192,6 @@ $sidebar-content-top: 180px;
   .link {
     @extend %title;
     width: 100%;
-    height: 40px;
     background-color: $white;
     color: $dark-text;
     display: flex;
@@ -200,6 +199,8 @@ $sidebar-content-top: 180px;
     justify-content: center;
     border-radius: $border-radius-desktop;
     text-decoration: none;
+    text-align: center;
+    padding: 10px 25px;
     &:hover {
       background-color: $brand-color-main;
     }


### PR DESCRIPTION
## Improve protected areas AOI data loading

### Description
Improve the loading process on protected area AOI.
Tested also with placeholders animation but it not seems to be visually harmonious.

### Testing instructions
Enter on a protected area AOI and check view when there are still not data:
<img width="365" alt="Screenshot 2023-02-09 at 18 29 15" src="https://user-images.githubusercontent.com/51995866/217892139-1e0e5876-c54a-42cc-93f3-a25b319a1404.png">

### Feature relevant tickets
[HE-710](https://vizzuality.atlassian.net/browse/HE-710)

[HE-710]: https://vizzuality.atlassian.net/browse/HE-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ