### PR TITLE
(fix): check landscape

### DIFF
--- a/src/containers/nrc-content/nrc-vertebrates/nrc-vertebrates-styles.module.scss
+++ b/src/containers/nrc-content/nrc-vertebrates/nrc-vertebrates-styles.module.scss
@@ -29,6 +29,7 @@
 
     @media #{$tablet-only} {
       grid-template-columns: 1fr 1fr;
+      row-gap: 10px;
     }
 
     .endemicCard {
@@ -56,7 +57,7 @@
     white-space: nowrap;
 
     @media #{$tablet-only} {
-      margin-left: 0;
+      margin: 10px 0 0 0;
       align-self: center;
     }
   }
@@ -78,11 +79,8 @@
         grid-template-columns: 1fr;
         grid-gap: 10px;
         margin-bottom: 0;
-
-        button {
-          margin-left: 0;
-        }
       }
+
     }
 
     .vertebratesButton {

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -2,8 +2,6 @@
 @import 'styles/ui.module';
 @import 'styles/typography-extends';
 
-$mobile-tooltip-min-width: 94vw;
-
 .esri-popup {
   @media #{$tablet-only} {
     top: auto !important;
@@ -48,7 +46,11 @@ $mobile-tooltip-min-width: 94vw;
   background-color: $firefly;
 
   @media #{$mobile-only} {
-    min-width: $mobile-tooltip-min-width !important;
+    min-width: 94vw !important;
+    background: transparent;
+  }
+  @media #{$mobile-landscape} {
+    min-width: 340px !important;
     background: transparent;
   }
 }

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -3,23 +3,24 @@
 @import 'styles/typography-extends';
 
 .esri-popup {
-  bottom: auto;
+  @media #{$tablet-only} {
+    top: 0 !important;
+    bottom: auto !important;
+  }
 
   @media #{$mobile-only} {
-    bottom: 60px !important;
     left: 0 !important;
     width: 100%;
     display: flex;
     align-items: center;
+    bottom: auto !important;
+    top: 40% !important;
   }
 
   @media #{$mobile-landscape} {
     top: 0 !important;
     right: 0px !important;
     margin-left: 30% !important;
-  }
-  @media #{$tablet-only} {
-    bottom: auto;
   }
 }
 

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -14,7 +14,10 @@
   }
 
   @media #{$mobile-landscape} {
-    bottom: 10px !important;
+    top: 10px !important;
+    right: 0px !important;
+    margin-left: 30% !important;
+
   }
   @media #{$tablet-landscape} {
     top: 10px !important;

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -2,25 +2,26 @@
 @import 'styles/ui.module';
 @import 'styles/typography-extends';
 
+$mobile-tooltip-min-width: 94vw;
+
 .esri-popup {
   @media #{$tablet-only} {
-    top: 0 !important;
+    top: auto !important;
     bottom: auto !important;
   }
 
   @media #{$mobile-only} {
-    left: 0 !important;
-    width: 100%;
-    display: flex;
-    align-items: center;
-    bottom: auto !important;
-    top: 65% !important;
+    left: 3vw !important;
+    top: auto !important;
+    bottom: 0 !important;
+    right: 3vw !important;
   }
 
   @media #{$mobile-landscape} {
-    top: 0 !important;
-    right: 0px !important;
-    margin-left: 30% !important;
+    left: auto !important;
+    right: 4vw !important;
+    bottom: 0 !important;
+    top: auto !important;
   }
 }
 
@@ -47,7 +48,7 @@
   background-color: $firefly;
 
   @media #{$mobile-only} {
-    min-width: 94vw;
+    min-width: $mobile-tooltip-min-width !important;
     background: transparent;
   }
 }

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -14,13 +14,12 @@
   }
 
   @media #{$mobile-landscape} {
-    top: 10px !important;
+    top: 0 !important;
     right: 0px !important;
     margin-left: 30% !important;
-
   }
-  @media #{$tablet-landscape} {
-    top: 10px !important;
+  @media #{$tablet-only} {
+    bottom: auto;
   }
 }
 

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -14,7 +14,7 @@
     display: flex;
     align-items: center;
     bottom: auto !important;
-    top: 40% !important;
+    top: 65% !important;
   }
 
   @media #{$mobile-landscape} {

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -6,11 +6,18 @@
   bottom: auto;
 
   @media #{$mobile-only} {
-    bottom: 60px;
+    bottom: 60px !important;
+    left: 0 !important;
+    width: 100%;
+    display: flex;
+    align-items: center;
   }
 
   @media #{$mobile-landscape} {
     bottom: 10px !important;
+  }
+  @media #{$tablet-landscape} {
+    top: 10px !important;
   }
 }
 

--- a/src/styles/override/esri-ui.scss
+++ b/src/styles/override/esri-ui.scss
@@ -2,7 +2,6 @@
   z-index: $default-z-index;
 
   @media #{$mobile-landscape} {
-    border: 2px solid red;
     top: 0 !important;
     z-index: $over-front;
   }

--- a/src/styles/override/esri-ui.scss
+++ b/src/styles/override/esri-ui.scss
@@ -2,6 +2,7 @@
   z-index: $default-z-index;
 
   @media #{$mobile-landscape} {
+    border: 2px solid red;
     top: 0 !important;
     z-index: $over-front;
   }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -201,7 +201,7 @@
   $mobile-landscape: 'screen and (max-width: #{$breakpoint-mobile-landscape}) and (orientation:landscape)';
   $tablet-only: 'screen and (max-width: #{$breakpoint-tablet-only})';
   $tablet-portrait: 'screen and (min-width: #{$breakpoint-tablet-portrait})';
-  $tablet-landscape: 'screen and (min-width: #{$breakpoint-tablet-landscape})';
+  $tablet-landscape: 'screen and (min-width: #{$breakpoint-tablet-landscape}) and (max-width: #{$breakpoint-desktop}) and (orientation:landscape)';
   $desktop: 'screen and (min-width: #{$breakpoint-desktop})';
 
   :export {


### PR DESCRIPTION
## Check mobile & tablet landscape

### Description
It seems that the mediaqueries for tablet landscape and mobile-landscape work correctly, but there is a problem with the positioning of the country tooltip in NRC.
However, on the first render, it didn't quite fit right.

### Testing instructions
Go to NRC and select a country in map. Check how tooltip fits in landscape and portrait for tablet and mobile devices.

### Feature relevant tickets
[HE-695](https://vizzuality.atlassian.net/browse/HE-695)

[HE-695]: https://vizzuality.atlassian.net/browse/HE-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ