### PR TITLE
Fix hide of Click options layers

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/component.jsx
@@ -139,7 +139,11 @@ function AnalyzeAreasCardComponent({
                     id={option.slug}
                     option={{ ...option, name: option.label }}
                     checked={selectedOption?.slug === option.slug}
-                    onChange={() => handleOptionSelection(option)}
+                    onChange={() => {
+                      if (selectedOption?.slug !== option.slug) {
+                        handleOptionSelection(option);
+                      }
+                    }}
                     theme={radioTheme}
                   />
                 )}

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -31,6 +31,7 @@ import {
   COMMUNITY_AREAS_VECTOR_TILE_LAYER,
   WDPA_OECM_FEATURE_LAYER,
   HALF_EARTH_FUTURE_TILE_LAYER,
+  GRAPHIC_LAYER,
 } from 'constants/layers-slugs';
 import { LAYERS_CATEGORIES } from 'constants/mol-layers-configs';
 
@@ -234,6 +235,12 @@ function AnalyzeAreasContainer(props) {
         layersToToggle = activeLayers.map((l) => ({
           layerId: l.title,
         }));
+      }
+
+      if (formerSelectedSlug === CLEAR_SELECTIONS) {
+        layersToToggle.push({
+          layerId: GRAPHIC_LAYER,
+        });
       }
 
       if (protectedAreasSelected) {

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -223,7 +223,8 @@ function AnalyzeAreasContainer(props) {
       layersToToggle.push({ layerId: formerSelectedSlug });
       if (
         newSelectedOption !== CLEAR_SELECTIONS &&
-        formerSelectedSlug !== undefined
+        (formerSelectedSlug !== undefined ||
+          formerSelectedSlug !== CLEAR_SELECTIONS)
       ) {
         layersToToggle.push({
           layerId: newSelectedOption,
@@ -254,6 +255,7 @@ function AnalyzeAreasContainer(props) {
     };
 
     const layersToToggle = getLayersToToggle();
+
     const categories = layersToToggle.reduce((acc, layer) => {
       acc[layer.layerId] = layer.category;
       return acc;
@@ -274,10 +276,6 @@ function AnalyzeAreasContainer(props) {
     } else if (sketchTool) {
       setSketchWidgetMode('create'); // Maybe it was in edit mode
       handleSketchToolDestroy();
-    }
-
-    if (selectedTab === 'click') {
-      handleLayerToggle(precalculatedAOIOptions[0]);
     }
   };
 


### PR DESCRIPTION
## Display click layers when switching back to Click option in Analyze Area on Data Globe
### Description
Currently when switching from Click to another option and back, the last selected option is deselected. This fix will keep that option active when going back to Click tab
### Testing instructions
Access the Analyze Area tab for the Data globe. Choose "Search" selection type and then select "Click" selection type. You will noticed that the regions are still able to be highlighted and clicked on
