### PR TITLE
Prevent enter key from submitting the search form

### DIFF
--- a/src/components/search-location/component.jsx
+++ b/src/components/search-location/component.jsx
@@ -127,6 +127,12 @@ function SearchLocation({
           ref={inputRef}
           onClick={handleOpenSearch}
           onFocus={handleOpenSearch}
+          onKeyDown={(e) => {
+            // Prevent enter key from submitting the form
+            if (e.key === 'Enter') {
+              e.preventDefault();
+            }
+          }}
           onChange={(e) => handleInputChange(e)}
         />
 


### PR DESCRIPTION
## Prevent reload on enter 
### Description
Enter key or arrow on mobile was submitting the form and so reloading the page. This behaviour is prevented
### Testing instructions
Go to the mobile search or the desktop NRC search and press enter. The page shouldn't reload
### Feature relevant tickets
https://vizzuality.atlassian.net/browse/HE-725?atlOrigin=eyJpIjoiYjhkNGY1OGZiN2VlNDJhN2IyMmJjZWQ5ZjYxZWYzZjEiLCJwIjoiaiJ9