### PR TITLE
(fix): globes size on landing desktop

### DIFF
--- a/src/containers/menus/globes-menu/styles.module.scss
+++ b/src/containers/menus/globes-menu/styles.module.scss
@@ -6,9 +6,9 @@
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   width: 100%;
+  margin: auto 0 0 0;
 
   @media #{$tablet-landscape} {
-    margin: auto 0 0 0;
     padding: 0 45px;
   }
   &.isMobile {


### PR DESCRIPTION
## Globes size on landing desktop

### Description
Fix the landing globes which are too big in home large screens.

### Testing instructions
Test globes size on tablet and desktop.

### Feature relevant tickets
[HE-726](https://vizzuality.atlassian.net/browse/HE-726)

[HE-726]: https://vizzuality.atlassian.net/browse/HE-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ