### PR TITLE
update rangemap api endpoint for expanded info

### DIFF
--- a/src/components/species-table/expanded-info/expanded-info-component.jsx
+++ b/src/components/species-table/expanded-info/expanded-info-component.jsx
@@ -41,13 +41,15 @@ function ExpandedInfo(props) {
 
   const { rangemap, image, info, scientificname } = data[0];
 
+  const imageUrl = `https://cdn.mol.org/thumbnails/square_thumb_${scientificname.replace(' ', '_')}.png`;
+
   return (
     <div className={styles.expandedInfo}>
       <div className={styles.imagesContainer}>
         <Image
           title={`${speciesName} ${t(' Range map')}`}
           alt={`${speciesName} ${t(' Range map')}`}
-          src={rangemap}
+          src={imageUrl}
           className={styles.image}
         />
         <Image


### PR DESCRIPTION
## update rangemap api endpoint for expanded info
### Description
Rangemaps for species was showing a broken image. Due to api being obsolete. This change uses the new image url until the api can be updated.
