### PR TITLE
remove layers on clear selection button click

### DIFF
--- a/src/constants/analyze-areas-constants.jsx
+++ b/src/constants/analyze-areas-constants.jsx
@@ -41,6 +41,7 @@ export const PROTECTED_ATTRIBUTES_SLUG = 'protected_attributes';
 export const SPECIES_SLUG = 'species';
 export const FUTURE_PLACES_SLUG = 'future-places';
 export const SPECIFIC_REGIONS = 'specific-regions';
+export const CLEAR_SELECTIONS = 'clear-selections';
 
 export const ADDITIONAL_PROTECTION_SLUG = 'additional-protection';
 
@@ -92,6 +93,10 @@ export const getPrecalculatedAOIOptions = () => [
     title: FUTURE_PLACES,
     slug: FUTURE_PLACES,
     label: t('Places for a Half-Earth Future'),
+  },
+  {
+    title: CLEAR_SELECTIONS,
+    slug: CLEAR_SELECTIONS,
   },
 ];
 

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
@@ -17,6 +17,7 @@ import ShapeFileUploader from 'components/shape-file-uploader';
 import {
   getPrecalculatedAOIOptions,
   HIGHER_AREA_SIZE_LIMIT,
+  CLEAR_SELECTIONS,
 } from 'constants/analyze-areas-constants';
 import { SEARCH_TYPES } from 'constants/search-location-constants';
 
@@ -66,6 +67,14 @@ function AnalyzeAreasCardComponent({
       aoiHistoryModalOpenAnalytics();
     }
     setAoiHistoryModalOpen(!isAoiHistoryModalOpen);
+  };
+
+  const clearFilters = () => {
+    handleOptionSelection({
+      slug: CLEAR_SELECTIONS,
+      label: CLEAR_SELECTIONS,
+      title: CLEAR_SELECTIONS,
+    });
   };
 
   return (
@@ -125,16 +134,25 @@ function AnalyzeAreasCardComponent({
                 className={styles.radioContainer}
                 key={`radio-container-${option.slug}`}
               >
-                <RadioButton
-                  id={option.slug}
-                  option={{ ...option, name: option.label }}
-                  checked={selectedOption?.slug === option.slug}
-                  onChange={() => handleOptionSelection(option)}
-                  theme={radioTheme}
-                />
+                {option.slug !== CLEAR_SELECTIONS && (
+                  <RadioButton
+                    id={option.slug}
+                    option={{ ...option, name: option.label }}
+                    checked={selectedOption?.slug === option.slug}
+                    onChange={() => handleOptionSelection(option)}
+                    theme={radioTheme}
+                  />
+                )}
               </div>
             );
           })}
+          <button
+            type="button"
+            className={styles.clearFilters}
+            onClick={clearFilters}
+          >
+            clear selections
+          </button>
         </div>
       )}
       {selectedAnalysisTab === 'search' && (

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -23,6 +23,7 @@ import { useSketchWidget } from 'hooks/esri';
 
 import {
   getPrecalculatedAOIOptions,
+  CLEAR_SELECTIONS,
   HIGHER_AREA_SIZE_LIMIT,
 } from 'constants/analyze-areas-constants';
 import {
@@ -218,10 +219,21 @@ function AnalyzeAreasContainer(props) {
           ? LAYERS_CATEGORIES.PROTECTION
           : undefined;
 
-      let layersToToggle = [
-        { layerId: formerSelectedSlug },
-        { layerId: newSelectedOption, category: newLayerCategory },
-      ];
+      let layersToToggle = [];
+      layersToToggle.push({ layerId: formerSelectedSlug });
+      if (
+        newSelectedOption !== CLEAR_SELECTIONS &&
+        formerSelectedSlug !== undefined
+      ) {
+        layersToToggle.push({
+          layerId: newSelectedOption,
+          category: newLayerCategory,
+        });
+      } else {
+        layersToToggle = activeLayers.map((l) => ({
+          layerId: l.title,
+        }));
+      }
 
       if (protectedAreasSelected) {
         const additionalProtectedAreasLayers = [
@@ -236,21 +248,6 @@ function AnalyzeAreasContainer(props) {
             });
           }
         });
-      }
-
-      // Never toggle (remove) future places layer if its active
-      // Future places layer will be activated if we select it at some point
-      // and never toggled unless we do it from the protection checkbox
-      const futureLayerIsActive = activeLayers.some(
-        (l) => l.title === HALF_EARTH_FUTURE_TILE_LAYER
-      );
-      if (
-        futureLayerIsActive &&
-        layersToToggle.some((l) => l.layerId === HALF_EARTH_FUTURE_TILE_LAYER)
-      ) {
-        layersToToggle = layersToToggle.filter(
-          (l) => l.layerId !== HALF_EARTH_FUTURE_TILE_LAYER
-        );
       }
 
       return layersToToggle;


### PR DESCRIPTION
## Add the functionality to remove layers from the Analyze Area tab
### Description
Added a button under the list of radio buttons for assigning layers in the Analyze Area tab, that when clicked, deselected any selected options and remove layers from the globe.

### Testing instructions
Go to Explore Data -> Analyze Area
Click Protected Areas option
Click Places for a Half-Earth Future option
Click Clear Selections button
Verify layers are removed

Click Administrative Boundaries option
Click Places for a Half-Earth Future option
Click Clear Selections button
Verify layers are removed