### PR TITLE
Fixes for recent arcgis 4.30 and react 17 update

### DIFF
--- a/src/store/redux-modules/aois-geometries/index.js
+++ b/src/store/redux-modules/aois-geometries/index.js
@@ -1,10 +1,7 @@
-import reducerRegistry from 'reducerRegistry';
-
 import * as actions from './actions';
 import reducers, { initialState } from './reducers';
 
-const reduxConfig = { actions, reducers, initialState };
+export const reduxConfig = { actions, reducers, initialState };
 
-reducerRegistry.registerModule('aoisGeometries', reduxConfig);
 
 export default actions;

--- a/src/store/redux-modules/metadata/metadata.js
+++ b/src/store/redux-modules/metadata/metadata.js
@@ -1,10 +1,6 @@
-import reducerRegistry from 'reducerRegistry';
-
 import * as actions from './metadata-actions';
 import reducers, { initialState } from './metadata-reducers';
 
 export const reduxConfig = { actions, reducers, initialState };
-
-reducerRegistry.registerModule('metadata', reduxConfig);
 
 export default actions;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -10,6 +10,9 @@ import  { reduxConfig as countryDataReduxConfig } from 'store/redux-modules/coun
 import  { reduxConfig as uiReduxConfig } from 'store/redux-modules/ui'
 import  { reduxConfig as featureMapsListReduxConfig } from 'store/redux-modules/featured-maps-list/featured-maps-list'
 import  { reduxConfig as featuredMapPlacesReduxConfig } from 'store/redux-modules/featured-map-places/featured-map-places'
+import { reduxConfig as AOIsGeometriesReduxConfig } from 'store/redux-modules/aois-geometries';
+import { reduxConfig as metadataReduxConfig } from 'store/redux-modules/metadata/metadata';
+
 import router from '../router';
 
 import reducerRegistry from './reducerRegistry';
@@ -26,6 +29,8 @@ reducerRegistry.registerModule('countryData', countryDataReduxConfig);
 reducerRegistry.registerModule('ui', uiReduxConfig);
 reducerRegistry.registerModule('featuredMapsList', featureMapsListReduxConfig);
 reducerRegistry.registerModule('featuredMapPlaces', featuredMapPlacesReduxConfig);
+reducerRegistry.registerModule('aoisGeometries', AOIsGeometriesReduxConfig);
+reducerRegistry.registerModule('metadata', metadataReduxConfig);
 
 const initialReducers = combineReducers(reducerRegistry.getReducers());
 


### PR DESCRIPTION
## Fixes for recent arcgis 4.30 and react 17 update
### Description
- [ ] - Drawing mode empty on the final step
- [ ] - Custom AOI empty after drawing
- [ ] - Landcover layer
- [X] - AOI link from NRC not working (displaying blank screen)