### PR TITLE
(fix): mobile height measures problems 

### DIFF
--- a/src/app-styles.module.scss
+++ b/src/app-styles.module.scss
@@ -10,5 +10,9 @@
   width: 100vw;
   height: 100vh;
   background-color: $app-background;
+
+  @media #{$mobile-only} {
+    height: 100svh;
+  }
 }
 

--- a/src/components/mobile-cards/mobile-cards-component.jsx
+++ b/src/components/mobile-cards/mobile-cards-component.jsx
@@ -87,7 +87,7 @@ function CardsComponent({ cardsContent, setCurrent }) {
               style={{
                 position: 'absolute',
                 width: '100%',
-                height: '100svh',
+                height: '100%',
                 x,
                 left: `${indexRange * 100}%`,
                 right: `${indexRange * 100}%`,

--- a/src/components/mobile-cards/mobile-cards-component.jsx
+++ b/src/components/mobile-cards/mobile-cards-component.jsx
@@ -87,7 +87,7 @@ function CardsComponent({ cardsContent, setCurrent }) {
               style={{
                 position: 'absolute',
                 width: '100%',
-                height: '100%',
+                height: '100svh',
                 x,
                 left: `${indexRange * 100}%`,
                 right: `${indexRange * 100}%`,
@@ -102,9 +102,11 @@ function CardsComponent({ cardsContent, setCurrent }) {
                 <div className={styles.card} draggable={false}>
                   <div>
                     <div className={styles.indicatorBg} />
-                    <p className={styles.progress}>
-                      {cardIndex + 1} / {cardsContent.length}
-                    </p>
+                    <div className={styles.progress}>
+                      <p>
+                        {cardIndex + 1} / {cardsContent.length}
+                      </p>
+                    </div>
                     <h5 className={styles.title}>
                       {cardsContent[cardIndex].title}
                     </h5>

--- a/src/components/mobile-cards/mobile-cards-styles.module.scss
+++ b/src/components/mobile-cards/mobile-cards-styles.module.scss
@@ -21,10 +21,10 @@
     }
 
   .cardPage {
-    position: relative;
-    padding-top: 10px;
-    height: 100%;
+    padding-top: 2svh;
+    height: 100svh;
     .card {
+      position: relative;
       border: 1px solid $elephant;
       color: $white;
       min-width: 94vw;
@@ -32,7 +32,7 @@
       background: rgba($navy-he, 0.5);
       display: flex;
       flex-direction: column;
-      height: 100%;
+      height: 100svh;
       justify-content: space-between;
       @include backdropBlur();
 
@@ -141,26 +141,27 @@
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;
         position: absolute;
-        height: 9px;
-        width: 34px;
-        z-index: 2;
-        top: -10px;
+        height: 3.5svh;
+        width: 38px;
+        z-index: $bring-to-front;
+        top: -2svh;
       }
     }
 
     .progress {
       @extend %bodyText;
+      align-items: center;
       border: 1px solid $elephant;
       border-radius: 2px;
       color: $white;
       display: flex;
-      height: 24px;
+      height: 3.5svh;
       justify-content: center;
       left: 16px;
       margin: 0;
       position: absolute;
-      top: -10px;
-      width: 34px;
+      top: -2svh;
+      width: 38px;
       z-index: 11;
 
       p {

--- a/src/components/mobile-cards/mobile-cards-styles.module.scss
+++ b/src/components/mobile-cards/mobile-cards-styles.module.scss
@@ -3,7 +3,7 @@
 @import 'styles/ui.module';
 
 .container {
-  bottom: 5svh;
+  bottom: 2svh;
   display: flex;
   justify-content: center;;
   height: 40svh;
@@ -13,9 +13,9 @@
   z-index: 10;
 
    @media #{$mobile-landscape} {
-      bottom: 12px;
+      bottom: 5svh;
       height: 68%;
-      right: 3%;
+      right: 4%;
       left: auto;
       width: 45vw;
     }

--- a/src/components/mobile-cards/mobile-cards-styles.module.scss
+++ b/src/components/mobile-cards/mobile-cards-styles.module.scss
@@ -22,7 +22,7 @@
 
   .cardPage {
     padding-top: 2svh;
-    height: 100svh;
+    height: 100%;
     .card {
       position: relative;
       border: 1px solid $elephant;
@@ -32,7 +32,7 @@
       background: rgba($navy-he, 0.5);
       display: flex;
       flex-direction: column;
-      height: 100svh;
+      height: 100%;
       justify-content: space-between;
       @include backdropBlur();
 

--- a/src/components/sidemenu-language-switcher/component.jsx
+++ b/src/components/sidemenu-language-switcher/component.jsx
@@ -48,7 +48,7 @@ function SideMenuLanguageSwitcher(props) {
           opacity: 0,
         }}
         animate={{
-          right: isHover ? '28px' : '-100px',
+          right: isHover ? '30px' : '-100px',
           opacity: isHover ? 1 : 0,
         }}
         transition={{

--- a/src/components/sidemenu-language-switcher/component.jsx
+++ b/src/components/sidemenu-language-switcher/component.jsx
@@ -48,7 +48,7 @@ function SideMenuLanguageSwitcher(props) {
           opacity: 0,
         }}
         animate={{
-          right: isHover ? '30px' : '-100px',
+          right: isHover ? '28px' : '-100px',
           opacity: isHover ? 1 : 0,
         }}
         transition={{

--- a/src/components/sidemenu-language-switcher/styles.module.scss
+++ b/src/components/sidemenu-language-switcher/styles.module.scss
@@ -44,7 +44,7 @@
     top: 8px;
 
     @media #{$mobile-only} {
-      top: 0.25svh;
+      top: 0.3svh;
     }
 
 

--- a/src/components/sidemenu-language-switcher/styles.module.scss
+++ b/src/components/sidemenu-language-switcher/styles.module.scss
@@ -4,7 +4,10 @@
 
 .switcher {
   display: inline-block;
-  // position: relative;
+  position: relative;
+  @media #{$mobile-only} {
+    position: static;
+  }
 
   &:hover .switcherContent {
     display: flex;

--- a/src/components/sidemenu-language-switcher/styles.module.scss
+++ b/src/components/sidemenu-language-switcher/styles.module.scss
@@ -4,7 +4,7 @@
 
 .switcher {
   display: inline-block;
-  position: relative;
+  // position: relative;
 
   &:hover .switcherContent {
     display: flex;
@@ -24,6 +24,11 @@
     transition: color 200ms ease-in;
     height: 32px;
     width: 32px;
+    @media #{$mobile-only} {
+      margin-top: 0;
+      padding-top: 0;
+      height: 7svh;
+    }
   }
 
   .switcherContent {
@@ -35,12 +40,24 @@
     right: 32px;
     top: 8px;
 
+    @media #{$mobile-only} {
+      top: 0.25svh;
+    }
+
+
     button {
       display: flex;
       color: $grey-text;
       font-size: $font-size-xs;
       text-transform: uppercase;
       padding: 5px;
+
+      @media #{$mobile-only} {
+        height: 7svh;
+        padding-top: 0;
+        display: flex;
+        align-items: center;
+      }
 
       &:hover {
         color: $white;

--- a/src/pages/mobile/landing-mobile/landing-mobile-styles.module.scss
+++ b/src/pages/mobile/landing-mobile/landing-mobile-styles.module.scss
@@ -10,9 +10,13 @@
   width: 100%;
 
   .switcherWrapper {
+    display: flex;
+    align-items: center;
     position: absolute;
+    height: 7svh;
     right: 20px;
-    top: 5px;
+    top: 0;
     z-index: $over-front;
+
   }
 }

--- a/src/styles/override/esri-component.scss
+++ b/src/styles/override/esri-component.scss
@@ -13,4 +13,8 @@
 .esri-view-root,
 .esri-view-surface {
   height: 100%;
+
+  @media #{$mobile-only} {
+    height: 100svh;
+  }
 }

--- a/src/styles/themes/scene-theme.module.scss
+++ b/src/styles/themes/scene-theme.module.scss
@@ -4,6 +4,7 @@
   width: 100%;
   height: 100%;
   position: relative;
+
   &.disabled {
     :global .esri-view-root {
       pointer-events: none;
@@ -11,6 +12,10 @@
   }
   :global .esri-ui-top-right {
     top: 58px;
+  }
+
+  @media #{$mobile-only} {
+    height: 100svh;
   }
 }
 
@@ -26,6 +31,10 @@
   :global .esri-ui-top-right {
     top: 58px;
     filter: blur($bottom-menu-blur);
+  }
+
+  @media #{$mobile-only} {
+    height: 100svh;
   }
 }
 


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes
### Description
- [x] NRC cards are cut in some mobile devices.
- [x] Indicator labels on NRC cards are not seeing correctly in some mobile devices.
- [x] Landing language switcher is not aligned in some mobile devices.
- [ ] Trend chart doesn't look right on some mobile devices: _testing in staging, the chart is displayed but not locally._

### Testing instructions
Please check mobile with devtools in different mobile devices. Anyway, errors were displayed on the physical device, so here are the prints with the bugs fixed:
![WhatsApp Image 2023-02-15 at 19 33 05](https://user-images.githubusercontent.com/51995866/219135439-4567a7e5-1c17-471f-b15e-a6bd8eaf298c.jpeg)
![WhatsApp Image 2023-02-15 at 20 46 46](https://user-images.githubusercontent.com/51995866/219136686-db3725f3-11f3-4ab6-b3e6-6a3412552d7d.jpeg)

### Feature relevant tickets
[HE-723](https://vizzuality.atlassian.net/browse/HE-723)

[HE-723]: https://vizzuality.atlassian.net/browse/HE-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ