### PR TITLE
Fix/selected species race

### DIFF
--- a/src/containers/sidebars/aoi-sidebar/species-card/index.js
+++ b/src/containers/sidebars/aoi-sidebar/species-card/index.js
@@ -46,7 +46,7 @@ function SpeciesCardContainer(props) {
   const [selectedSpeciesFilter, setSpeciesFilter] = useState(
     DEFAULT_SPECIES_FILTER
   );
-  const [selectedSpeciesIndex, setSelectedSpeciesIndex] = useState(0);
+  const [selectedSpeciesIndex, setSelectedSpeciesIndex] = useState(urlSelectedSpeciesId || 0);
   const [placeholderText, setPlaceholderText] = useState(null);
   const [speciesFilters, setFilterWithCount] = useState(speciesFiltersSource);
   const [speciesToDisplay, setSpeciesToDisplay] = useState(species);

--- a/src/containers/sidebars/aoi-sidebar/species-card/index.js
+++ b/src/containers/sidebars/aoi-sidebar/species-card/index.js
@@ -240,12 +240,15 @@ function SpeciesCardContainer(props) {
     const urlSelectedSpecies = speciesToDisplay.find(
       (s) => s.id === urlSelectedSpeciesId
     );
-    setSelectedSpecies(urlSelectedSpecies || speciesToDisplay[selectedSpeciesIndex]);
+    // Don't select a species if we have one in the URL and until is loaded
+    if (!urlSelectedSpeciesId || urlSelectedSpecies) {
+      setSelectedSpecies(urlSelectedSpecies || speciesToDisplay[selectedSpeciesIndex]);
+    }
   }, [speciesToDisplay, selectedSpeciesIndex, urlSelectedSpeciesId]);
 
   useEffect(() => {
     setSelectedSpeciesIndex(0);
-  }, [selectedSpeciesFilter]);
+  }, [selectedSpeciesFilter?.slug]);
 
   // Get individual species info and image for slider
   useEffect(() => {


### PR DESCRIPTION
## Fix racing condition that was sometimes selecting the wrong species on the Detailed analysis modal
### Testing instructions
Eg. `localhost:3000/aoi/2246?precalculatedLayerSlug=gadm-1-admin-areas-feature-layer&OBJECTID=2258&ui=%7B"isSpeciesModalOpen"%3Atrue%2C"selectedSpecies"%3A"birds-776"%2C"aoiId"%3A2246%7D`
Open a url with a selected species or select it and reload several times. The selected species should always be the one on the URL