### PR TITLE
Fix/nrc crash

### DIFF
--- a/src/constants/layers-urls.js
+++ b/src/constants/layers-urls.js
@@ -130,7 +130,7 @@ const isNotProduction =
   REACT_APP_VERCEL_ENV === 'development' || REACT_APP_VERCEL_ENV === 'preview';
 
 const COUNTRIES_DATA_URL =
-  'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/NRC_final_20240507/FeatureServer';
+  'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/NRC_final_20240315/FeatureServer';
 
 const EEZ_MARINE_BORDERS_URL =
   'https://services9.arcgis.com/IkktFdUAcY3WrH25/arcgis/rest/services/Country_boundaries_with_EEZ/FeatureServer';

--- a/src/containers/nrc-content/nrc-challenges/nrc-challenges-selectors.js
+++ b/src/containers/nrc-content/nrc-challenges/nrc-challenges-selectors.js
@@ -98,12 +98,24 @@ const getSelectedFilterSlug = createSelector(
 const getSelectedCountryRelations = createSelector(
   [selectCountriesData, selectCountryIso, getLandMarineSelected],
   (countriesData, selectedCountryIso, landMarineSelection) => {
-    if (!countriesData || !selectedCountryIso) return null;
-    return JSON.parse(
-      countriesData[selectedCountryIso][
-        `filter_${LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection].similar}`
-      ]
-    );
+    if (
+      !countriesData ||
+      !selectedCountryIso ||
+      !countriesData[selectedCountryIso]
+    ) {
+      return null;
+    }
+    let countryRelations = null;
+    try {
+      countryRelations = JSON.parse(
+        countriesData[selectedCountryIso][
+          `filter_${LAND_MARINE_COUNTRY_ATTRIBUTES[landMarineSelection].similar}`
+        ]
+      );
+    } catch (e) {
+      console.error('Error parsing countries data', e);
+    }
+    return countryRelations;
   }
 );
 
@@ -127,7 +139,7 @@ const getFilteredData = createSelector(
     getCountryChallengesSelectedKey,
   ],
   (plotRawData, selectedFilter, selectedCountryRelations, selectedKey) => {
-    if (!plotRawData) return null;
+    if (!plotRawData || !selectedCountryRelations) return null;
     if (!selectedFilter || selectedFilter === 'all') return plotRawData;
     const relatedCountries = selectedCountryRelations[selectedFilter];
     const hasNotNullXValue = (country) =>


### PR DESCRIPTION
This PR creates some guards for selectedCountryRelations on the NRC page also reverts the COUNTRIES_DATA_URL change. The filter_similar_ter attribute contained a invalid JSON.