### PR TITLE
Set the active layer option in dropdown

### DIFF
--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card.js
@@ -22,7 +22,6 @@ import {
   MARINE,
   DEFAULT_RESOLUTIONS,
 } from 'constants/biodiversity-layers-constants';
-import { ALL_TAXA_PRIORITY } from 'constants/layers-slugs';
 import { LAYERS_CATEGORIES } from 'constants/mol-layers-configs';
 
 import Component from './biodiversity-sidebar-card-component';
@@ -41,7 +40,9 @@ function BiodiversitySidebarCard(props) {
     [RICHNESS]: {},
     [RARITY]: {},
   });
-  const [selectedLayer, setSelectedLayer] = useState(ALL_TAXA_PRIORITY);
+  const [selectedLayer, setSelectedLayer] = useState(
+    activeLayers[activeLayers.length - 1].title
+  );
 
   const [showCard, setShowCard] = useState(true);
   const resolutionOptions = useMemo(() => getResolutionOptions(), [locale]);


### PR DESCRIPTION
## Dataglobe -> Biodiversity layer dropdowns to be default to active layer from URL

### Description
When loading Dataglobe from URL with an active layer in the URL, the dropdown option is not correctly selected.


### Testing instructions
Choose a layer option, refresh page or paste URL into new browser tab and verify that layer option is selected in dropdown

### Feature relevant tickets
_Link to the related task manager tickets_