### PR TITLE
Fix Map layers tab when we have cleared the analysis selection

### DIFF
--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card.js
@@ -41,7 +41,7 @@ function BiodiversitySidebarCard(props) {
     [RARITY]: {},
   });
   const [selectedLayer, setSelectedLayer] = useState(
-    activeLayers[activeLayers.length - 1].title
+    activeLayers?.[activeLayers.length - 1]?.title
   );
 
   const [showCard, setShowCard] = useState(true);


### PR DESCRIPTION
## Fix map layers crash

### Description
Fix a crash on the aplication when selecting map layers after clearing the analysis selection

### Testing instructions
- Go to the data globe map
- Select analyze areas tab
- Click on clear selection button
- Go to the map layers tab
The app shouldn't crash