### PR TITLE
Fix stewardship typo in NRC

### DIFF
--- a/src/components/species-table/species-table-component.jsx
+++ b/src/components/species-table/species-table-component.jsx
@@ -58,7 +58,7 @@ function SpeciesTable({
   };
 
   const renderRow = (index) => {
-    const { species, speciesgroup, NSPS, percentprotected, stewawrdship } =
+    const { species, speciesgroup, NSPS, percentprotected, stewardship } =
       speciesList[index];
 
     const isOpened = expandedRow === index;
@@ -95,15 +95,15 @@ function SpeciesTable({
               <div className={styles.tableItem}>{NSPS}</div>
               <div
                 className={cx(styles.tableItem, {
-                  [styles.bold]: stewawrdship === 1,
+                  [styles.bold]: stewardship === 1,
                 })}
               >
-                {stewawrdship === 1 ? (
+                {stewardship === 1 ? (
                   t('Endemic')
                 ) : (
                   <T
                     _str="{stewardship} countries"
-                    stewardship={stewawrdship}
+                    stewardship={stewardship}
                   />
                 )}
               </div>

--- a/src/components/species-table/species-table-selectors.js
+++ b/src/components/species-table/species-table-selectors.js
@@ -61,7 +61,7 @@ export const getSortedSpeciesList = createSelector(
       speciesModalSort && speciesModalSort.split('-')[0].toLowerCase();
 
     if (sortedCategory === 'stewardship') {
-      sortedCategory = 'stewawrdship';
+      sortedCategory = 'stewardship';
     }
 
     const direction = speciesModalSort && speciesModalSort.split('-')[1];


### PR DESCRIPTION
## Fix stewardship typo in NRC
### Description
On the All vertebrates tab the stewardship numbers were not showing as it was misspelled on the frontend.
### Testing instructions
- Go to any NRC country page: http://localhost:3000/nrc/ECU

- Click on the 'All vertebrates button'

Stewardship numbers should appear correctly for land and marine species
