### PR TITLE
Feature/basemap performance

### DIFF
--- a/src/components/scene/scene.js
+++ b/src/components/scene/scene.js
@@ -14,8 +14,6 @@ import { useWatchUtils } from 'hooks/esri';
 import { SATELLITE_BASEMAP_LAYER } from 'constants/layers-slugs';
 import { useMobile } from 'constants/responsive';
 
-import { setBasemap } from '../../utils/layer-manager-utils';
-
 import Component from './scene-component';
 import mapStateToProps from './selectors';
 
@@ -68,7 +66,6 @@ function SceneContainer(props) {
     urlParamsUpdateDisabled,
     initialRotation,
     centerOn,
-    landcoverBasemap,
   } = props;
 
   const [map, setMap] = useState(null);
@@ -103,17 +100,6 @@ function SceneContainer(props) {
         console.error(err);
       });
   }, []);
-
-  useEffect(() => {
-    if (map) {
-      setBasemap({
-        map,
-        landcoverBasemap,
-        surfaceColor: sceneSettings.basemap.surfaceColor || '#0A212E',
-        layersArray: sceneSettings.basemap.layersArray,
-      });
-    }
-  }, [landcoverBasemap]);
 
   const mobileCustomPan = (mapView) => {
     const pointers = new Map(); // javascript map

--- a/src/components/scene/scene.js
+++ b/src/components/scene/scene.js
@@ -89,6 +89,9 @@ function SceneContainer(props) {
       .then(([Map]) => {
         const _map = new Map({
           basemap: SATELLITE_BASEMAP_LAYER,
+          ground: {
+            surfaceColor: '#070710',
+          },
         });
 
         setMap(_map);

--- a/src/components/scene/selectors.js
+++ b/src/components/scene/selectors.js
@@ -1,7 +1,6 @@
 import { createStructuredSelector } from 'reselect';
 
 import { getIsGlobesMenuPages } from 'selectors/location-selectors';
-import { getLandcoverBasemap } from 'selectors/ui-selectors';
 
 const selectCenterOn = ({ location }) =>
   (location.query && location.query.centerOn) || null;
@@ -9,5 +8,4 @@ const selectCenterOn = ({ location }) =>
 export default createStructuredSelector({
   isGlobesMenuPages: getIsGlobesMenuPages,
   centerOn: selectCenterOn,
-  landcoverBasemap: getLandcoverBasemap,
 });

--- a/src/containers/scenes/aoi-scene/config.js
+++ b/src/containers/scenes/aoi-scene/config.js
@@ -34,7 +34,6 @@ export default {
     components: [],
   },
   basemap: {
-    surfaceColor: '#070710',
     layersArray: [FIREFLY_BASEMAP_LAYER, SATELLITE_BASEMAP_LAYER],
   },
   constraints: {

--- a/src/containers/scenes/aoi-scene/index.js
+++ b/src/containers/scenes/aoi-scene/index.js
@@ -80,6 +80,7 @@ function AOIScene(props) {
     [areReptilesLoaded, areMammalsLoaded, areBirdsLoaded, areAmphibiansLoaded]
   );
 
+  const [loadedMap, setMap] = useState(null);
   const [geometry, setGeometry] = useState(null);
   const [jsonUtils, setJsonUtils] = useState(null);
   const [contextualData, setContextualData] = useState(null);
@@ -219,13 +220,19 @@ function AOIScene(props) {
 
   const handleGlobeUpdating = (updating) =>
     changeGlobe({ isGlobeUpdating: updating });
+
+  useEffect(() => {
+    if (loadedMap) {
+      setBasemap({
+        map: loadedMap,
+        landcoverBasemap,
+        layersArray: sceneSettings.basemap.layersArray,
+      });
+    }
+  }, [landcoverBasemap]);
+
   const handleMapLoad = (map, initialActiveLayers) => {
-    setBasemap({
-      map,
-      surfaceColor: sceneSettings.basemap.surfaceColor,
-      landcoverBasemap,
-      layersArray: sceneSettings.basemap.layersArray,
-    });
+    setMap(map);
     activateLayersOnLoad(map, initialActiveLayers, layersConfig);
   };
 

--- a/src/containers/scenes/aoi-scene/index.js
+++ b/src/containers/scenes/aoi-scene/index.js
@@ -225,7 +225,7 @@ function AOIScene(props) {
     if (loadedMap) {
       setBasemap({
         map: loadedMap,
-        landcoverBasemap,
+        isLandcoverBasemap: landcoverBasemap,
         layersArray: sceneSettings.basemap.layersArray,
       });
     }

--- a/src/containers/scenes/data-scene/data-scene-config.js
+++ b/src/containers/scenes/data-scene/data-scene-config.js
@@ -53,7 +53,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [FIREFLY_BASEMAP_LAYER, SATELLITE_BASEMAP_LAYER],
     },
   },

--- a/src/containers/scenes/landing-scene/landing-scene-config.js
+++ b/src/containers/scenes/landing-scene/landing-scene-config.js
@@ -12,7 +12,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [],
     },
   },

--- a/src/containers/scenes/mobile/nrc-landing-scene-mobile/scene-config.js
+++ b/src/containers/scenes/mobile/nrc-landing-scene-mobile/scene-config.js
@@ -46,7 +46,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [FIREFLY_BASEMAP_LAYER, SATELLITE_BASEMAP_LAYER],
     },
   },

--- a/src/containers/scenes/mobile/priority-scene-mobile/scene-config.js
+++ b/src/containers/scenes/mobile/priority-scene-mobile/scene-config.js
@@ -40,7 +40,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [FIREFLY_BASEMAP_LAYER, SATELLITE_BASEMAP_LAYER],
     },
   },

--- a/src/containers/scenes/nrc-landing-scene/scene-config.js
+++ b/src/containers/scenes/nrc-landing-scene/scene-config.js
@@ -45,7 +45,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [FIREFLY_BASEMAP_LAYER, SATELLITE_BASEMAP_LAYER],
     },
   },

--- a/src/pages/data-globe/index.js
+++ b/src/pages/data-globe/index.js
@@ -23,7 +23,6 @@ function DataGlobeContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: sceneSettings.basemap.layersArray,
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/pages/featured-globe/featured-globe-initial-state.js
+++ b/src/pages/featured-globe/featured-globe-initial-state.js
@@ -40,7 +40,6 @@ export default {
       components: [],
     },
     basemap: {
-      surfaceColor: '#070710',
       layersArray: [VIBRANT_BASEMAP_LAYER],
     },
   },

--- a/src/pages/featured-globe/index.js
+++ b/src/pages/featured-globe/index.js
@@ -77,7 +77,6 @@ const featuredGlobeContainer = (props) => {
   const handleMapLoad = (map, _activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: sceneSettings.basemap.layersArray,
     });
     activateLayersOnLoad(map, _activeLayers, layersConfig);

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -7,8 +7,6 @@ import { activateLayersOnLoad } from 'utils/layer-manager-utils';
 
 import { layersConfig } from 'constants/mol-layers-configs';
 
-import { setBasemap } from '../../utils/layer-manager-utils.js';
-
 import LandingComponent from './landing-component.jsx';
 import mapStateToProps from './landing-selectors';
 
@@ -19,10 +17,6 @@ function LandingContainer(props) {
   const handleGlobeUpdating = (updating) =>
     changeGlobe({ isGlobeUpdating: updating });
   const handleMapLoad = (map, activeLayers) => {
-    setBasemap({
-      map,
-      layersArray: [],
-    });
     activateLayersOnLoad(map, activeLayers, layersConfig);
   };
 

--- a/src/pages/landing/index.js
+++ b/src/pages/landing/index.js
@@ -21,7 +21,6 @@ function LandingContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: [],
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/pages/mobile/landing-mobile/index.js
+++ b/src/pages/mobile/landing-mobile/index.js
@@ -7,8 +7,6 @@ import { activateLayersOnLoad } from 'utils/layer-manager-utils';
 
 import { layersConfig } from 'constants/mol-layers-configs';
 
-import { setBasemap } from '../../../utils/layer-manager-utils.js';
-
 import LandingComponent from './landing-mobile-component.jsx';
 import mapStateToProps from './landing-mobile-selectors';
 
@@ -21,10 +19,6 @@ function LandingMobileContainer(props) {
     changeGlobe({ isGlobeUpdating: updating });
 
   const handleMapLoad = (map, activeLayers) => {
-    setBasemap({
-      map,
-      layersArray: [],
-    });
     activateLayersOnLoad(map, activeLayers, layersConfig);
   };
 

--- a/src/pages/mobile/landing-mobile/index.js
+++ b/src/pages/mobile/landing-mobile/index.js
@@ -23,7 +23,6 @@ function LandingMobileContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: [],
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/pages/mobile/nrc-landing-mobile/index.js
+++ b/src/pages/mobile/nrc-landing-mobile/index.js
@@ -22,7 +22,6 @@ function NrcLandingMobileContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: sceneSettings.basemap.layersArray,
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/pages/mobile/priority-mobile/index.js
+++ b/src/pages/mobile/priority-mobile/index.js
@@ -21,7 +21,6 @@ function PriorityMobileContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: sceneSettings.basemap.layersArray,
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/pages/nrc-landing/index.js
+++ b/src/pages/nrc-landing/index.js
@@ -23,7 +23,6 @@ function NrcLandingContainer(props) {
   const handleMapLoad = (map, activeLayers) => {
     setBasemap({
       map,
-      surfaceColor: '#070710',
       layersArray: sceneSettings.basemap.layersArray,
     });
     activateLayersOnLoad(map, activeLayers, layersConfig);

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -256,23 +256,16 @@ export const addActiveLayersToScene = (activeLayers, _layersConfig, map) => {
   }
 };
 
-export const setBasemap = async ({
-  map,
-  surfaceColor,
-  layersArray,
-  landcoverBasemap,
-}) => {
-  map.ground.surfaceColor = surfaceColor || '#070710'; // set surface color, before basemap is loaded
+export const setBasemap = async ({ map, layersArray, isLandcoverBasemap }) => {
   const baseLayers = await Promise.all(
     layersArray.map(async (layer) => createLayer(layersConfig[layer]))
   );
-
   loadModules(['esri/Basemap']).then(([Basemap]) => {
     const basemap = new Basemap({
       baseLayers,
       title: 'half-earth-basemap',
       id: 'half-earth-basemap',
-      ...(landcoverBasemap && {
+      ...(isLandcoverBasemap && {
         portalItem: {
           id: 'aa5922ee948b41e0af7544e21682abcb',
         },

--- a/src/utils/layer-manager-utils.js
+++ b/src/utils/layer-manager-utils.js
@@ -262,7 +262,7 @@ export const setBasemap = async ({
   layersArray,
   landcoverBasemap,
 }) => {
-  map.ground.surfaceColor = surfaceColor || '#0A212E'; // set surface color, before basemap is loaded
+  map.ground.surfaceColor = surfaceColor || '#070710'; // set surface color, before basemap is loaded
   const baseLayers = await Promise.all(
     layersArray.map(async (layer) => createLayer(layersConfig[layer]))
   );


### PR DESCRIPTION
## Improve basemap loading
### Description
This PR removes unneded calls to setBasemap and moves the basemap change of landcover only to the AOI scene where it belongs. Also, the surface color is set up on the map load.

After checking if the load was more performant just loading the basemap on map load without calling setBasemap I found out that it's actually worse in most of the times. This is because we have to wait to create all the layers to add a new custom basemap as most of the basemaps are composite or not default. The unnecessary calls to setBasemap were removed like on the landing pages.

### Testing instructions
Open the different pages and see how the maps are loaded. The change is not very noticeable.