### PR TITLE
(fix): country tooltip button is cut on mobile landscape

### DIFF
--- a/src/components/country-entry-tooltip/country-entry-tooltip-styles.module.scss
+++ b/src/components/country-entry-tooltip/country-entry-tooltip-styles.module.scss
@@ -193,6 +193,19 @@
         line-height: 16px;
       }
     }
+
+    @media #{$mobile-landscape} {
+      padding: 10px 10% 10px 8%;
+      .infoPill {
+        padding-bottom: 4px;
+        .text {
+          font-size: 12px;
+        }
+        .numeric {
+          font-size: 12px;
+        }
+      }
+    }
   }
 
   .tooltipExplore {

--- a/src/components/mobile-cards/mobile-cards-styles.module.scss
+++ b/src/components/mobile-cards/mobile-cards-styles.module.scss
@@ -14,7 +14,7 @@
 
    @media #{$mobile-landscape} {
       bottom: 5svh;
-      height: 68%;
+      height: 68svh;
       right: 4%;
       left: auto;
       width: 45vw;

--- a/src/styles/override/esri-popup-widget.scss
+++ b/src/styles/override/esri-popup-widget.scss
@@ -18,8 +18,8 @@
   @media #{$mobile-landscape} {
     left: auto !important;
     right: 4vw !important;
-    bottom: 0 !important;
-    top: auto !important;
+    bottom: auto !important;
+    top: 0 !important;
   }
 }
 
@@ -37,6 +37,9 @@
   @media #{$mobile-only} {
     border-radius: 8px;
   }
+  @media #{$mobile-landscape} {
+    border-radius: 8px;
+  }
 }
 
 .esri-popup__main-container {
@@ -51,6 +54,7 @@
   }
   @media #{$mobile-landscape} {
     min-width: 340px !important;
+    max-height: 340px !important;
     background: transparent;
   }
 }
@@ -91,6 +95,12 @@
 
 .esri-popup--shadow {
   box-shadow: none;
+}
+
+.esri-popup__pointer {
+  @media #{$mobile-landscape} {
+    display: none;
+  }
 }
 
 .tooltip-dot {


### PR DESCRIPTION
## Reduce landscape mobile country tooltip

### Description
NRC country tooltip is cut on landscape mobile devices and not showing the link to enter into the country info, so it has been positioned on top and reducing some fonts and paddings to make it a bit smaller (only for mobile landscape).

### Testing instructions
Test it on different physical mobile devices, on landscape position, please.

### Feature relevant tickets
[HE-695](https://vizzuality.atlassian.net/browse/HE-695)