### PR TITLE
Fix/nrc-translation-feedback

### DIFF
--- a/src/components/country-entry-tooltip/country-entry-tooltip-styles.module.scss
+++ b/src/components/country-entry-tooltip/country-entry-tooltip-styles.module.scss
@@ -30,7 +30,7 @@
     font-size: $font-size-xxs;
     height: 25px;
     text-transform: capitalize;
-    width: 50px;
+    min-width: 50px;
 
     &:disabled {
       cursor: not-allowed;

--- a/src/components/ranking-chart/ranking-chart-component.jsx
+++ b/src/components/ranking-chart/ranking-chart-component.jsx
@@ -4,6 +4,8 @@ import { useT, useLocale } from '@transifex/react';
 
 import PropTypes from 'prop-types';
 
+import { getLocaleNumber } from 'utils/data-formatting-utils';
+
 import Tooltip from '@tippyjs/react';
 import cx from 'classnames';
 import camelCase from 'lodash/camelCase';
@@ -16,6 +18,7 @@ import {
   getRankingLegend,
   SORT_GROUPS_SLUGS,
 } from 'constants/country-mode-constants';
+import { getCountryNames } from 'constants/translation-constants';
 
 import { getLegendItems } from './ranking-chart-constants';
 import styles from './ranking-chart-styles.module.scss';
@@ -61,6 +64,8 @@ function RankingChart({
       tableRef.current.scroll(0, ROW_HEIGHT * selectedCountry.index - PADDING);
     }
   }, [selectedLandMarineOption]);
+
+  const countryNames = useMemo(getCountryNames, [locale]);
 
   const onScroll = () => {
     if (!hasScrolled) {
@@ -189,7 +194,7 @@ function RankingChart({
                     [styles.found]: scrollIndex === i,
                   })}
                 >
-                  {d.name}
+                  {countryNames[d.name] || d.name}
                 </span>
               </button>
               {categories.map((category) =>
@@ -198,7 +203,7 @@ function RankingChart({
                     key={category}
                     className={cx(styles.titleText, styles.spiIndex)}
                   >
-                    {d[category]}
+                    {getLocaleNumber(d[category], locale)}
                   </span>
                 ) : (
                   renderBar(category, d)

--- a/src/containers/nrc-content/nrc-challenges/nrc-challenges-component.jsx
+++ b/src/containers/nrc-content/nrc-challenges/nrc-challenges-component.jsx
@@ -160,10 +160,7 @@ function Challenges({
 
           <div className={styles.yAxisContainer}>
             <span className={styles.yAxisIndicator}>
-              <T
-                _str="{landMarineSelection} SPI"
-                landMarineSelection={land ? 'Land' : 'Marine'}
-              />
+              {land ? <T _str="Land SPI" /> : <T _str="Marine SPI" />}
             </span>
           </div>
         </div>

--- a/src/containers/nrc-content/nrc-challenges/nrc-challenges-component.jsx
+++ b/src/containers/nrc-content/nrc-challenges/nrc-challenges-component.jsx
@@ -41,6 +41,17 @@ function Challenges({
   const { description: challengesTooltipInfo } = challengesInfo;
   const land = landMarineSelection === 'land';
 
+  const CONTINENT_LABELS = {
+    africa: t('Africa'),
+    antarctica: t('Antarctica'),
+    asia: t('Asia'),
+    europe: t('Europe'),
+    'north-america': t('North America'),
+    'south-america': t('South America'),
+    oceania: t('Oceania'),
+    australia: t('Australia'),
+  };
+
   return (
     <div
       className={cx({
@@ -177,7 +188,7 @@ function Challenges({
                     }}
                   />
                   <p className={styles.legendItemLabel}>
-                    <T _str="{country}" country={c.label} />
+                    {CONTINENT_LABELS[c.slug]}
                   </p>
                 </div>
               ))}

--- a/src/containers/nrc-content/nrc-challenges/nrc-challenges-constants.js
+++ b/src/containers/nrc-content/nrc-challenges/nrc-challenges-constants.js
@@ -2,31 +2,31 @@ import COLORS from 'styles/settings';
 
 export const CONTINENTS = [
   {
-    label: 'Africa',
+    slug: 'africa',
     color: COLORS.shamrock,
   },
   {
-    label: 'Antarctica',
+    slug: 'antarctica',
     color: COLORS.conifer,
   },
   {
-    label: 'Asia',
+    slug: 'asia',
     color: COLORS['picton-blue'],
   },
   {
-    label: 'Europe',
+    slug: 'europe',
     color: COLORS.gold,
   },
   {
-    label: 'North America',
+    slug: 'north-america',
     color: COLORS['medium-purple'],
   },
   {
-    label: 'South America',
+    slug: 'south-america',
     color: COLORS['french-rose'],
   },
   {
-    label: 'Oceanía',
+    slug: 'oceania',
     color: COLORS.tango,
   },
 ];

--- a/src/containers/nrc-content/nrc-content.js
+++ b/src/containers/nrc-content/nrc-content.js
@@ -80,6 +80,9 @@ function NrcContainer(props) {
       'precalculatedLayerSlug',
       PRECALCULATED_LAYERS_SLUG.national
     );
+    if (locale) {
+      aoiUrl.searchParams.append('lang', locale);
+    }
     window.open(aoiUrl);
   };
 

--- a/src/containers/nrc-content/nrc-vertebrates/nrc-vertebrates-component.jsx
+++ b/src/containers/nrc-content/nrc-vertebrates/nrc-vertebrates-component.jsx
@@ -135,9 +135,8 @@ function NRCVertebrates({
                 <s.icon className={styles.endemicIcon} />
                 <p>
                   <T
-                    _str="{localNumber} {endemicSpecie} of {totalNumber}"
+                    _str="{endemicNumber} {endemicSpecie} of {totalNumber}"
                     endemicNumber={getLocaleNumber(s.endemic, locale)}
-                    localNumber={getLocaleNumber(s.endemic, locale)}
                     totalNumber={getLocaleNumber(s.total, locale)}
                     endemicSpecie={
                       <>

--- a/src/pages/nrc/nrc-component.jsx
+++ b/src/pages/nrc/nrc-component.jsx
@@ -64,10 +64,10 @@ function NationalReportCard({
 
   const tabsData = {
     land: {
-      text: t('Land SPI'),
+      text: t('Land', { __comment: '(Land) SPI' }),
     },
     marine: {
-      text: t('Marine SPI'),
+      text: t('Marine', { __comment: '(Marine) SPI' }),
     },
   };
 

--- a/src/pages/nrc/nrc-styles.module.scss
+++ b/src/pages/nrc/nrc-styles.module.scss
@@ -54,7 +54,7 @@
 .switchDataButtons {
   position: absolute;
   top: 14px;
-  right: 20px;
+  right: 12px;
 }
 
 .switchDataButton {


### PR DESCRIPTION
## Translation fixes
### Description
Some translation fixes:

- Translate the country on the rankings
- Localize numbers on the rankings SPI
- Translate the “SPI Land” Y-axis and  Continent legend ( and Oceania had “i” with unnecessary  tilde in English version). 

- Fix The “Ranking By” text in the country ranker overlaps the buttons or gets very close in other translations.

- Fix in NRC landing the window that appears after clicking a country - the buttons need more space for text. 

- Fix in Portuguese the translation of the vertebrates text

- Fix Missing space between value and 'vertebrados' in the ES version. (Transifex)


- Add locale if needed when clicking the AOI button  and opening in new page

### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-712?atlOrigin=eyJpIjoiY2JkNjU0MTBmMjEzNDZkYjgyNTUxM2IwZTFjZDJkMzgiLCJwIjoiaiJ9