### PR TITLE
Radio-selection-update

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -232,11 +232,13 @@ function AnalyzeAreasContainer(props) {
           layerId: newSelectedOption,
           category: newLayerCategory,
         });
-      } else {
-        layersToToggle = activeLayers.map((l) => ({
-          layerId: l.title,
-        }));
       }
+      // else {
+
+        // layersToToggle = activeLayers.map((l) => ({
+        //   layerId: l.title,
+        // }));
+      // }
 
       if (formerSelectedSlug === CLEAR_SELECTIONS) {
         layersToToggle.push({

--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -233,12 +233,6 @@ function AnalyzeAreasContainer(props) {
           category: newLayerCategory,
         });
       }
-      // else {
-
-        // layersToToggle = activeLayers.map((l) => ({
-        //   layerId: l.title,
-        // }));
-      // }
 
       if (formerSelectedSlug === CLEAR_SELECTIONS) {
         layersToToggle.push({

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
@@ -100,7 +100,7 @@ export const useSelectLayersOnTabOrResolutionChange = ({
       // select matching layer on selected variant
       handleLayerToggle(hasMatchingLayer);
     } else if(hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
-      handleLayerToggle(availableLayers[0]);
+      handleLayerToggle(hasMatchingLayer);
     } else if(!hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
       if(availableLayers){
         handleLayerToggle(availableLayers[0]);

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
@@ -4,7 +4,7 @@ import {
   TERRESTRIAL_GLOBAL,
   TERRESTRIAL_REGIONAL,
   MARINE,
-  // DEFAULT_RESOLUTIONS,
+  DEFAULT_RESOLUTIONS,
 } from 'constants/biodiversity-layers-constants';
 import { LAYERS_CATEGORIES } from 'constants/mol-layers-configs';
 
@@ -77,10 +77,10 @@ export const useSelectLayersOnTabOrResolutionChange = ({
       .filter((l) => l.category === LAYERS_CATEGORIES.BIODIVERSITY)
       .map((l) => l.title);
     const resolution = selectedResolutions[currentResolutionGroup];
-    // const defaultResolutionLayers =
-    //   layersToggleConfig[biodiversityLayerVariant][currentResolutionGroup][
-    //     DEFAULT_RESOLUTIONS[currentResolutionGroup]
-    //   ];
+    const defaultResolutionLayers =
+      layersToggleConfig[biodiversityLayerVariant][currentResolutionGroup][
+        DEFAULT_RESOLUTIONS[currentResolutionGroup]
+      ];
     const availableLayers =
       layersToggleConfig[biodiversityLayerVariant][currentResolutionGroup][
         resolution
@@ -100,9 +100,13 @@ export const useSelectLayersOnTabOrResolutionChange = ({
       // select matching layer on selected variant
       handleLayerToggle(hasMatchingLayer);
     } else if(hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
-      handleLayerToggle(hasMatchingLayer)
+      handleLayerToggle(hasMatchingLayer);
     } else if(!hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
-      handleLayerToggle(availableLayers[0])
+      if(availableLayers){
+        handleLayerToggle(availableLayers[0]);
+      } else {
+        handleLayerToggle(defaultResolutionLayers[0]);
+      }
     }
   }, [
     biodiversityLayerVariant,

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
@@ -99,15 +99,11 @@ export const useSelectLayersOnTabOrResolutionChange = ({
     if (hasMatchingLayer && selectedCategory === category) {
       // select matching layer on selected variant
       handleLayerToggle(hasMatchingLayer);
+    } else if(hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
+      handleLayerToggle(hasMatchingLayer)
+    } else if(!hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
+      handleLayerToggle(availableLayers[0])
     }
-    // else if (availableLayers && layerTaxa !== 'all') {
-    //   // select first element if there's no matching layer
-    //   handleLayerToggle(availableLayers[0]);
-    // }
-    // else {
-    //   // select first element if there's no maching resolution
-    //   handleLayerToggle(defaultResolutionLayers[0]);
-    // }
   }, [
     biodiversityLayerVariant,
     selectedResolutions,

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
@@ -15,6 +15,7 @@ export const useSelectLayersOnTabOrResolutionChange = ({
   previousSelectedResolutions,
   layersToggleConfig,
   category,
+  selectedCategory,
   isChecked,
   allActiveLayerTitles,
   activeLayers,
@@ -95,13 +96,14 @@ export const useSelectLayersOnTabOrResolutionChange = ({
       availableLayers &&
       availableLayers.find((layer) => layer.value.includes(layerTaxa));
 
-    if (hasMatchingLayer) {
+    if (hasMatchingLayer && selectedCategory === category) {
       // select matching layer on selected variant
       handleLayerToggle(hasMatchingLayer);
-    } else if (availableLayers && layerTaxa !== 'all') {
-      // select first element if there's no matching layer
-      handleLayerToggle(availableLayers[0]);
     }
+    // else if (availableLayers && layerTaxa !== 'all') {
+    //   // select first element if there's no matching layer
+    //   handleLayerToggle(availableLayers[0]);
+    // }
     // else {
     //   // select first element if there's no maching resolution
     //   handleLayerToggle(defaultResolutionLayers[0]);

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-hooks.js
@@ -100,7 +100,7 @@ export const useSelectLayersOnTabOrResolutionChange = ({
       // select matching layer on selected variant
       handleLayerToggle(hasMatchingLayer);
     } else if(hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
-      handleLayerToggle(hasMatchingLayer);
+      handleLayerToggle(availableLayers[0]);
     } else if(!hasMatchingLayer && category === TERRESTRIAL_GLOBAL){
       if(availableLayers){
         handleLayerToggle(availableLayers[0]);

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle-selectors.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle-selectors.js
@@ -83,8 +83,9 @@ const getGroupedLayerOptions = createSelector(
 const getSelectedLayerOption = createSelector(
   [getCategoryLayerOptions, getSelectedLayer],
   (options, selectedLayer) => {
+    const allTaxaIndex = options.findIndex(item => item.name === 'all taxa');
     const optionsSelectedLayer =
-      options.find((l) => l.value === selectedLayer) || options[0];
+      options.find((l) => l.value === selectedLayer) || options[allTaxaIndex] || options[0];
     if (!optionsSelectedLayer) return null;
 
     // label is needed for grouped layer option

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
@@ -44,6 +44,7 @@ function BiodiversityLayerToggle(props) {
   const locale = useLocale();
   const layersToggleConfig = useMemo(() => getLayersToggleConfig(), [locale]);
   const [isChecked, setIsChecked] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState();
   useEffect(() => {
     const newChecked =
       selectedLayerOption &&
@@ -60,6 +61,7 @@ function BiodiversityLayerToggle(props) {
   const previousSelectedResolutions = usePrevious(selectedResolutions);
 
   const handleLayerToggle = (option) => {
+    setSelectedCategory(category);
     const layer = layersConfig[option.layer];
     if (!allActiveLayerTitles) {
       // Add layer to empty selection
@@ -113,6 +115,7 @@ function BiodiversityLayerToggle(props) {
     isChecked,
     allActiveLayerTitles,
     activeLayers,
+    selectedCategory,
     handleLayerToggle,
   });
 

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
@@ -44,7 +44,7 @@ function BiodiversityLayerToggle(props) {
   const locale = useLocale();
   const layersToggleConfig = useMemo(() => getLayersToggleConfig(), [locale]);
   const [isChecked, setIsChecked] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState();
+  const [selectedCategory, setSelectedCategory] = useState('terrestrial-global');
   useEffect(() => {
     const newChecked =
       selectedLayerOption &&

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-layer-toggle/biodiversity-layer-toggle.js
@@ -40,11 +40,12 @@ function BiodiversityLayerToggle(props) {
     setSelectedLayer,
     allActiveLayerTitles,
     category,
+    setSelectedCategory,
+    selectedCategory
   } = props;
   const locale = useLocale();
   const layersToggleConfig = useMemo(() => getLayersToggleConfig(), [locale]);
   const [isChecked, setIsChecked] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState('terrestrial-global');
   useEffect(() => {
     const newChecked =
       selectedLayerOption &&

--- a/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card-component.jsx
+++ b/src/containers/sidebars/map-layers/biodiversity-sidebar-card/biodiversity-sidebar-card-component.jsx
@@ -71,6 +71,7 @@ function BiodiversitySidebarCardComponent({
   const firstStep = onboardingStep === 0;
   const { title, description, source } = cardMetadata || {};
   const [isOpen, setOpen] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState(TERRESTRIAL_GLOBAL);
   const handleBoxClick = () => setOpen(!isOpen);
 
   // --- Onboarding
@@ -115,6 +116,8 @@ function BiodiversitySidebarCardComponent({
         activeLayers={activeLayers}
         selectedLayer={selectedLayer}
         setSelectedLayer={setSelectedLayer}
+        selectedCategory={selectedCategory}
+        setSelectedCategory={setSelectedCategory}
         selectedResolutions={selectedResolutions}
         resolutionOptions={categoryResolutionOptions}
         selectedResolutionOption={selectedResolutionOptions[category]}


### PR DESCRIPTION
Radio buttons in Biodiversity section were not acting as desired

### Description
* Clear just the selected layer in the Analyze Area section
* Keep Global or Regional radio buttons selected when switching between tabs in Map Layers section

