### PR TITLE
Switching tabs, reset layers

### DIFF
--- a/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
+++ b/src/containers/sidebars/data-global-sidebar/analyze-areas-sidebar-card/index.js
@@ -115,6 +115,7 @@ function AnalyzeAreasContainer(props) {
     changeUI,
     selectedAnalysisLayer,
     selectedAnalysisTab,
+    resetOption
   } = props;
 
   const [selectedOption, setSelectedOption] = useState(
@@ -140,6 +141,16 @@ function AnalyzeAreasContainer(props) {
       setIsFirstLoad(false);
     }
   }, [selectedAnalysisLayer, precalculatedAOIOptions, setSelectedOption]);
+
+  useEffect(() => {
+    if(resetOption){
+      handleOptionSelection({
+        slug: CLEAR_SELECTIONS,
+        label: CLEAR_SELECTIONS,
+        title: CLEAR_SELECTIONS,
+      });
+    }
+  }, [resetOption])
 
   const postDrawCallback = (geometry) => {
     const hash = createHashFromGeometry(geometry);
@@ -213,6 +224,7 @@ function AnalyzeAreasContainer(props) {
   const handleLayerToggle = (newSelectedOption) => {
     const protectedAreasSelected =
       newSelectedOption === WDPA_OECM_FEATURE_LAYER;
+    const protectedAreasFormerSelected = selectedOption?.slug === WDPA_OECM_FEATURE_LAYER;
 
     const getLayersToToggle = () => {
       const formerSelectedSlug = selectedOption?.slug;
@@ -240,13 +252,24 @@ function AnalyzeAreasContainer(props) {
         });
       }
 
+      const additionalProtectedAreasLayers = [
+        PROTECTED_AREAS_VECTOR_TILE_LAYER,
+        COMMUNITY_AREAS_VECTOR_TILE_LAYER,
+      ];
       if (protectedAreasSelected) {
-        const additionalProtectedAreasLayers = [
-          PROTECTED_AREAS_VECTOR_TILE_LAYER,
-          COMMUNITY_AREAS_VECTOR_TILE_LAYER,
-        ];
         additionalProtectedAreasLayers.forEach((layer) => {
           if (!activeLayers.some((l) => l.title === layer)) {
+            layersToToggle.push({
+              layerId: layer,
+              category: LAYERS_CATEGORIES.PROTECTION,
+            });
+          }
+        });
+      }
+
+      if(protectedAreasFormerSelected){
+        additionalProtectedAreasLayers.forEach((layer) => {
+          if (activeLayers.some((l) => l.title === PROTECTED_AREAS_VECTOR_TILE_LAYER)) {
             layersToToggle.push({
               layerId: layer,
               category: LAYERS_CATEGORIES.PROTECTION,
@@ -286,6 +309,7 @@ function AnalyzeAreasContainer(props) {
   const watchUtils = useWatchUtils();
 
   const handleOptionSelection = async (option) => {
+    console.log(option)
     if (option?.slug === HALF_EARTH_FUTURE_TILE_LAYER && isFirstLoad) {
       setShowProgress(true);
     }

--- a/src/containers/sidebars/data-global-sidebar/data-global-sidebar-component.jsx
+++ b/src/containers/sidebars/data-global-sidebar/data-global-sidebar-component.jsx
@@ -14,6 +14,10 @@ import uiStyles from 'styles/ui.module.scss';
 import AnalyzeAreasSidebarCard from './analyze-areas-sidebar-card';
 import styles from './data-global-sidebar-styles.module.scss';
 import mapStateToProps from './selectors';
+import { useEffect, useState } from 'react';
+import { batchToggleLayers } from 'utils/layer-manager-utils';
+
+import dataScene from 'containers/scenes/data-scene/data-scene-config.js';
 
 function DataGlobalSidebarComponent({
   map,
@@ -26,10 +30,43 @@ function DataGlobalSidebarComponent({
   onboardingType,
   waitingInteraction,
   sidebarTabActive,
+  changeGlobe,
   aoiId,
   changeUI,
 }) {
   const [mapLayersTab, analyzeAreasTab] = getSidebarTabs();
+  const [resetOption, setResetOption] = useState(false);
+
+  useEffect(() => {
+    if(!sidebarTabActive) return;
+
+    clearLayers();
+  }, [sidebarTabActive]);
+
+  const clearLayers = () => {
+    const initialLayers = dataScene.globe.activeLayers;
+    const layersToToggle = [];
+
+    activeLayers.forEach(layer => {
+      if(!initialLayers.some(l => l.title === layer.title)){
+        layersToToggle.push({
+          layerId: layer.title,
+        })
+      }
+    })
+
+    if(layersToToggle.length){
+      batchToggleLayers(
+        layersToToggle.map((l) => l.layerId),
+        activeLayers,
+        changeGlobe,
+        {}
+      );
+    }
+
+    setResetOption(true);
+  };
+
   return (
     <div className={cx(styles.container, className)}>
       <TabsSidebar
@@ -82,6 +119,7 @@ function DataGlobalSidebarComponent({
               <AnalyzeAreasSidebarCard
                 activeLayers={activeLayers}
                 view={view}
+                resetOption={resetOption}
                 onboardingStep={onboardingStep}
                 onboardingType={onboardingType}
               />


### PR DESCRIPTION
Remove selected layers on Data Globe when switching tabs

### Description
When switching between Map Layers and Analyze Areas, remove selected layer (reset) from the map

### Testing instructions
Select a layer or multiple in the Map Layers section then click on Analyze Areas tab, selected layers should be removed.
Select a radio option in Analyze Areas then click the Map Layers tab and see layers be removed.

